### PR TITLE
feat: configure augur.net custom domain for GitHub Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,7 +23,8 @@ const baseConfig = {
 
 // GitHub Pages specific configuration
 const gitHubPagesConfig = {
-  base: repoName ? `/${repoName}` : undefined,
+  site: 'https://augur.net',
+  // No base path needed for custom domain - apex domain serves from root
   output: /** @type {'static'} */ ('static')
 };
 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+augur.net

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,7 +7,7 @@ export function cn(...inputs: ClassValue[]) {
 
 /**
  * Utility function to construct URLs with the correct base path
- * Works with both Cloudflare (no base) and GitHub Pages (with base path)
+ * Works with Cloudflare (no base), GitHub Pages (with base path), and custom domain (no base)
  */
 export function withBase(path: string): string {
   let base = import.meta.env.BASE_URL || '/';

--- a/src/stores/animationStore.ts
+++ b/src/stores/animationStore.ts
@@ -16,9 +16,12 @@ const getInitialState = (): AppState => {
   let initialUIState = UIState.BOOT_SEQUENCE;
   
   if (typeof window !== 'undefined') {
-    // Get the base path from environment (accounts for both Cloudflare and GitHub Pages)
+    // Get the base path from environment (accounts for Cloudflare, GitHub Pages, and custom domain)
     const basePath = import.meta.env.BASE_URL || '/';
-    // Normalize base path to ensure consistent comparison
+    
+    // For custom domain (augur.net), base path will be '/' and pathname will be '/'
+    // For GitHub Pages without custom domain, base path will be '/augur-reboot-website/' 
+    // For Cloudflare testing, base path will be '/'
     const normalizedBasePath = basePath.endsWith('/') ? basePath : basePath + '/';
     const normalizedPathname = window.location.pathname.endsWith('/') ? window.location.pathname : window.location.pathname + '/';
     


### PR DESCRIPTION
# Configure augur.net Custom Domain for GitHub Pages

This PR configures the website to use `augur.net` as the custom domain for GitHub Pages production deployment.

## Changes Made

- [x] Add CNAME file with `augur.net` domain
- [x] Update Astro configuration to use `https://augur.net` as site URL
- [x] Remove base path for production (no `/augur-reboot-website` prefix needed)
- [x] Update homepage detection logic to handle custom domain scenarios
- [x] Maintain compatibility with Cloudflare Workers testing environment

## DNS Configuration Required (Before Merging)

Add these A records for `augur.net`:

```
augur.net  →  185.199.108.153
augur.net  →  185.199.109.153
augur.net  →  185.199.110.153  
augur.net  →  185.199.111.153
```

## Verification

Check DNS propagation before merging:
```bash
dig augur.net A
nslookup augur.net 8.8.8.8
```

## Post-Merge Checklist

- [ ] Go to Repository Settings > Pages
- [ ] Confirm custom domain shows as `augur.net`
- [ ] Wait for DNS verification checkmark
- [ ] Enable "Enforce HTTPS" once available (up to 24 hours for SSL certificate)

## Timeline

1. Configure DNS A records
2. Wait for DNS propagation (1-48 hours)
3. Merge this PR
4. GitHub provisions SSL certificate (1-24 hours)
5. Site live at `https://augur.net`