### PR TITLE
feat: add homepage footer with smart vertical spacing

### DIFF
--- a/src/components/HeroBanner.astro
+++ b/src/components/HeroBanner.astro
@@ -5,8 +5,8 @@ import SocialLinks from './SocialLinks.astro';
 import { withBase } from '../lib/utils';
 ---
 
-<div class="fixed inset-0 h-screen w-screen overflow-scroll">
-  <div id="hero-banner-container" class="grid grid-rows-[1fr_auto_1fr] h-screen z-10 text-center gap-y-8">
+<div class="h-screen min-h-fit w-full relative">
+  <div id="hero-banner-container" class="grid grid-rows-[auto_auto_auto] min-h-full z-10 text-center content-between">
     <!-- Top Section: Social Links Only -->
     <div class="flex justify-center md:justify-end place-content-start p-8">
       <SocialLinks />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,9 +2,11 @@
 import Layout from '../layouts/Layout.astro';
 import Intro from '../components/Intro.tsx';
 import HeroBanner from '../components/HeroBanner.astro';
+import Footer from '../components/Footer.astro';
 ---
 
 <Layout title="Augur is Rebooting">
   <Intro client:only="react" />
   <HeroBanner />
+  <Footer />
 </Layout>


### PR DESCRIPTION
## Summary
Adds Footer component to homepage to display when user scrolls down, ensuring the full design remains visible above the fold.

## Key Changes
- **Smart Height Management**: Hero banner uses `h-screen min-h-fit` approach for viewport-first design that adapts to content
- **Intelligent Spacing**: Replaced fixed gaps with CSS Grid `content-between` for adaptive vertical spacing
- **Footer Integration**: Added Footer component to index.astro to appear below hero content

## Technical Details
- Removes `overflow-scroll` classes that caused double scrollbars (addressed separately in PR #37)
- Uses CSS Grid with `grid-rows-[auto_auto_auto]` and `content-between` for smart spacing
- Hero banner fills viewport but shrinks only to minimum needed for content
- No magic numbers or fixed heights - fully responsive approach

## Dependencies
⚠️ **This PR should be merged after PR #37** which fixes the double scrollbar issue.

## Test Plan
- [x] Hero banner fills viewport on different screen sizes
- [x] Footer appears when scrolling down
- [x] No double scrollbars or overflow issues
- [x] Smart vertical spacing adapts to available space
- [x] Full design visible above the fold