### PR TITLE
feat: migrate fork learning pages to MDX content collection

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import cloudflare from '@astrojs/cloudflare';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
+import mdx from '@astrojs/mdx';
 
 // Check if building in GitHub Actions (for GitHub Pages)
 const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
@@ -36,6 +37,6 @@ export default defineConfig({
       } : undefined
     }
   },
-  integrations: [react(), sitemap()],
+  integrations: [react(), sitemap(), mdx()],
   ...(isGitHubActions ? gitHubPagesConfig : cloudflareConfig)
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/cloudflare": "^12.6.0",
+        "@astrojs/mdx": "^4.3.10",
         "@astrojs/react": "^4.3.0",
         "@astrojs/sitemap": "^3.6.0",
         "@nanostores/persistent": "^1.1.0",
@@ -1050,7 +1051,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.21.tgz",
       "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.7",
@@ -1139,7 +1139,6 @@
       "integrity": "sha512-oT/K4YWNhmwpVmGeaHNmF7mLRfgjszlVr7lJtpS4jx5khmxmMzWZEEQRrJEpgzeHP6DOq9qWLPNT0bjMK7TchQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -1257,6 +1256,33 @@
         "unist-util-visit": "^5.0.0",
         "unist-util-visit-parents": "^6.0.1",
         "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/mdx": {
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-4.3.10.tgz",
+      "integrity": "sha512-2T5+XIr7PMqMeXhRofXY5NlY4lA0Km+wkfsqmr9lq5KXUHpGlKPQ9dlDZJP9E/CtljJyEBNS17zq66LrIJ1tiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/markdown-remark": "6.3.8",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.15.0",
+        "es-module-lexer": "^1.7.0",
+        "estree-util-visit": "^2.0.0",
+        "hast-util-to-html": "^9.0.5",
+        "picocolors": "^1.1.1",
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1",
+        "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.3"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^5.0.0"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -1428,7 +1454,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1956,8 +1981,7 @@
       "version": "4.20251109.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251109.0.tgz",
       "integrity": "sha512-/wMfoS6NmoY0GgKVoRUp4x0yiZM0eNXwXTTzM7gFJKcm+0NtZmzUzgXj6xpShkfWSrmug0mX7BbyaFMAMHFlPA==",
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2916,6 +2940,43 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mdx-js/mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
+      "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdx": "^2.0.0",
+        "acorn": "^8.0.0",
+        "collapse-white-space": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-util-scope": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "markdown-extensions": "^2.0.0",
+        "recma-build-jsx": "^1.0.0",
+        "recma-jsx": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "rehype-recma": "^1.0.0",
+        "remark-mdx": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "source-map": "^0.7.0",
+        "unified": "^11.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@nanostores/persistent": {
@@ -4112,6 +4173,15 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/fontkit": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/fontkit/-/fontkit-2.0.8.tgz",
@@ -4139,6 +4209,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/mdx": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
+      "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -4159,7 +4235,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4169,7 +4244,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4179,7 +4253,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4235,6 +4308,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -4394,12 +4476,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/astro": {
       "version": "5.15.4",
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.15.4.tgz",
       "integrity": "sha512-0g/68hLHEJZF2nYUcZM5O0kOnzCsCIf8eA9+0jfBAxp4ycujrIHRgIOdZCFKL9GoTsn8AypWbziypH5aEIF+aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.7.4",
@@ -4676,7 +4766,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4775,6 +4864,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -4845,6 +4944,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/color": {
@@ -5145,6 +5254,38 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "license": "MIT"
     },
+    "node_modules/esast-util-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
+      "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esast-util-from-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
+      "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "acorn": "^8.0.0",
+        "esast-util-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -5205,6 +5346,88 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-attach-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
+      "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-build-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
+      "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "estree-walker": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-scope": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
+      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
+      "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "astring": "^1.8.0",
+        "source-map": "^0.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/estree-walker": {
@@ -5517,6 +5740,34 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-estree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
+      "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-attach-comments": "^3.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -5534,6 +5785,33 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.0",
         "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5647,6 +5925,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.6.tgz",
+      "integrity": "sha512-gtGXVaBdl5mAes3rPcMedEBm12ibjt1kDMFfheul1wUAOVEJW60voNdMVzVkfLN06O7ZaD/rxhfKgtlgtTbMjg==",
+      "license": "MIT"
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -5656,11 +5940,45 @@
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -5684,6 +6002,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-inside-container": {
@@ -5737,7 +6065,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5799,7 +6126,6 @@
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "devOptional": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6103,6 +6429,18 @@
         "source-map-js": "^1.2.0"
       }
     },
+    "node_modules/markdown-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
+      "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -6259,6 +6597,83 @@
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
       "license": "MIT",
       "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -6534,6 +6949,108 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -6575,6 +7092,33 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -6777,6 +7321,31 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -7468,7 +8037,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -7609,6 +8177,31 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
     "node_modules/parse-latin": {
@@ -7756,7 +8349,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7766,7 +8358,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7865,6 +8456,73 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/recma-build-jsx": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
+      "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-build-jsx": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-jsx": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
+      "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn-jsx": "^5.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "recma-parse": "^1.0.0",
+        "recma-stringify": "^1.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/recma-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
+      "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "esast-util-from-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/recma-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
+      "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-util-to-js": "^2.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
@@ -7935,6 +8593,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-recma": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
+      "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
@@ -7962,6 +8635,20 @@
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8286,6 +8973,15 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8367,6 +9063,24 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/style-to-js": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.19.tgz",
+      "integrity": "sha512-Ev+SgeqiNGT1ufsXyVC5RrJRXdrkRJ1Gol9Qw7Pb72YCKJXrBvP0ckZhBeVSrw2m06DJpei2528uIpjMb4TsoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.12"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.12.tgz",
+      "integrity": "sha512-ddJqYnoT4t97QvN2C95bCgt+m7AAgXjVnkk/jxAfmp7EAB8nnqqZYEbMd3em7/vEomDb2LAQKAy1RFfv41mdNw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.6"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -8394,8 +9108,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -8563,7 +9276,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -8663,6 +9375,19 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -9100,7 +9825,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -9742,7 +10466,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.0",
+    "@astrojs/mdx": "^4.3.10",
     "@astrojs/react": "^4.3.0",
     "@astrojs/sitemap": "^3.6.0",
     "@nanostores/persistent": "^1.1.0",

--- a/src/components/LearnNavigation.tsx
+++ b/src/components/LearnNavigation.tsx
@@ -52,7 +52,7 @@ export default function LearnNavigation({
 					{/* Left: Jump to Topic */}
 					<button
 						onClick={() => setIsExpanded(!isExpanded)}
-						className={`text-xs font-light tracking-widest uppercase transition-colors cursor-pointer ${
+						className={`text-sm font-light tracking-widest uppercase transition-colors cursor-pointer ${
 							isExpanded
 								? 'text-muted-foreground hover:text-loud-foreground focus:text-loud-foreground hover:fx-glow focus:fx-glow'
 								: 'text-muted-foreground hover:text-primary'
@@ -65,12 +65,12 @@ export default function LearnNavigation({
 					{nextTopic ? (
 						<a
 							href={nextTopic.path}
-							className="text-xs font-light tracking-widest text-muted-foreground hover:text-primary transition-colors"
+							className="text-sm font-light tracking-widest text-muted-foreground hover:text-primary transition-colors"
 						>
 							UP NEXT: {nextTopic.title}
 						</a>
 					) : (
-						<span className="text-xs font-light tracking-widest text-muted-foreground">
+						<span className="text-sm font-light tracking-widest text-muted-foreground">
 							END OF TOPICS
 						</span>
 					)}

--- a/src/components/LearnNavigation.tsx
+++ b/src/components/LearnNavigation.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useRef, useEffect } from 'react'
+
+interface Topic {
+	title: string
+	slug: string
+	path: string
+}
+
+interface LearnNavigationProps {
+	currentPath: string
+	currentTitle: string
+	topics: Topic[]
+}
+
+export default function LearnNavigation({
+	currentPath,
+	currentTitle,
+	topics,
+}: LearnNavigationProps) {
+	const [isExpanded, setIsExpanded] = useState(false)
+	const drawerRef = useRef<HTMLDivElement>(null)
+
+	// Find current topic and next topic
+	const currentIndex = topics.findIndex((t) => t.path === currentPath)
+	const nextTopic = currentIndex < topics.length - 1 ? topics[currentIndex + 1] : null
+
+	// Close drawer when clicking outside
+	useEffect(() => {
+		function handleClickOutside(event: MouseEvent) {
+			if (drawerRef.current && !drawerRef.current.contains(event.target as Node)) {
+				setIsExpanded(false)
+			}
+		}
+
+		if (isExpanded) {
+			document.addEventListener('mousedown', handleClickOutside)
+			return () => document.removeEventListener('mousedown', handleClickOutside)
+		}
+	}, [isExpanded])
+
+	return (
+		<aside
+			ref={drawerRef}
+			className="sticky bottom-0 border-t border-foreground/30 bg-background uppercase transition-all duration-300"
+			style={{
+				zIndex: isExpanded ? 50 : 10,
+			}}
+		>
+			{/* Collapsed State */}
+			<div className="max-w-2xl mx-auto px-4 md:px-8 py-3 md:py-6 w-full">
+				<div className="flex items-center justify-between">
+					{/* Left: Jump to Topic */}
+					<button
+						onClick={() => setIsExpanded(!isExpanded)}
+						className={`text-xs font-light tracking-widest uppercase transition-colors cursor-pointer ${
+							isExpanded
+								? 'text-muted-foreground hover:text-loud-foreground focus:text-loud-foreground hover:fx-glow focus:fx-glow'
+								: 'text-muted-foreground hover:text-primary'
+						}`}
+					>
+						{isExpanded ? '[ X ] CLOSE' : 'JUMP TO TOPIC →'}
+					</button>
+
+					{/* Right: Up Next */}
+					{nextTopic ? (
+						<a
+							href={nextTopic.path}
+							className="text-xs font-light tracking-widest text-muted-foreground hover:text-primary transition-colors"
+						>
+							UP NEXT: {nextTopic.title}
+						</a>
+					) : (
+						<span className="text-xs font-light tracking-widest text-muted-foreground">
+							END OF TOPICS
+						</span>
+					)}
+				</div>
+			</div>
+
+			{/* Expanded Drawer */}
+			{isExpanded && (
+				<div className="border-t border-foreground/30 bg-background overflow-hidden animate-in fade-in duration-200 w-full">
+					<div className="max-w-2xl mx-auto px-4 md:px-8 py-4 w-full">
+						<div className="space-y-2">
+							{topics.map((topic) => (
+								<a
+									key={topic.path}
+									href={topic.path}
+									className={`block text-sm font-light uppercase tracking-widest px-3 py-2 transition-colors ${
+										currentPath === topic.path
+											? 'bg-foreground/10 text-primary border border-foreground/30'
+											: 'text-muted-foreground hover:text-foreground hover:bg-foreground/5'
+									}`}
+								>
+									{topic.title}
+								</a>
+							))}
+						</div>
+					</div>
+				</div>
+			)}
+		</aside>
+	)
+}

--- a/src/components/ProseCard.astro
+++ b/src/components/ProseCard.astro
@@ -1,0 +1,22 @@
+---
+/**
+ * ProseCard Component
+ *
+ * A styled card component for prose content with border and padding.
+ * Used in learning/documentation pages to highlight important content sections.
+ */
+
+interface Props {
+  class?: string;
+}
+
+const { class: className = "" } = Astro.props;
+---
+
+<div class={`border border-foreground/30 px-6 mb-6 ${className}`}>
+  <slot />
+</div>
+
+<style>
+  /* ProseCard specific styling can be added here if needed */
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,13 @@
+import { defineCollection, z } from 'astro:content';
+
+const learnCollection = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+  }),
+});
+
+export const collections = {
+  learn: learnCollection,
+};

--- a/src/content/learn/fork/disputes-and-bonds.mdx
+++ b/src/content/learn/fork/disputes-and-bonds.mdx
@@ -1,0 +1,157 @@
+---
+title: "How Disputes & Bonds Work"
+description: "Understand dispute escalation, bond mechanics, and how fork risk is calculated."
+---
+
+import ProseCard from '../../../components/ProseCard.astro'
+
+# How Disputes & Bonds Work
+
+Disputes are the core mechanism that makes Augur work. When people disagree about a market outcome, they challenge each other using bonds—financial commitments that keep everyone honest.
+
+## A Real-World Example
+
+Imagine a market asks: **"Will BTC reach $100,000 in 2025?"**
+
+1. **Reporter A** says YES and locks up REP as their report bond
+2. **Reporter B** disagrees and says NO—they lock up 2x the initial bond amount to dispute
+3. **Reporter C** thinks B is wrong and says YES again—they lock up 2x B's bond (4x initial)
+4. This continues escalating until everyone agrees... or the bond reaches 275,000 REP and a fork is triggered
+
+## What is a Dispute Bond?
+
+A dispute bond is REP (Augur's governance token) that you must lock up to challenge a market outcome. It serves three purposes:
+
+1. **Skin in the game:** Disputers must risk their own capital to challenge outcomes
+2. **Spam prevention:** High bond amounts deter frivolous disputes
+3. **Fair resolution:** If your dispute is correct, you get your bond back plus a fee
+
+## The Dispute Process Step-by-Step
+
+```
+┌─────────────────────────────┐         ┌─────────────────────────────┐
+│  STEP 1: Initial Report     │         │  STEP 2: First Dispute      │
+│                             │         │                             │
+│  Reporter submits outcome   │────────▶│  Someone disagrees          │
+│  Example: "YES"             │         │  Posts 2x initial bond      │
+│  Locks up initial bond      │         │  Submits: "NO"              │
+└─────────────────────────────┘         │  If no further dispute →    │
+                                        │  Market settles             │
+                                        └────────────┬────────────────┘
+                                                     ↓
+┌─────────────────────────────┐         ┌─────────────────────────────┐
+│  STEP 4: Fork Trigger       │         │  STEP 3: Escalation         │
+│                             │         │                             │
+│  Bond reaches 275,000 REP   │◀────────│  Another disputes back      │
+│  Instead of continuing,     │         │  Posts 2x previous bond     │
+│  FORK IS TRIGGERED          │         │  Submits: "YES"             │
+│                             │         │  Process repeats...         │
+│  → 60-day fork period       │         │  Bonds keep doubling        │
+│  → REP holders vote         │         └─────────────────────────────┘
+└─────────────────────────────┘
+```
+
+## Bond Escalation Example
+
+Here's how bonds grow with each dispute round:
+
+<ProseCard>
+| Round | Bond Size | Risk Level |
+|-------|-----------|-----------|
+| 1st Dispute | 1,000 REP | Low |
+| 2nd Dispute | 2,000 REP | Low |
+| 3rd Dispute | 4,000 REP | Medium |
+| 4th Dispute | 8,000 REP | High |
+| 5th+ Disputes | 16,000+ REP | Extreme |
+
+*Actual bond amounts vary based on protocol parameters, but the doubling pattern is consistent.*
+</ProseCard>
+
+## Why 275,000 REP?
+
+The 275,000 REP threshold was chosen as a balance:
+
+<ProseCard>
+- **ACCESSIBILITY:** Low enough that disputes can escalate naturally
+- **SAFETY:** High enough that only serious, well-funded disputes trigger forks
+- **GOVERNANCE:** Ensures protocol-level disagreements go to REP holders to vote on
+</ProseCard>
+
+## Bond Economics: Winning and Losing
+
+<ProseCard>
+| OUTCOME | WHAT HAPPENS TO YOUR BOND |
+|---------|--------------------------|
+| **Your Dispute Is Correct** | **You get your bond back + a fee**<br/>The fee is additional REP awarded for being right |
+| **Your Dispute Is Incorrect** | **You lose your bond**<br/>It gets redistributed to winning disputers or the protocol |
+</ProseCard>
+
+## How Fork Risk is Calculated
+
+The fork meter shows a simple calculation:
+
+<ProseCard class="text-center">
+(Largest Dispute Bond ÷ 275,000 REP) × 100 = Fork Risk %
+</ProseCard>
+
+### Understanding the Formula
+
+**Largest Dispute Bond**: This is the single largest bond currently active across all markets. Why track the largest? Because it determines how close we are to the fork threshold.
+
+**Example**: If the largest active dispute is 150,000 REP, the next challenger would need to post ~300,000 REP to dispute it—which exceeds 275,000 and triggers a fork immediately.
+
+### Two Calculation Examples
+
+<ProseCard>
+**EXAMPLE 1: LOW RISK**
+
+Current largest dispute bond: **15,000 REP**
+
+(15,000 ÷ 275,000) × 100 = **5.5% risk**
+
+*Interpretation: Disputes are active but still far from fork. The next dispute would need ~30,000 REP.*
+</ProseCard>
+
+<ProseCard>
+**EXAMPLE 2: HIGH RISK**
+
+Current largest dispute bond: **200,000 REP**
+
+(200,000 ÷ 275,000) × 100 = **73% risk**
+
+*Interpretation: Close to fork. The next dispute would need ~400,000 REP, exceeding the threshold. Fork is likely with one more escalation.*
+</ProseCard>
+
+## What Happens When Fork Conditions Are Met?
+
+Once a dispute bond reaches or exceeds 275,000 REP:
+
+<ProseCard>
+- **FORK PERIOD:** A 60-day window begins for REP holders to vote
+- **MARKETS FREEZE:** No new trades on disputed markets
+- **REP MIGRATION:** You choose which fork version you support
+- **WINNING FORK:** The fork with the most REP support becomes canonical
+- **RESOLUTION:** Markets settle according to the winning fork's outcomes
+</ProseCard>
+
+## Strategic Considerations
+
+### For Dispute Participants
+- High-conviction disputes are only worth posting if you're confident you'll win
+- Later dispute rounds become prohibitively expensive for casual participants
+- High-stakes disputes push the system toward fork, affecting all markets
+
+### For Market Users
+- Monitor disputes if your market outcome is challenged
+- Disputed markets settle slower than undisputed ones
+- High-risk markets might not settle until after a fork resolves
+
+## Key Takeaways
+
+- **Disputes escalate:** Each new dispute doubles the bond size (approximately)
+- **Forks are triggered mechanically:** When the largest bond hits 275,000 REP
+- **Risk is measurable:** The fork formula lets you calculate exactly how close we are
+- **Escalation is expensive:** High-stakes disputes require serious financial commitment
+- **Fork is ultimate resolution:** When community disagreement is severe, REP holders decide
+
+[Next: What To Do at Different Risk Levels →](/learn/fork/what-to-do)

--- a/src/content/learn/fork/disputes-and-bonds.mdx
+++ b/src/content/learn/fork/disputes-and-bonds.mdx
@@ -7,7 +7,7 @@ import ProseCard from '../../../components/ProseCard.astro'
 
 # How Disputes & Bonds Work
 
-Disputes are the core mechanism that makes Augur work. When people disagree about a market outcome, they challenge each other using bonds—financial commitments that keep everyone honest.
+Disputes are the core mechanism that makes Augur work. When people disagree about an outcome, they challenge each other using bonds—financial commitments that keep everyone honest.
 
 ## A Real-World Example
 
@@ -20,7 +20,7 @@ Imagine a market asks: **"Will BTC reach $100,000 in 2025?"**
 
 ## What is a Dispute Bond?
 
-A dispute bond is REP (Augur's governance token) that you must lock up to challenge a market outcome. It serves three purposes:
+A dispute bond is REP (Augur's governance token) that you must lock up to challenge an outcome. It serves three purposes:
 
 1. **Skin in the game:** Disputers must risk their own capital to challenge outcomes
 2. **Spam prevention:** High bond amounts deter frivolous disputes
@@ -142,7 +142,7 @@ Once a dispute bond reaches or exceeds 275,000 REP:
 - High-stakes disputes push the system toward fork, affecting all markets
 
 ### For Market Users
-- Monitor disputes if your market outcome is challenged
+- Monitor disputes if your outcome is challenged
 - Disputed markets settle slower than undisputed ones
 - High-risk markets might not settle until after a fork resolves
 

--- a/src/content/learn/fork/disputes-and-bonds.mdx
+++ b/src/content/learn/fork/disputes-and-bonds.mdx
@@ -47,7 +47,7 @@ A dispute bond is REP (Augur's governance token) that you must lock up to challe
 │  FORK IS TRIGGERED          │         │  Submits: "YES"             │
 │                             │         │  Process repeats...         │
 │  → 60-day fork period       │         │  Bonds keep doubling        │
-│  → REP holders vote         │         └─────────────────────────────┘
+│  → REP holders govern       │         └─────────────────────────────┘
 └─────────────────────────────┘
 ```
 
@@ -74,7 +74,7 @@ The 275,000 REP threshold was chosen as a balance:
 <ProseCard>
 - **ACCESSIBILITY:** Low enough that disputes can escalate naturally
 - **SAFETY:** High enough that only serious, well-funded disputes trigger forks
-- **GOVERNANCE:** Ensures protocol-level disagreements go to REP holders to vote on
+- **GOVERNANCE:** Ensures protocol-level disagreements go to REP holders to choose
 </ProseCard>
 
 ## Bond Economics: Winning and Losing
@@ -127,7 +127,7 @@ Current largest dispute bond: **200,000 REP**
 Once a dispute bond reaches or exceeds 275,000 REP:
 
 <ProseCard>
-- **FORK PERIOD:** A 60-day window begins for REP holders to vote
+- **FORK PERIOD:** A 60-day window begins for REP holders to migrate their REP
 - **MARKETS FREEZE:** No new trades on disputed markets
 - **REP MIGRATION:** You choose which fork version you support
 - **WINNING FORK:** The fork with the most REP support becomes canonical

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -1,0 +1,76 @@
+---
+title: "What is a Fork?"
+description: "Learn about Augur protocol forks, how they work, and why fork risk matters."
+---
+
+import ProseCard from '../../../components/ProseCard.astro'
+
+> **New to Augur?** This guide assumes some familiarity with prediction markets. If you're completely new, start with [Augur basics](/) first.
+
+# What is a Fork?
+
+**TL;DR** — A fork is Augur's emergency mechanism when the community can't agree on a market outcome. It's rare, but important to monitor.
+
+A fork happens when a severe disagreement about a market outcome escalates through the dispute system. When disputes get expensive and serious enough (bond reaches 275,000 REP), the protocol splits into two branches and REP holders vote on which version is correct.
+
+## Key Terms
+
+<ProseCard>
+**REP** — Augur's governance token. Used to report market outcomes and settle disputes.
+
+**Dispute** — A challenge to a market outcome. When someone disagrees with the current outcome, they post a bond to dispute it.
+
+**Bond** — REP locked up to challenge a market outcome. Bonds grow larger with each dispute round.
+
+**Fork Threshold** — 275,000 REP. When the largest active dispute bond hits this amount, a fork is triggered.
+</ProseCard>
+
+## Why Forks Matter
+
+Forks are Augur's ultimate security mechanism. They ensure that:
+
+- **No single entity controls outcomes** — Disputes can always be escalated to the community
+- **REP holders govern** — When serious disagreements arise, the community votes on what's correct
+- **Bad actors face consequences** — Invalid outcomes get rejected by the network
+
+## How to Monitor Fork Risk
+
+The fork meter shows **how close we are to a fork** by tracking the largest dispute bond:
+
+<ProseCard>
+<p class="text-center mb-3">
+  <strong class="text-loud-foreground uppercase">The Formula</strong>
+</p>
+<p class="text-center text-loud-foreground font-mono text-lg">
+  (Largest Dispute Bond ÷ 275,000 REP) × 100 = Risk %
+</p>
+</ProseCard>
+
+The percentage tells you how much of the way to fork we are:
+
+<ProseCard>
+| LEVEL | RANGE | WHAT IT MEANS |
+|-------|-------|--------------|
+| NO RISK | 0% | No disputes. Normal trading. |
+| LOW | 0-10% | Early disputes. Fork unlikely. |
+| MEDIUM | 10-25% | Serious disputes. Monitor closely. |
+| HIGH | 25-75% | Large bonds active. Fork possible. |
+| EXTREME | 75-100%+ | Fork imminent or triggered. |
+</ProseCard>
+
+## What Happens If a Fork Occurs
+
+When a fork is triggered:
+
+1. **Fork period starts** — 60 days for REP holders to vote
+2. **Markets freeze** — No new trades on disputed markets
+3. **You choose a fork** — Migrate your REP to the branch you believe is correct
+4. **Community votes** — Most REP wins; that fork becomes the new Augur
+5. **Markets settle** — According to the winning fork's outcomes
+
+## Learn More
+
+Ready to dive deeper? Here's what you should know:
+
+- **[How Disputes & Bonds Work](/learn/fork/disputes-and-bonds)** — Understand dispute escalation and why bonds matter
+- **[What To Do at Different Risk Levels](/learn/fork/what-to-do)** — Practical actions for each risk level

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -5,7 +5,7 @@ description: "Learn about Augur protocol forks, how they work, and why fork risk
 
 import ProseCard from '../../../components/ProseCard.astro'
 
-> **New to Augur?** This guide assumes some familiarity with prediction markets. If you're completely new, start with [Augur basics](/) first.
+> **New to Augur?** This guide assumes some familiarity with prediction markets. If you're completely new, start with Augur basics first.
 
 # What is a Fork?
 
@@ -37,13 +37,10 @@ Forks are Augur's ultimate security mechanism. They ensure that:
 
 The fork meter shows **how close we are to a fork** by tracking the largest dispute bond:
 
-<ProseCard>
-<p class="text-center mb-3">
-  <strong class="text-loud-foreground uppercase">The Formula</strong>
-</p>
-<p class="text-center text-loud-foreground font-mono text-lg">
-  (Largest Dispute Bond ÷ 275,000 REP) × 100 = Risk %
-</p>
+<ProseCard class="text-center">
+The Formula
+
+**(Largest Dispute Bond ÷ 275,000 REP) × 100 = Risk %**
 </ProseCard>
 
 The percentage tells you how much of the way to fork we are:

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -9,18 +9,18 @@ import ProseCard from '../../../components/ProseCard.astro'
 
 # What is a Fork?
 
-**TL;DR** — A fork is Augur's emergency mechanism when the community can't agree on a market outcome. It's rare, but important to monitor.
+**TL;DR** — A fork is Augur's emergency mechanism when the community can't agree on an outcome. It's rare, but important to monitor.
 
-A fork happens when a severe disagreement about a market outcome escalates through the dispute system. When disputes get expensive and serious enough (bond reaches 275,000 REP), the protocol splits into two branches and REP holders choose which version is correct.
+A fork happens when a severe disagreement about an outcome escalates through the dispute system. When disputes get expensive and serious enough (bond reaches 275,000 REP), the protocol splits into two branches and REP holders choose which version is correct.
 
 ## Key Terms
 
 <ProseCard>
-**REP** — Augur's governance token. Used to report market outcomes and settle disputes.
+**REP** — Augur's governance token. Used to report outcomes and settle disputes.
 
-**Dispute** — A challenge to a market outcome. When someone disagrees with the current outcome, they post a bond to dispute it.
+**Dispute** — A challenge to an outcome. When someone disagrees with the current outcome, they post a bond to dispute it.
 
-**Bond** — REP locked up to challenge a market outcome. Bonds grow larger with each dispute round.
+**Bond** — REP locked up to challenge an outcome. Bonds grow larger with each dispute round.
 
 **Fork Threshold** — 275,000 REP. When the largest active dispute bond hits this amount, a fork is triggered.
 </ProseCard>

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -11,7 +11,7 @@ import ProseCard from '../../../components/ProseCard.astro'
 
 **TL;DR** — A fork is Augur's emergency mechanism when the community can't agree on a market outcome. It's rare, but important to monitor.
 
-A fork happens when a severe disagreement about a market outcome escalates through the dispute system. When disputes get expensive and serious enough (bond reaches 275,000 REP), the protocol splits into two branches and REP holders vote on which version is correct.
+A fork happens when a severe disagreement about a market outcome escalates through the dispute system. When disputes get expensive and serious enough (bond reaches 275,000 REP), the protocol splits into two branches and REP holders choose which version is correct.
 
 ## Key Terms
 
@@ -30,7 +30,7 @@ A fork happens when a severe disagreement about a market outcome escalates throu
 Forks are Augur's ultimate security mechanism. They ensure that:
 
 - **No single entity controls outcomes** — Disputes can always be escalated to the community
-- **REP holders govern** — When serious disagreements arise, the community votes on what's correct
+- **REP holders govern** — When serious disagreements arise, the community chooses what's correct
 - **Bad actors face consequences** — Invalid outcomes get rejected by the network
 
 ## How to Monitor Fork Risk
@@ -59,10 +59,10 @@ The percentage tells you how much of the way to fork we are:
 
 When a fork is triggered:
 
-1. **Fork period starts** — 60 days for REP holders to vote
+1. **Fork period starts** — 60 days for REP holders to choose
 2. **Markets freeze** — No new trades on disputed markets
 3. **You choose a fork** — Migrate your REP to the branch you believe is correct
-4. **Community votes** — Most REP wins; that fork becomes the new Augur
+4. **Community chooses** — Most REP wins; that fork becomes the new Augur
 5. **Markets settle** — According to the winning fork's outcomes
 
 ## Learn More

--- a/src/content/learn/fork/what-to-do.mdx
+++ b/src/content/learn/fork/what-to-do.mdx
@@ -30,7 +30,7 @@ The gap to fork threshold is narrowing. Fork is increasingly likely with continu
 - **Reduce exposure if uncomfortable** — Consider exiting disputed positions
 - **Monitor daily** — Check the fork meter and dispute progress regularly
 - **Understand the disagreement** — Review community discussions about the disputed outcome
-- **Prepare for fork governance** — If a fork occurs, be ready to vote with your REP
+- **Prepare for fork governance** — If a fork occurs, be ready to choose with your REP
 - **Avoid new large bets** — Don't enter high-risk markets during escalation
 - **Know your positions** — Understand exactly how a fork would affect you
 
@@ -53,7 +53,7 @@ Fork threshold is nearly reached. A fork is imminent or may have been triggered.
 
 - **Markets freeze:** No new trades on disputed markets
 - **You must migrate REP:** Choose which fork version you support
-- **Voting occurs:** Your REP choice determines your vote on the disputed outcome
+- **Voting occurs:** Your REP migration determines your choice on the disputed outcome
 - **Communicate:** Engage in governance discussions about the right outcome
 - **Wait for resolution:** The fork window is 60 days
 

--- a/src/content/learn/fork/what-to-do.mdx
+++ b/src/content/learn/fork/what-to-do.mdx
@@ -1,0 +1,75 @@
+---
+title: "What To Do"
+description: "Action items to take at different fork risk levels."
+---
+
+import ProseCard from '../../../components/ProseCard.astro'
+
+# What To Do During Rising Fork Risk
+
+**TL;DR** — Fork risk is manageable at low levels. Monitor more closely as it rises. At high levels, take concrete action to protect your positions.
+
+## Risk Overview
+
+<ProseCard>
+| LEVEL | SITUATION | YOUR ACTION |
+|-------|-----------|-------------|
+| No Risk (0%) | No disputes active | Trade normally. Check meter occasionally. |
+| Low (0-10%) | Early disputes | Identify which markets are disputed. Understand the disagreement. |
+| Medium (10-25%) | Disputes escalating | Calculate your exposure. Think about exit strategies if needed. |
+| High (25-75%) | Large bonds active | Monitor daily. Consider reducing exposure. Prepare for fork governance. |
+| Extreme (75%+) | Fork imminent | Take action now. Prepare to choose a fork. Engage with community. |
+</ProseCard>
+
+## High Risk (25-75%) — Take Action
+
+The gap to fork threshold is narrowing. Fork is increasingly likely with continued escalation.
+
+**What you should do:**
+
+- **Reduce exposure if uncomfortable** — Consider exiting disputed positions
+- **Monitor daily** — Check the fork meter and dispute progress regularly
+- **Understand the disagreement** — Review community discussions about the disputed outcome
+- **Prepare for fork governance** — If a fork occurs, be ready to vote with your REP
+- **Avoid new large bets** — Don't enter high-risk markets during escalation
+- **Know your positions** — Understand exactly how a fork would affect you
+
+## Extreme Risk (75%+) — Fork Is Likely
+
+Fork threshold is nearly reached. A fork is imminent or may have been triggered. This is the highest-stakes scenario.
+
+**What you must do:**
+
+- **Understand your position** — Know exactly what outcome you're betting on in disputed markets
+- **Plan your fork choice** — Which fork version do you believe represents the correct outcomes?
+- **Prepare to migrate REP** — You'll choose which fork version to support during the 60-day period
+- **Engage with the community** — Discuss the disputed outcomes with other REP holders
+- **Be ready to act** — The fork period requires active participation and decision-making
+- **Prepare for market freezes** — Disputed markets will be frozen until the fork resolves
+
+## During a Fork Event
+
+### The 60-Day Fork Period
+
+- **Markets freeze:** No new trades on disputed markets
+- **You must migrate REP:** Choose which fork version you support
+- **Voting occurs:** Your REP choice determines your vote on the disputed outcome
+- **Communicate:** Engage in governance discussions about the right outcome
+- **Wait for resolution:** The fork window is 60 days
+
+### After Fork Resolution
+
+- **Check your REP:** You now have REP on the winning fork
+- **Markets settle:** Markets settle according to the winning fork's outcomes
+- **Resume trading:** Normal Augur operations resume
+- **Evaluate impact:** Assess how the fork affected your positions
+
+## General Best Practices
+
+- **Check the meter regularly:** Make fork risk checking part of your routine
+- **Understand disputed outcomes:** Know what you're betting on before a dispute arises
+- **Size positions appropriately:** Don't over-commit to markets that could fork
+- **Stay informed:** Follow Augur discussions and governance
+- **Plan ahead:** Think through fork scenarios before they happen
+- **Engage with the community:** Forks are community decisions
+

--- a/src/layouts/LearnLayout.astro
+++ b/src/layouts/LearnLayout.astro
@@ -1,0 +1,131 @@
+---
+import Layout from "../layouts/Layout.astro";
+import SocialLinks from "../components/SocialLinks.astro";
+import Footer from "../components/Footer.astro";
+import LearnNavigation from "../components/LearnNavigation.tsx";
+import Button from "../components/Button.tsx";
+import Pointer from "../components/Pointer.tsx";
+import PageHeading from "../components/PageHeading.astro";
+import { withBase } from "../lib/utils";
+
+interface Props {
+	title: string
+	description?: string
+}
+
+const { title, description } = Astro.props
+
+// Topic navigation data
+const topics = [
+	{ title: 'WHAT IS A FORK?', slug: '/learn/fork', path: '/learn/fork' },
+	{
+		title: 'HOW DISPUTES & BONDS WORK',
+		slug: '/learn/fork/disputes-and-bonds',
+		path: '/learn/fork/disputes-and-bonds',
+	},
+	{ title: 'WHAT TO DO', slug: '/learn/fork/what-to-do', path: '/learn/fork/what-to-do' },
+]
+
+const currentPath = Astro.url.pathname
+---
+
+<Layout
+	title={`${title} - Augur Fork Mechanics`}
+	description={description || "Learn about Augur protocol forks and fork mechanics"}
+	ogType="article"
+>
+	<div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
+		{/* Top Section: Navigation */}
+		<div class="flex justify-between items-start p-8">
+			{/* Back Button */}
+			<Button id="back-button" variant="link" href={withBase('/?intro=false')} autofocus>
+				<Pointer direction="left" animated="auto" />
+				BACK TO HOME
+			</Button>
+
+			{/* Social Links */}
+			<SocialLinks />
+		</div>
+
+		{/* Middle Section: Scrollable Content */}
+		<main class="overflow-y-auto px-4 md:px-8 mb-12">
+			<div class="max-w-xl mx-auto">
+				<PageHeading text={title} />
+
+				{/* Main Content */}
+				<article class="prose prose-sm prose-invert max-w-none">
+					<slot />
+				</article>
+			</div>
+		</main>
+
+		{/* Bottom Section: Sticky Navigation + Footer */}
+		<LearnNavigation client:load currentPath={currentPath} currentTitle={title} topics={topics} />
+		<Footer />
+	</div>
+
+	<style is:global>
+		/* Custom prose styles for dark mode - Tailwind v4 CSS-first approach */
+		.prose {
+			--tw-prose-headings: var(--color-loud-foreground);
+			--tw-prose-links: var(--color-primary);
+			--tw-prose-body: var(--color-foreground);
+			--tw-prose-bold: var(--color-foreground);
+			--tw-prose-code: var(--color-green-400);
+			--tw-prose-borders: var(--color-primary);
+			--tw-prose-bg-hover: var(--color-primary);
+			--tw-prose-line-height: 1.2;
+			--tw-prose-pre-bg: transparent;
+			--tw-prose-pre-code: var(--color-foreground);
+		}
+
+		.prose-sm {
+			line-height: 1.325em;
+			letter-spacing: 0.025em;
+		}
+
+		.prose :is(h1, h2, h3, h4, h5, h6) {
+			text-transform: uppercase;
+		}
+
+		.prose h1 {
+			font-size: 1.5rem;
+		}
+
+		.prose p {
+			font-family: var(--tw-prose-p-font-family);
+		}
+
+		.prose li {
+			font-family: var(--tw-prose-p-font-family);
+		}
+
+		.prose ol > li::marker {
+			color: var(--color-muted-foreground);
+		}
+
+		.prose table td {
+			font-family: var(--tw-prose-p-font-family);
+		}
+
+		/* Override Shiki syntax highlighting theme for code blocks */
+		.prose pre.astro-code {
+			background-color: transparent !important;
+			border: none;
+			padding: 0;
+		}
+
+		.prose pre.astro-code code {
+			color: var(--color-foreground);
+		}
+
+		/* Blockquote styling */
+		.prose blockquote {
+			border-left-color: var(--color-muted-foreground);
+		}
+
+		.prose blockquote p {
+			color: var(--color-foreground);
+		}
+	</style>
+</Layout>

--- a/src/layouts/LearnLayout.astro
+++ b/src/layouts/LearnLayout.astro
@@ -17,13 +17,13 @@ const { title, description } = Astro.props
 
 // Topic navigation data
 const topics = [
-	{ title: 'WHAT IS A FORK?', slug: '/learn/fork', path: '/learn/fork' },
+	{ title: 'WHAT IS A FORK?', slug: 'fork/index', path: '/learn/fork/' },
 	{
 		title: 'HOW DISPUTES & BONDS WORK',
-		slug: '/learn/fork/disputes-and-bonds',
-		path: '/learn/fork/disputes-and-bonds',
+		slug: 'fork/disputes-and-bonds',
+		path: '/learn/fork/disputes-and-bonds/',
 	},
-	{ title: 'WHAT TO DO', slug: '/learn/fork/what-to-do', path: '/learn/fork/what-to-do' },
+	{ title: 'WHAT TO DO', slug: 'fork/what-to-do', path: '/learn/fork/what-to-do/' },
 ]
 
 const currentPath = Astro.url.pathname
@@ -73,10 +73,12 @@ const currentPath = Astro.url.pathname
 			--tw-prose-bold: var(--color-foreground);
 			--tw-prose-code: var(--color-green-400);
 			--tw-prose-borders: var(--color-primary);
-			--tw-prose-bg-hover: var(--color-primary);
-			--tw-prose-line-height: 1.2;
-			--tw-prose-pre-bg: transparent;
-			--tw-prose-pre-code: var(--color-foreground);
+		--tw-prose-td-borders: var(--color-muted-foreground);
+		--tw-prose-th-borders: var(--color-muted-foreground);
+		--tw-prose-bg-hover: var(--color-primary);
+		--tw-prose-line-height: 1.2;
+		--tw-prose-pre-bg: transparent;
+		--tw-prose-pre-code: var(--color-foreground);
 		}
 
 		.prose-sm {

--- a/src/pages/learn/[...slug].astro
+++ b/src/pages/learn/[...slug].astro
@@ -1,0 +1,32 @@
+---
+import { getCollection } from 'astro:content';
+import LearnLayout from '../../layouts/LearnLayout.astro';
+
+export const prerender = true;
+
+interface Props {
+  entry: any;
+}
+
+export async function getStaticPaths() {
+  const learnCollection = await getCollection('learn');
+
+  return learnCollection.map((entry) => {
+    // Create slug from the entry's file path
+    const slug = entry.slug;
+
+    return {
+      params: { slug },
+      props: { entry },
+    };
+  });
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+const { title, description } = entry.data;
+---
+
+<LearnLayout title={title} description={description}>
+  <Content />
+</LearnLayout>


### PR DESCRIPTION
## Summary

Preview or use for review https://tease.bytebros.workers.dev/

Migrate fork learning documentation from individual Astro pages to a centralized MDX content collection. Creates comprehensive educational content about Augur fork mechanics with improved styling and navigation.

## Changes

1. **Content Collection Migration**
   - Create MDX content collection for fork learning pages
   - Add 'What is a Fork?' landing page with fork basics and risk levels
   - Add 'How Disputes & Bonds Work' with dispute escalation mechanics
   - Add 'What To Do at Different Risk Levels' with action guides
   - Convert HTML tables to markdown syntax for maintainability

2. **New Components & Layout**
   - Create LearnLayout for fork education pages with custom prose styling
   - Add LearnNavigation component for topic navigation between pages
   - Add ProseCard component for styled content blocks
   - Add blockquote styling with muted-foreground border and foreground text
   - Style prose code blocks with transparent backgrounds

3. **Cleanup & Configuration**
   - Remove obsolete fork detail pages (bonds, calculation, trigger, mitigation)
   - Update astro.config.mjs to support content collections
   - Update package dependencies for MDX content collection support
   - Consolidate fork learning materials, reducing repetition

## Test plan
- [ ] Navigate through all three fork learning pages
- [ ] Verify LearnNavigation links work correctly between pages
- [ ] Check responsive design on mobile and desktop
- [ ] Verify prose styling (tables, blockquotes, code blocks) renders correctly
- [ ] Test that all internal links work correctly
- [ ] Run typecheck, lint, build