### PR TITLE
optimize: defer build and deploy until fork-risk data changes

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,6 +22,8 @@ permissions:
 
 jobs:
   build:
+    needs: risk-monitor
+    if: github.event_name != 'schedule' || needs.risk-monitor.outputs.risk-changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -222,7 +224,7 @@ jobs:
 
   deploy:
     needs: [risk-monitor, build]
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && needs.risk-monitor.outputs.risk-changed == 'true'))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

On scheduled hourly runs, skip build and deploy jobs if fork-risk data hasn't changed. This eliminates unnecessary resource usage (build time, artifact storage, GitHub Pages deployment) when the output would be identical to the previous hour.

## Changes

- `build` job now waits for `risk-monitor` completion
- `build` skips on schedule trigger unless `risk-changed == true`
- `deploy` skips on schedule trigger unless `risk-changed == true`
- Push/dispatch events still build and deploy normally (unchanged behavior)

## Benefits

- Reduced GitHub Actions build minutes on majority of hourly runs
- No artifact creation/storage waste when data unchanged
- GitHub Pages deployment only when necessary
- Preserves immediate deployment on push/dispatch

## Test Plan

- [ ] Verify scheduled workflow with no risk change skips build/deploy
- [ ] Verify scheduled workflow with risk change triggers build/deploy
- [ ] Verify push to main still triggers build/deploy
- [ ] Verify manual dispatch still triggers build/deploy