### PR TITLE
Update mission page with Q2 through Q4 updates

### DIFF
--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -44,7 +44,7 @@ import { withBase } from "../lib/utils";
         <PageHeading text="Our Work On Augur" />
 
         <div class="max-w-4xl mx-auto">
-          <p class="text-center text-foreground mb-8 mx-auto max-w-2xl">Augur has always represented a bold idea: <span class="text-loud-foreground">A decentralized oracle system that lets anyone ask and resolve questions about the future — without trusted intermediaries</span>. In 2025, the Lituus Foundation began rebooting Augur from the ground up, adapting its core ideas to a radically changed crypto landscape. Here's how our journey has unfolded so far:</p>
+          <p class="text-center text-foreground mb-8 mx-auto max-w-2xl">Augur has always represented a bold idea: <span class="text-loud-foreground">A decentralized oracle system that lets anyone ask and resolve questions about the future — without trusted intermediaries</span>. In 2025, the Lituus Foundation began rebooting Augur from the ground up, adapting its core ideas to a radically changed crypto landscape. Here's how our journey has unfolded over the past year:</p>
 
           <SectionHeading text="The Reboot Timeline" />
 
@@ -71,7 +71,7 @@ import { withBase } from "../lib/utils";
             <p>This was a major conceptual expansion — from a niche oracle for a specific prediction market to a <strong>modular, cross-chain truth layer for Web3</strong>.</p>
           </TimelineSection>
 
-          <TimelineSection title="Augur's Revival" date="July 1, 2025" isLast>
+          <TimelineSection title="Augur's Revival" date="July 1, 2025">
             <h3>Q1 and Beyond</h3>
             <p>Three months into the reboot, we published our first comprehensive progress report. Key updates included:</p>
             <ul>
@@ -80,6 +80,30 @@ import { withBase } from "../lib/utils";
               <li><strong>Community and ecosystem building:</strong> Participation in major crypto events, dev outreach, and Discord engagement</li>
             </ul>
             <p><em>R&D milestone:</em> Paused implementation of a prototype (AugurCP) after discovering a critical game-theoretic vulnerability. We're now conducting deeper oracle security research before proceeding.</p>
+          </TimelineSection>
+
+          <TimelineSection title="Augur's Rising" date="October 1, 2025">
+            <h3>Q2: Momentum and the Fork</h3>
+            <p>Six months in, our footing solidified and we began scaling operations. This quarter marked two significant milestones:</p>
+            <ul>
+              <li><strong>Website relaunch:</strong> Augur.net went live with clear messaging on oracle design, architecture, and our vision</li>
+              <li><strong>Oracle research streams:</strong> Continued progress on two complementary paths—one focused on consumer prediction markets, the other on enterprise-grade oracle use cases</li>
+              <li><strong>Fork experiment:</strong> Community developer <strong>Micah Zoltu</strong> launched a crowdsourcer to deliberately trigger Augur's first algorithmic fork, a bold test of our core security model</li>
+              <li><strong>REP support:</strong> Expanded Foundation holdings to 1M REP, doubling our position and strengthening the token's on-chain liquidity</li>
+            </ul>
+            <p>The fork crowdsourcer gained significant traction, eventually filling and setting the stage for a live demonstration of Augur's ultimate defense mechanism.</p>
+          </TimelineSection>
+
+          <TimelineSection title="Augur's Decade" date="January 2, 2026" isLast>
+            <h3>Q3: The Fork Completes, the Whitepaper Approaches</h3>
+            <p>Our third fiscal quarter brought us to a historic milestone—ten years since Augur first deployed to Ethereum. The quarter was defined by preparation and refinement:</p>
+            <ul>
+              <li><strong>Fork crowdsourcer completed:</strong> Micah's crowdsourcer filled, enabling final preparation for crypto's first algorithmic fork and a rare, live demonstration of Augur's security model</li>
+              <li><strong>Whitepaper in final review:</strong> After extensive external feedback from academics and researchers, we completed the <strong>Augur Lituus Whitepaper</strong>—a comprehensive design for a modular, cross-chain oracle infrastructure</li>
+              <li><strong>Parallel development advances:</strong> Both development tracks (B2C consumer markets and B2B enterprise oracles) progressed toward a unified REP direction</li>
+              <li><strong>Fork and migration tooling:</strong> Community-led development of tools to support fork participation and smooth REP migration across outcomes</li>
+            </ul>
+            <p>The whitepaper marked the transition from research to development, establishing Augur Lituus as a shared resolution layer for prediction markets, DeFi protocols, and cross-chain systems. Meanwhile, preparation for the fork—one of the most significant on-chain events in Augur's history—advanced toward execution.</p>
           </TimelineSection>
         </div>
       </div>

--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -94,7 +94,7 @@ import { withBase } from "../lib/utils";
             <p>The fork crowdsourcer gained significant traction, eventually filling and setting the stage for a live demonstration of Augur's ultimate defense mechanism.</p>
           </TimelineSection>
 
-          <TimelineSection title="Augur's Decade" date="January 2, 2026" isLast>
+          <TimelineSection title="Augur's Decade" date="January 2, 2026">
             <h3>Q3: The Fork Completes, the Whitepaper Approaches</h3>
             <p>Our third fiscal quarter brought us to a historic milestone—ten years since Augur first deployed to Ethereum. The quarter was defined by preparation and refinement:</p>
             <ul>
@@ -104,6 +104,18 @@ import { withBase } from "../lib/utils";
               <li><strong>Fork and migration tooling:</strong> Community-led development of tools to support fork participation and smooth REP migration across outcomes</li>
             </ul>
             <p>The whitepaper marked the transition from research to development, establishing Augur Lituus as a shared resolution layer for prediction markets, DeFi protocols, and cross-chain systems. Meanwhile, preparation for the fork—one of the most significant on-chain events in Augur's history—advanced toward execution.</p>
+          </TimelineSection>
+
+          <TimelineSection title="Building the Future" date="Q4 2026">
+            <h3>From Research to Reality</h3>
+            <p>We're now in the execution phase—building toward the fork and bringing Augur Lituus from whitepaper to live system:</p>
+            <ul>
+              <li><strong>Whitepaper released:</strong> The Augur Lituus Whitepaper is now <a href="https://github.com/AugurProject/whitepaper/blob/master/Lituus/English/Augur_Lituus_Whitepaper.pdf" target="_blank" rel="noopener noreferrer">publicly available</a>, presenting a modular oracle design and comparative analysis of oracle security</li>
+              <li><strong>Engineering underway:</strong> Development teams are actively building the Augur Lituus protocol based on the whitepaper specifications</li>
+              <li><strong>Fork preparation:</strong> Final tooling and infrastructure for the algorithmic fork are in development, with execution on the horizon</li>
+              <li><strong>Community growth:</strong> Discord engagement and developer interest continue to build as we approach these milestones</li>
+            </ul>
+            <p>Stay tuned—major announcements coming as we cross each threshold.</p>
           </TimelineSection>
         </div>
       </div>

--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -106,16 +106,11 @@ import { withBase } from "../lib/utils";
             <p>The whitepaper marked the transition from research to development, establishing Augur Lituus as a shared resolution layer for prediction markets, DeFi protocols, and cross-chain systems. Meanwhile, preparation for the fork—one of the most significant on-chain events in Augur's history—advanced toward execution.</p>
           </TimelineSection>
 
-          <TimelineSection title="Building the Future" date="Q4 2026">
-            <h3>From Research to Reality</h3>
-            <p>We're now in the execution phase—building toward the fork and bringing Augur Lituus from whitepaper to live system:</p>
-            <ul>
-              <li><strong>Whitepaper released:</strong> The Augur Lituus Whitepaper is now <a href="https://github.com/AugurProject/whitepaper/blob/master/Lituus/English/Augur_Lituus_Whitepaper.pdf" target="_blank" rel="noopener noreferrer">publicly available</a>, presenting a modular oracle design and comparative analysis of oracle security</li>
-              <li><strong>Engineering underway:</strong> Development teams are actively building the Augur Lituus protocol based on the whitepaper specifications</li>
-              <li><strong>Fork preparation:</strong> Final tooling and infrastructure for the algorithmic fork are in development, with execution on the horizon</li>
-              <li><strong>Community growth:</strong> Discord engagement and developer interest continue to build as we approach these milestones</li>
-            </ul>
-            <p>Stay tuned—major announcements coming as we cross each threshold.</p>
+          <TimelineSection title="Building the Future" date="Q4 2026" isLast>
+            <h3>Whitepaper Released</h3>
+            <p>The <strong>Augur Lituus Whitepaper</strong> is now <a href="https://github.com/AugurProject/whitepaper/blob/master/Lituus/English/Augur_Lituus_Whitepaper.pdf" target="_blank" rel="noopener noreferrer">publicly available</a>, presenting a modular oracle design and comparative analysis of oracle security.</p>
+            <br />
+            <p>More updates coming as we continue building toward a live system.</p>
           </TimelineSection>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Updated the mission page timeline to include Q2 (October 2025) and Q3 (January 2026) milestones, bringing it current with recent foundation progress.

**Q2 additions:**
- Website relaunch at augur.net
- Oracle research on two complementary streams (B2C and B2B)
- Micah Zoltu's fork crowdsourcer launch
- REP holdings expanded to 1M

**Q3 additions:**
- Fork crowdsourcer completion and final preparation
- Augur Lituus Whitepaper release and transition to development
- Parallel development advances toward unified REP
- Fork and migration tooling development

Maintains consistent design and writing style with existing timeline sections.