### PR TITLE
fix: replace dead RPC endpoints and consume ETH_RPC_URL secret

### DIFF
--- a/docs/fork-risk-assessment.md
+++ b/docs/fork-risk-assessment.md
@@ -81,7 +81,7 @@ These thresholds replace previously conservative levels that would have triggere
 - **GitHub Actions**: Hourly automated calculations (sufficient for 7-day dispute windows)
 - **Public RPC Endpoints**: No API keys required, fully transparent access
   - Primary: PublicNode (`https://ethereum-rpc.publicnode.com`)
-  - Fallbacks: Cloudflare, Ankr, 1RPC
+  - Fallbacks: dRPC, 1RPC
   - Optional: `ETH_RPC_URL` env var prepended as primary when set
 - **Static JSON Storage**: Results saved to version-controlled JSON file
 - **Audit Trail**: All calculations and changes tracked in git history
@@ -96,9 +96,8 @@ These thresholds replace previously conservative levels that would have triggere
 The system attempts to connect to public RPC endpoints in order of preference:
 1. **`ETH_RPC_URL`** (when configured via environment/secret)
 2. **PublicNode** (`https://ethereum-rpc.publicnode.com`)
-3. **Cloudflare** (`https://cloudflare-eth.com`)
-4. **Ankr** (`https://rpc.ankr.com/eth`)
-5. **1RPC** (`https://1rpc.io/eth`)
+3. **dRPC** (`https://eth.drpc.org`)
+4. **1RPC** (`https://1rpc.io/eth`)
 
 Each endpoint is tested with a `getBlockNumber()` call before use. If all endpoints fail, the system reports an error state rather than falling back to mock data. Connection latency and endpoint used are logged for transparency.
 

--- a/docs/fork-risk-assessment.md
+++ b/docs/fork-risk-assessment.md
@@ -80,8 +80,9 @@ These thresholds replace previously conservative levels that would have triggere
 ### Infrastructure Design
 - **GitHub Actions**: Hourly automated calculations (sufficient for 7-day dispute windows)
 - **Public RPC Endpoints**: No API keys required, fully transparent access
-  - Primary: LlamaRPC (`https://eth.llamarpc.com`)
-  - Fallbacks: LinkPool, PublicNode, 1RPC
+  - Primary: PublicNode (`https://ethereum-rpc.publicnode.com`)
+  - Fallbacks: Cloudflare, Ankr, 1RPC
+  - Optional: `ETH_RPC_URL` env var prepended as primary when set
 - **Static JSON Storage**: Results saved to version-controlled JSON file
 - **Audit Trail**: All calculations and changes tracked in git history
 - **No Private Infrastructure**: No databases, no API keys, fully auditable
@@ -93,10 +94,11 @@ These thresholds replace previously conservative levels that would have triggere
 
 ### RPC Failover Strategy
 The system attempts to connect to public RPC endpoints in order of preference:
-1. **LlamaRPC** (`https://eth.llamarpc.com`)
-2. **LinkPool** (`https://main-light.eth.linkpool.io`)
-3. **PublicNode** (`https://ethereum.publicnode.com`)
-4. **1RPC** (`https://1rpc.io/eth`)
+1. **`ETH_RPC_URL`** (when configured via environment/secret)
+2. **PublicNode** (`https://ethereum-rpc.publicnode.com`)
+3. **Cloudflare** (`https://cloudflare-eth.com`)
+4. **Ankr** (`https://rpc.ankr.com/eth`)
+5. **1RPC** (`https://1rpc.io/eth`)
 
 Each endpoint is tested with a `getBlockNumber()` call before use. If all endpoints fail, the system reports an error state rather than falling back to mock data. Connection latency and endpoint used are logged for transparency.
 

--- a/docs/fork-risk-monitoring-system.md
+++ b/docs/fork-risk-monitoring-system.md
@@ -135,7 +135,7 @@ Frontend fetches JSON → displays gauge
     "disputeDetails": []
   },
   "rpcInfo": {
-    "endpoint": "https://eth.llamarpc.com",
+    "endpoint": "https://ethereum-rpc.publicnode.com",
     "latency": 632,
     "fallbacksAttempted": 0
   },

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -104,8 +104,7 @@ const VALIDATION_DEPTH = 8 // blocks (detects corruption within ~2 minutes)
 const PUBLIC_RPC_ENDPOINTS = [
 	...(process.env.ETH_RPC_URL ? [process.env.ETH_RPC_URL] : []),
 	'https://ethereum-rpc.publicnode.com', // PublicNode (Allnodes)
-	'https://cloudflare-eth.com', // Cloudflare
-	'https://rpc.ankr.com/eth', // Ankr
+	'https://eth.drpc.org', // dRPC
 	'https://1rpc.io/eth', // 1RPC (Automata)
 ]
 

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -100,11 +100,13 @@ const FINALITY_DEPTH = 32 // Ethereum finality depth (~6.4 minutes)
 const VALIDATION_DEPTH = 8 // blocks (detects corruption within ~2 minutes)
 
 // Public RPC endpoints (no API keys required!)
+// ETH_RPC_URL env var is prepended as primary when set
 const PUBLIC_RPC_ENDPOINTS = [
-	'https://eth.llamarpc.com', // LlamaRPC
-	'https://main-light.eth.linkpool.io', // LinkPool
-	'https://ethereum.publicnode.com', // PublicNode
-	'https://1rpc.io/eth', // 1RPC
+	...(process.env.ETH_RPC_URL ? [process.env.ETH_RPC_URL] : []),
+	'https://ethereum-rpc.publicnode.com', // PublicNode (Allnodes)
+	'https://cloudflare-eth.com', // Cloudflare
+	'https://rpc.ankr.com/eth', // Ankr
+	'https://1rpc.io/eth', // 1RPC (Automata)
 ]
 
 interface RpcConnection {


### PR DESCRIPTION
## Summary
- Remove dead RPC endpoints: LlamaRPC (403 Cloudflare challenge) and LinkPool (self-signed cert)
- Replace with reliable public endpoints: PublicNode, Cloudflare, Ankr (kept 1RPC)
- Consume `ETH_RPC_URL` env var as primary endpoint when set — previously passed in workflow but ignored by the script

## Test plan
- [ ] Trigger `workflow_dispatch` on this branch to verify no RPC fallback warnings
- [ ] Confirm `fork-risk.json` output shows `fallbacksAttempted: 0`

Fixes #82