### PR TITLE
Experiment: CTA as full-width announcement bar

### DIFF
--- a/src/components/AnnouncementBar.astro
+++ b/src/components/AnnouncementBar.astro
@@ -33,14 +33,17 @@ const { show = true } = Astro.props;
 
   function revealBar(bar: HTMLElement) {
     const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.get('intro') === 'false') {
-      bar.style.opacity = '1';
-    } else {
+    const isHome = window.location.pathname === '/' || window.location.pathname === '/index.html';
+    const introPlaying = isHome && urlParams.get('intro') !== 'false';
+
+    if (introPlaying) {
       // Wait for the intro animation to complete (~4.9s)
       setTimeout(() => {
         bar.style.transition = 'opacity 0.5s ease-out';
         bar.style.opacity = '1';
       }, 4900);
+    } else {
+      bar.style.opacity = '1';
     }
   }
 

--- a/src/components/AnnouncementBar.astro
+++ b/src/components/AnnouncementBar.astro
@@ -1,0 +1,41 @@
+---
+import WarningMark from '@phosphor-icons/core/assets/regular/siren.svg';
+import { withBase } from '../lib/utils';
+
+export interface Props {
+  show?: boolean;
+}
+
+const { show = true } = Astro.props;
+---
+
+{show && (
+  <div id="announcement-bar" class="relative w-full bg-green-500 text-black flex items-center justify-center gap-3 px-10 py-2.5 text-sm font-bold tracking-wide z-50">
+    <WarningMark class="w-5 h-5 shrink-0" />
+    <a href={withBase('/faq')} class="hover:underline focus:underline focus:outline-none whitespace-nowrap">
+      THE FORK IS HERE! OWN REP? ACT NOW.
+    </a>
+    <button
+      id="announcement-bar-close"
+      aria-label="Dismiss announcement"
+      class="absolute right-3 top-1/2 -translate-y-1/2 p-1 hover:opacity-70 focus:opacity-70 focus:outline-none"
+    >
+      ✕
+    </button>
+  </div>
+)}
+
+<script>
+  function initAnnouncementBar() {
+    const bar = document.getElementById('announcement-bar');
+    const closeBtn = document.getElementById('announcement-bar-close');
+    if (!bar || !closeBtn) return;
+
+    closeBtn.addEventListener('click', () => {
+      bar.remove();
+    });
+  }
+
+  document.addEventListener('astro:page-load', initAnnouncementBar);
+  initAnnouncementBar();
+</script>

--- a/src/components/AnnouncementBar.astro
+++ b/src/components/AnnouncementBar.astro
@@ -10,7 +10,7 @@ const { show = true } = Astro.props;
 ---
 
 {show && (
-  <div id="announcement-bar" class="relative w-full bg-green-500 text-black flex items-center justify-center gap-3 px-10 py-2.5 text-sm font-bold tracking-wide z-50">
+  <div id="announcement-bar" class="relative w-full bg-green-500 text-black flex items-center justify-center gap-3 px-10 py-2.5 text-sm font-bold tracking-wide z-50 opacity-0">
     <WarningMark class="w-5 h-5 shrink-0" />
     <a href={withBase('/faq')} class="hover:underline focus:underline focus:outline-none whitespace-nowrap">
       THE FORK IS HERE! OWN REP? ACT NOW.
@@ -31,11 +31,26 @@ const { show = true } = Astro.props;
     document.documentElement.style.setProperty('--bar-height', bar ? `${bar.offsetHeight}px` : '0px');
   }
 
+  function revealBar(bar: HTMLElement) {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('intro') === 'false') {
+      bar.style.opacity = '1';
+    } else {
+      // Wait for the intro animation to complete (~4.9s)
+      setTimeout(() => {
+        bar.style.transition = 'opacity 0.5s ease-out';
+        bar.style.opacity = '1';
+      }, 4900);
+    }
+  }
+
   function initAnnouncementBar() {
     setBarHeight();
     const bar = document.getElementById('announcement-bar');
     const closeBtn = document.getElementById('announcement-bar-close');
     if (!bar || !closeBtn) return;
+
+    revealBar(bar);
 
     closeBtn.addEventListener('click', () => {
       bar.remove();

--- a/src/components/AnnouncementBar.astro
+++ b/src/components/AnnouncementBar.astro
@@ -26,38 +26,54 @@ const { show = true } = Astro.props;
 )}
 
 <script>
+  import { $appStore, UIState, shouldSkipFromURL } from '../stores/animationStore';
+
+  let unsubscribe: (() => void) | null = null;
+  let revealTimeout: number | null = null;
+
   function setBarHeight() {
     const bar = document.getElementById('announcement-bar');
     document.documentElement.style.setProperty('--bar-height', bar ? `${bar.offsetHeight}px` : '0px');
   }
 
-  function revealBar(bar: HTMLElement) {
-    const urlParams = new URLSearchParams(window.location.search);
-    const isHome = window.location.pathname === '/' || window.location.pathname === '/index.html';
-    const introPlaying = isHome && urlParams.get('intro') !== 'false';
-
-    if (introPlaying) {
-      // Wait for the intro animation to complete (~4.9s)
-      setTimeout(() => {
-        bar.style.transition = 'opacity 0.5s ease-out';
-        bar.style.opacity = '1';
-      }, 4900);
-    } else {
-      bar.style.opacity = '1';
-    }
-  }
-
   function initAnnouncementBar() {
     setBarHeight();
+
     const bar = document.getElementById('announcement-bar');
     const closeBtn = document.getElementById('announcement-bar-close');
     if (!bar || !closeBtn) return;
 
-    revealBar(bar);
-
     closeBtn.addEventListener('click', () => {
       bar.remove();
       document.documentElement.style.setProperty('--bar-height', '0px');
+    });
+
+    // Clean up any previous subscription/timeout
+    if (unsubscribe) { unsubscribe(); unsubscribe = null; }
+    if (revealTimeout) { clearTimeout(revealTimeout); revealTimeout = null; }
+
+    // Subscribe to the app store — same pattern as HeroBanner
+    unsubscribe = $appStore.subscribe((state) => {
+      if (state.uiState !== UIState.MAIN_CONTENT) return;
+
+      const bar = document.getElementById('announcement-bar');
+      if (!bar) return;
+
+      if (shouldSkipFromURL()) {
+        // Intro was skipped — show immediately
+        bar.style.opacity = '1';
+      } else {
+        // Intro animation played — wait for it to finish (~4.9s from animations-started)
+        revealTimeout = window.setTimeout(() => {
+          bar.style.transition = 'opacity 0.5s ease-out';
+          bar.style.opacity = '1';
+          revealTimeout = null;
+        }, 4900);
+      }
+
+      // One-shot: unsubscribe after revealing
+      unsubscribe?.();
+      unsubscribe = null;
     });
   }
 

--- a/src/components/AnnouncementBar.astro
+++ b/src/components/AnnouncementBar.astro
@@ -26,13 +26,20 @@ const { show = true } = Astro.props;
 )}
 
 <script>
+  function setBarHeight() {
+    const bar = document.getElementById('announcement-bar');
+    document.documentElement.style.setProperty('--bar-height', bar ? `${bar.offsetHeight}px` : '0px');
+  }
+
   function initAnnouncementBar() {
+    setBarHeight();
     const bar = document.getElementById('announcement-bar');
     const closeBtn = document.getElementById('announcement-bar-close');
     if (!bar || !closeBtn) return;
 
     closeBtn.addEventListener('click', () => {
       bar.remove();
+      document.documentElement.style.setProperty('--bar-height', '0px');
     });
   }
 

--- a/src/components/HeroBanner.astro
+++ b/src/components/HeroBanner.astro
@@ -6,7 +6,7 @@ import { withBase } from '../lib/utils';
 import PageHeader from './PageHeader.astro';
 ---
 
-<div class="h-screen min-h-fit w-full relative">
+<div class="h-[calc(100vh-var(--bar-height,0px))] min-h-fit w-full relative">
   <div id="hero-banner-container" class="grid grid-rows-[auto_auto_auto] min-h-full z-10 text-center content-between">
     <div id="top-header-row">
       <PageHeader />

--- a/src/components/HeroBanner.astro
+++ b/src/components/HeroBanner.astro
@@ -9,7 +9,7 @@ import PageHeader from './PageHeader.astro';
 <div class="h-screen min-h-fit w-full relative">
   <div id="hero-banner-container" class="grid grid-rows-[auto_auto_auto] min-h-full z-10 text-center content-between">
     <div id="top-header-row">
-      <PageHeader showCta={true} />
+      <PageHeader />
     </div>
 
     <!-- Middle Section: Main Content (Logo, Tagline, IS REBOOTING, Menu) -->

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -24,7 +24,7 @@ export interface Props {
 
 const {
   backHref,
-  showCta = true,
+  showCta = false,
   class: className = '',
 } = Astro.props;
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import { ClientRouter } from "astro:transitions";
 import "../styles/global.css";
 import PerspectiveGridTunnel from "../components/PerspectiveGridTunnel.tsx";
 import GoogleAnalytics from "../components/GoogleAnalytics.astro";
+import AnnouncementBar from "../components/AnnouncementBar.astro";
 import { withBase } from "../lib/utils";
 
 interface Props {
@@ -14,6 +15,7 @@ interface Props {
 	noindex?: boolean;
 	author?: string;
 	keywords?: string[];
+	showAnnouncementBar?: boolean;
 }
 
 // Safe URL construction for Cloudflare Workers
@@ -28,6 +30,7 @@ const {
 	canonicalURL = defaultCanonicalURL,
 	noindex = false,
 	author = "Augur Project",
+	showAnnouncementBar = true,
 	keywords = [
 		"prediction markets",
 		"blockchain",
@@ -115,14 +118,15 @@ const {
 	<GoogleAnalytics gaId={import.meta.env.PUBLIC_GA_ID} />
 </head>
 	<body>
-		<PerspectiveGridTunnel 
-			client:load 
+		<AnnouncementBar show={showAnnouncementBar} />
+		<PerspectiveGridTunnel
+			client:load
 			transition:persist
 			transition:persist-props
 			transition:name="grid-tunnel"
-			numLines={12} 
-			animationSpeed={0.1} 
-			maxOpacity={0.2} 
+			numLines={12}
+			animationSpeed={0.1}
+			maxOpacity={0.2}
 			lineColor="#2AE7A8"
 			vanishingPoint={0.75}
 		/>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -9,6 +9,7 @@ import { withBase } from "../lib/utils";
 <Layout
   title="FAQ — Fork & Migration | Augur"
   description="If you own REP, read this. Everything you need to know about the Augur fork and how to migrate your tokens safely."
+  showAnnouncementBar={false}
   keywords={[
     "augur fork",
     "REP migration",


### PR DESCRIPTION
Experimental branch testing full-width green announcement bar placement.

- Bar appears at top of viewport, dismissible
- Respects intro animation timing via store subscription
- Hidden on FAQ page
- Independently mergeable if preferred over PageHeader placement