### PR TITLE
Experiment: CTA below nav links in hero

### DIFF
--- a/src/components/HeroBanner.astro
+++ b/src/components/HeroBanner.astro
@@ -4,12 +4,14 @@ import ForkMonitor from './ForkMonitor.tsx';
 import { ScrollIndicator } from './ScrollIndicator';
 import { withBase } from '../lib/utils';
 import PageHeader from './PageHeader.astro';
+import BorderBeam from './ui/BorderBeam';
+import WarningMark from '@phosphor-icons/core/assets/regular/siren.svg';
 ---
 
 <div class="h-screen min-h-fit w-full relative">
   <div id="hero-banner-container" class="grid grid-rows-[auto_auto_auto] min-h-full z-10 text-center content-between">
     <div id="top-header-row">
-      <PageHeader showCta={true} />
+      <PageHeader showCta={false} />
     </div>
 
     <!-- Middle Section: Main Content (Logo, Tagline, IS REBOOTING, Menu) -->
@@ -39,6 +41,21 @@ import PageHeader from './PageHeader.astro';
         <a href={withBase('/team')} class="text-2xl font-bold text-foreground hover:text-loud-foreground focus:text-loud-foreground block hover:fx-glow focus:fx-glow focus:outline-none">
           THE MINDS BEHIND THE REBOOT
         </a>
+      </div>
+
+      <!-- Fork CTA: moved to hero, below nav links -->
+      <div id="fork-cta-container">
+        <div class="animate-[bob_2s_ease-in-out_infinite]">
+          <BorderBeam client:load duration={2.5}>
+            <a
+              href={withBase('/faq')}
+              class="bg-foreground/5 tracking-wide flex items-center px-4 py-2 text-lg font-semibold text-loud-foreground shadow-[0_0_10px_oklch(from_var(--color-foreground)_l_c_h/_0.4)] hover:fx-glow-sm focus:fx-glow-sm focus:outline-none whitespace-nowrap"
+            >
+              <WarningMark class="w-6 h-6 border-muted-foreground/80 rounded-full p-1 mr-3" />
+              THE FORK IS HERE! OWN REP? ACT NOW.
+            </a>
+          </BorderBeam>
+        </div>
       </div>
     </div>
 
@@ -109,6 +126,7 @@ import PageHeader from './PageHeader.astro';
   #line-right,
   #prediction-market-text,
   #menu-items-container a,
+  #fork-cta-container,
   #fork-meter-container {
     opacity: 0;
   }
@@ -167,6 +185,7 @@ import PageHeader from './PageHeader.astro';
   #hero-banner-container.animations-skipped #line-right,
   #hero-banner-container.animations-skipped #prediction-market-text,
   #hero-banner-container.animations-skipped #menu-items-container a,
+  #hero-banner-container.animations-skipped #fork-cta-container,
   #hero-banner-container.animations-skipped #fork-meter-container {
     opacity: 1;
     transform: none; /* Resets any initial transform */
@@ -206,8 +225,12 @@ import PageHeader from './PageHeader.astro';
     animation: fade-in-up 0.5s ease-out 3.4s forwards;
   }
 
+  #hero-banner-container.animations-started #fork-cta-container {
+    animation: fade-in-up 0.5s ease-out 3.6s forwards;
+  }
+
   #hero-banner-container.animations-started #fork-meter-container {
-    animation: fade-in-up 0.6s ease-out 3.6s forwards;
+    animation: fade-in-up 0.6s ease-out 3.8s forwards;
   }
 </style>
 

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -24,7 +24,7 @@ export interface Props {
 
 const {
   backHref,
-  showCta = true,
+  showCta = false,
   class: className = '',
 } = Astro.props;
 

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -52,7 +52,11 @@ import { withBase } from "../lib/utils";
             <summary>I OWN REPV2. WHAT IS HAPPENING?</summary>
             <div class="faq-answer">
               <p>Micah Zoltu, an Augur community member, has raised funds to trigger a fork over whether the Artemis II mission successfully lifted off (it did). As part of this fork, Augur will create new tokens for each outcome, and REP holders must choose which token to migrate their REP to.</p>
-              <p><strong>Learn more:</strong> <a href="https://augur.net/blog/micahs-augur-fork/" target="_blank">Blog post</a> | <a href="https://augur.net/blog/augur-cryptos-first-algorithmic-fork/" target="_blank">Fork overview</a></p>
+              <p><strong>Learn more:</strong></p>
+              <ul>
+                <li><a href="https://augur.net/blog/micahs-augur-fork/" target="_blank">Micah's Augur Fork</a></li>
+                <li><a href="https://augur.net/blog/augur-cryptos-first-algorithmic-fork/" target="_blank">Augur Crypto's First Algorithmic Fork</a></li>
+              </ul>
             </div>
           </details>
           <details class="faq-item">
@@ -76,15 +80,9 @@ import { withBase } from "../lib/utils";
             <summary>WHEN DOES THE FORK START AND END?</summary>
             <div class="faq-answer">
               <p><strong>Start:</strong> April 8</p>
-              <p><strong>Escalation game:</strong> 2 months</p>
-              <p><strong>Migration window:</strong> 2 months</p>
+              <p><strong>Escalation Game (Phase 1):</strong> ~2 months</p>
+              <p><strong>Migration Window (Phase 2):</strong> ~2 months</p>
               <p><strong>Total duration:</strong> ~4 months</p>
-            </div>
-          </details>
-          <details class="faq-item">
-            <summary>WHAT HAPPENS DURING THE ESCALATION GAME (PHASE 1)?</summary>
-            <div class="faq-answer">
-              <p>People can dispute outcomes by staking REP in an escalation game, where each round requires a larger stake on opposing sides. If you back the correct outcome, you earn a return from those on the losing side (up to ~40% in this test). Participation is optional.</p>
             </div>
           </details>
           <details class="faq-item">
@@ -99,33 +97,9 @@ import { withBase } from "../lib/utils";
         <SectionHeading text="Required Action" />
         <div class="faq-group mb-12">
           <details class="faq-item">
-            <summary>DO I NEED TO PARTICIPATE IN THE ESCALATION GAME?</summary>
+            <summary>WHAT HAPPENS DURING THE ESCALATION GAME (PHASE 1)?</summary>
             <div class="faq-answer">
-              <p>No. It is optional.</p>
-            </div>
-          </details>
-          <details class="faq-item">
-            <summary>DO I NEED TO PARTICIPATE IN MIGRATION?</summary>
-            <div class="faq-answer">
-              <p><strong>Yes.</strong> If you do not migrate, your REP will likely become worthless.</p>
-            </div>
-          </details>
-          <details class="faq-item">
-            <summary>WHAT DOES "MIGRATION" MEAN?</summary>
-            <div class="faq-answer">
-              <p>You send your REP into the new, correct version of Augur. This is a one-time, one-way action.</p>
-            </div>
-          </details>
-          <details class="faq-item">
-            <summary>WHAT HAPPENS IF I DON'T MIGRATE?</summary>
-            <div class="faq-answer">
-              <p>Your REP may remain in an old version that no one uses. It will likely have no value.</p>
-            </div>
-          </details>
-          <details class="faq-item">
-            <summary>WHAT HAPPENS IF I MIGRATE TO THE WRONG UNIVERSE?</summary>
-            <div class="faq-answer">
-              <p>Your REP will likely become worthless, since that universe will not be used going forward.</p>
+              <p>People can dispute outcomes by staking REP in an escalation game, where each round requires a larger stake on opposing sides. If you back the correct outcome, you earn a return from those on the losing side (up to ~40% in this test). Participation is optional.</p>
             </div>
           </details>
           <details class="faq-item">
@@ -135,9 +109,21 @@ import { withBase } from "../lib/utils";
             </div>
           </details>
           <details class="faq-item">
+            <summary>WHAT HAPPENS IF I DON'T MIGRATE?</summary>
+            <div class="faq-answer">
+              <p>Your REP will remain in an old version that no one uses. It will likely have no value.</p>
+            </div>
+          </details>
+          <details class="faq-item">
+            <summary>WHAT HAPPENS IF I MIGRATE TO THE WRONG UNIVERSE?</summary>
+            <div class="faq-answer">
+              <p>Your REP will likely become worthless, since that universe will not be used going forward.</p>
+            </div>
+          </details>
+          <details class="faq-item">
             <summary>HOW DO I MIGRATE?</summary>
             <div class="faq-answer">
-              <p>You will use the tool at augurfork.eth. A step-by-step guide will also be provided.</p>
+              <p>You will use the tool at <a href="https://6.augurfork.eth.limo" target="_blank">6.augurfork.eth.limo</a>. A step-by-step guide will also be provided.</p>
             </div>
           </details>
         </div>
@@ -171,7 +157,7 @@ import { withBase } from "../lib/utils";
           <details class="faq-item">
             <summary>I OWN REPV1. WHAT SHOULD I DO?</summary>
             <div class="faq-answer">
-              <p>Convert it to REPv2 first using the official migration page. Then follow the fork migration steps.</p>
+              <p>Convert it to REPv2 using the migration tool at <a href="https://6.augurfork.eth.limo" target="_blank">6.augurfork.eth.limo</a>. Then follow the fork migration steps.</p>
             </div>
           </details>
           <details class="faq-item">
@@ -188,8 +174,7 @@ import { withBase } from "../lib/utils";
           <details class="faq-item">
             <summary>MY REP IS ON AN EXCHANGE (KRAKEN, GATE). WHAT SHOULD I DO?</summary>
             <div class="faq-answer">
-              <p><strong>Best option:</strong> Withdraw to your own wallet and migrate yourself.</p>
-              <p>We are in discussions with exchanges such as Kraken and Gate.io, but support is not guaranteed.</p>
+              <p><strong>Best option:</strong> withdraw to your own wallet and migrate yourself. We are in discussions with exchanges such as <a href="https://kraken.com/" target="_blank">Kraken</a> and <a href="https://gate.com/" target="_blank">Gate.io</a>, but support is not guaranteed.</p>
             </div>
           </details>
           <details class="faq-item">
@@ -212,21 +197,16 @@ import { withBase } from "../lib/utils";
           <details class="faq-item">
             <summary>IS THERE A DEADLINE?</summary>
             <div class="faq-answer">
-              <p>Yes. You only have the 2-month migration window.</p>
+              <p>Yes. You only have the ~2-month migration window.</p>
             </div>
           </details>
-          <details class="faq-item">
-            <summary>WILL THERE BE AN OFFICIAL MIGRATION TOOL?</summary>
-            <div class="faq-answer">
-              <p>Yes. Always use official Augur links only.</p>
-            </div>
-          </details>
-          <details class="faq-item">
-            <summary>HOW DO I KNOW WHICH UNIVERSE IS CORRECT?</summary>
-            <div class="faq-answer">
-              <p>Follow official Augur communications. Do not guess.</p>
-            </div>
-          </details>
+        </div>
+
+        <!-- Closing -->
+        <div class="mt-8 border-foreground/10 font-prose text-xs text-foreground">
+          <p class="mb-3">Still have questions? Come find us in the community:</p>
+          <p class="mb-1">→ <a class="text-loud-foreground" href="https://discord.gg/aNBTq55" target="_blank">Join the Discord</a></p>
+          <p>→ Follow <a class="text-loud-foreground" href="https://x.com/AugurProject" target="_blank">@AugurProject</a> on X</p>
         </div>
 
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -277,7 +277,7 @@ html {
 	--tw-prose-td-borders: var(--color-muted-foreground);
 	--tw-prose-th-borders: var(--color-muted-foreground);
 	--tw-prose-bg-hover: var(--color-primary);
-	--tw-prose-line-height: 1.2;
+	--tw-prose-line-height: 1.4;
 	--tw-prose-pre-bg: transparent;
 	--tw-prose-pre-code: var(--color-foreground);
 }
@@ -721,7 +721,8 @@ body:not(:has(#hero-banner-container)) #github-link {
 	padding: 1rem;
 	padding-left: 2.75rem;
 	font-family: var(--font-prose);
-	font-size: 0.75rem;
+	font-size: 0.825rem;
+	line-height: var(--tw-prose-line-height);
 	letter-spacing: var(--tracking-prose);
 	color: var(--color-foreground);
 	text-transform: none;
@@ -736,4 +737,30 @@ body:not(:has(#hero-banner-container)) #github-link {
 .faq-answer strong {
 	color: var(--color-loud-foreground);
 	font-weight: 400;
+}
+
+.faq-answer a {
+	color: var(--color-loud-foreground);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+	transition: filter 0.2s;
+
+	&:hover {
+		color: var(--color-loud-foreground);
+		filter: drop-shadow(0 0 0.375rem var(--color-primary));
+	}
+}
+
+.faq-answer ul {
+	list-style-type: square;
+	padding-left: 1.5rem;
+	margin: 0.5rem 0;
+}
+
+.faq-answer ul > li {
+	margin-bottom: 0.25rem;
+}
+
+.faq-answer ul > li::marker {
+	color: var(--color-muted-foreground);
 }


### PR DESCRIPTION
Experimental branch testing CTA placement below the 2 hero nav links.

- CTA appears after 'THE MINDS BEHIND THE REBOOT' with same BorderBeam design
- Fades in with animation sequence (3.6s)
- PageHeader CTA disabled (showCta=false)
- Independently mergeable if preferred over top-of-page placement