### PR TITLE
Update mission timeline with recent events

### DIFF
--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -84,22 +84,44 @@ import { withBase } from "../lib/utils";
           </TimelineSection>
 
           <TimelineSection title="Augur's Decade" date="January 2, 2026">
-            <h3>Q3: The Fork Completes, the Whitepaper Approaches</h3>
+            <h3>Q3: Crowdsourcer Filled, Whitepaper Approaching</h3>
             <p>Our third fiscal quarter brought us to a historic milestone—ten years since Augur first deployed to Ethereum. The quarter was defined by preparation and refinement:</p>
             <ul>
-              <li><strong>Fork crowdsourcer completed:</strong> Micah's crowdsourcer filled, enabling final preparation for crypto's first algorithmic fork and a rare, live demonstration of Augur's security model</li>
+              <li><strong>Crowdsourcer filled:</strong> Micah's crowdsourcer successfully raised enough REP to trigger a fork, setting the stage for crypto's first algorithmic fork and a rare, live demonstration of Augur's security model</li>
               <li><strong>Whitepaper in final review:</strong> After extensive external feedback from academics and researchers, we completed the <strong>Augur Lituus Whitepaper</strong>—a comprehensive design for a modular, cross-chain oracle infrastructure</li>
               <li><strong>Parallel development advances:</strong> Both development tracks (B2C consumer markets and B2B enterprise oracles) progressed toward a unified REP direction</li>
               <li><strong>Fork and migration tooling:</strong> Community-led development of tools to support fork participation and smooth REP migration across outcomes</li>
             </ul>
-            <p>The whitepaper marked the transition from research to development, establishing Augur Lituus as a shared resolution layer for prediction markets, DeFi protocols, and cross-chain systems. Meanwhile, preparation for the fork—one of the most significant on-chain events in Augur's history—advanced toward execution.</p>
+            <p>The whitepaper marked the transition from research to development, establishing Augur Lituus as a shared resolution layer for prediction markets, DeFi protocols, and cross-chain systems. Meanwhile, with the crowdsourcer filled, preparation for the fork—one of the most significant on-chain events in Augur's history—advanced toward execution.</p>
           </TimelineSection>
 
-          <TimelineSection title="Building the Future" date="Q4 2026" isLast>
-            <h3>Whitepaper Released</h3>
-            <p>The <strong>Augur Lituus Whitepaper</strong> is now <a href="https://github.com/AugurProject/whitepaper/blob/master/Lituus/English/Augur_Lituus_Whitepaper.pdf" target="_blank" rel="noopener noreferrer">publicly available</a>, presenting a modular oracle design and comparative analysis of oracle security.</p>
-            <br />
-            <p>More updates coming as we continue building toward a live system.</p>
+          <TimelineSection title="The Augur Lituus Whitepaper" date="January 29, 2026">
+            <h3>Q4: From Research to Development</h3>
+            <p>The <strong>Augur Lituus Whitepaper</strong> was officially <a href="https://github.com/AugurProject/whitepaper/blob/master/Lituus/English/Augur_Lituus_Whitepaper.pdf" target="_blank" rel="noopener noreferrer">released to the public</a>, presenting a modular oracle design and comparative analysis of oracle security. The paper formalizes Augur Lituus as a shared resolution layer for prediction markets, DeFi protocols, and cross-chain systems—marking the transition from research to active development.</p>
+          </TimelineSection>
+
+          <TimelineSection title="One Year In" date="April 2, 2026">
+            <h3>Q4: Rebuilding the Foundation</h3>
+            <p>Twelve months into the reboot, Augur is no longer dormant. Two development tracks are live, the whitepaper is out, a fork is imminent, and REP is liquid. Key progress:</p>
+            <ul>
+              <li><strong>Research & development:</strong> Continued parallel open-source development across both B2C and B2B tracks, released a 20-page academic whitepaper formalizing Augur Lituus, and reached final stages of contract review with an established team to build it</li>
+              <li><strong>Liquidity & token support:</strong> Maintained and expanded on-chain and CEX liquidity, built internal market making capabilities</li>
+              <li><strong>Ecosystem growth:</strong> Attended 8 conferences, participated in panels and interviews, re-established Augur's presence among builders</li>
+            </ul>
+            <p>Year one was about getting the design right. Year two is about execution.</p>
+          </TimelineSection>
+
+          <TimelineSection title="The Moon Fork Begins" date="April 8, 2026">
+            <h3>Crypto's First Algorithmic Fork</h3>
+            <p>On April 8, Augur entered its first live algorithmic fork — codenamed <strong>The Moon Fork</strong> after the market that triggered it, a dispute over whether NASA's Artemis II mission successfully lifted off (it did). The fork was intentionally triggered by community member <strong>Micah Zoltu</strong> as a planned test of Augur's core security mechanism under real conditions.</p>
+            <p>The escalation game is underway, with REP staked on competing outcomes over multiple rounds. A 2-month migration window will open in June where all REP holders must migrate their tokens 1:1 into the new universe. The fork demonstrates an oracle security model where dishonest positions lose capital and honest positions profit — truth enforced by economic incentives, not centralized actors.</p>
+          </TimelineSection>
+
+          <TimelineSection title="The Fork and Beyond" date="2026" isLast>
+            <h3>Execution Begins</h3>
+            <p>Full development of <strong>Augur Lituus</strong> begins this year, with continued focus on a unified REP infrastructure across both the B2C and B2B tracks.</p>
+            <p>The migration window for the Moon Fork opens in June. The Lituus Foundation is coordinating with exchanges to support migration on behalf of users, and migration tooling is available at <a href="https://6.augurfork.eth.limo/" target="_blank" rel="noopener noreferrer">6.augurfork.eth.limo</a>.</p>
+            <p>Future official Augur development, funded by the foundation, will continue on the fork corresponding with truth.</p>
           </TimelineSection>
         </div>
       </div>

--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -96,7 +96,7 @@ import { withBase } from "../lib/utils";
           </TimelineSection>
 
           <TimelineSection title="The Augur Lituus Whitepaper" date="January 29, 2026">
-            <h3>Q4: From Research to Development</h3>
+            <h3>From Research to Development</h3>
             <p>The <strong>Augur Lituus Whitepaper</strong> was officially <a href="https://github.com/AugurProject/whitepaper/blob/master/Lituus/English/Augur_Lituus_Whitepaper.pdf" target="_blank" rel="noopener noreferrer">released to the public</a>, presenting a modular oracle design and comparative analysis of oracle security. The paper formalizes Augur Lituus as a shared resolution layer for prediction markets, DeFi protocols, and cross-chain systems—marking the transition from research to active development.</p>
           </TimelineSection>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -493,6 +493,10 @@ html {
 		padding-left: 1.5rem;
 	}
 
+	& p + p {
+		margin-top: 1rem;
+	}
+
 	& li {
 		list-style: disc;
 		margin-bottom: 0.25rem;


### PR DESCRIPTION
## Summary
- Added whitepaper release, yearly update, and Moon Fork entries to the mission timeline
- Fixed "Augur's Decade" wording: clarified crowdsourcer vs fork completion
- Renamed final entry to "The Fork and Beyond" / "Execution Begins"
- Added `rehype-callouts` plugin and callout styling for 👉-prefixed paragraphs
- Added `p + p` spacing in timeline content

**Stacked on #90** (blog post PR)

## Test Plan
- [x] `astro build` passes
- [x] Visual review of mission page timeline