### PR TITLE
Fix: Point fork meter to Augur v2 and update fetch strategy

### DIFF
--- a/contracts/augur-abis.json
+++ b/contracts/augur-abis.json
@@ -1,6 +1,6 @@
 {
 	"universe": {
-		"address": "0xe991247b78f937d7b69cfc00f1a487a293557677",
+		"address": "0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA",
 		"abi": [
 			{
 				"constant": true,
@@ -73,7 +73,7 @@
 		]
 	},
 	"augur": {
-		"address": "0x75228dce4d82566d93068a8d5d49435216551599",
+		"address": "0x23916a8F5C3846e3100e5f587FF14F3098722F5d",
 		"abi": [
 			{
 				"constant": true,

--- a/docs/fork-risk-assessment.md
+++ b/docs/fork-risk-assessment.md
@@ -8,55 +8,44 @@ The Augur Fork Meter provides transparent monitoring of the risk that Augur's or
 
 Based on the Augur v2 whitepaper, forks are triggered when:
 
-1. **A dispute bond reaches ≥2.5% of all theoretical REP** (275,000 REP in the genesis universe; in post-fork universes, this threshold changes based on migratable REP from sibling universes)
+1. **A dispute bond reaches the fork threshold** — read live from `universe.getDisputeThresholdForFork()` (approximately 2.5% of REP supply in the v2 genesis universe: ~274,859 REP as of April 2026)
 2. **This creates a 60-day forking period** where REP holders must migrate to child universes
 3. **The universe with the most migrated REP becomes the "winning" universe**
 
 ## Risk Calculation Framework
 
-### Simplified Risk Assessment
+### Core Calculation
 
-The Augur Fork Meter uses a direct, transparent calculation based solely on dispute bond size relative to the fork threshold:
+The meter reads live on-chain state for each tracked market:
 
-#### Core Calculation
-- **Dispute Bond Monitoring**: Track the largest active dispute bond across all markets
-- **Fork Threshold**: 275,000 REP in the genesis universe (2.5% of theoretical REP supply; threshold varies in post-fork universes based on migratable REP from sibling universes)
-- **Risk Percentage**: Direct calculation of how close the largest dispute is to triggering a fork
+1. **Market Discovery**: `DisputeCrowdsourcerContribution` and `DisputeCrowdsourcerCompleted` events from the Augur v2 contract identify markets with active disputes
+2. **Bond Readout**: For each market, `market.participants(i).getSize()` gives the protocol-correct bond size for each dispute round — the target bond, which is what the fork threshold is measured against
+3. **Fork Threshold**: Read live from `universe.getDisputeThresholdForFork()`, not hardcoded
+4. **Risk Percentage**: `Risk % = (Largest Dispute Bond / Fork Threshold) × 100`
 
-**Primary Formula**: `Risk % = (Largest Dispute Bond / 275,000 REP) × 100`
+**Why `getSize()` over `getStake()`**: `getSize()` is the target bond for the round — the value Augur uses internally to determine if a fork triggers. `getStake()` is the amount currently accumulated, which may be partial. For public accuracy, the meter shows the authoritative protocol value.
 
-#### Supplementary Information
-- **Active Markets**: Number of markets currently in dispute
-- **Dispute Round Depth**: Current escalation level of active disputes
-- **Time Analysis**: Days remaining in dispute windows
+### Market Tracking Architecture
+
+Markets are tracked across three persistence layers:
+
+| Layer | Lifespan | Purpose |
+|---|---|---|
+| **Events** (in cache) | 7 days, pruned | Discover *new* disputes entering the system |
+| **Tracked markets** (in cache) | Indefinite until finalized | Remember *known* disputes across runs |
+| **Seed file** (git-committed) | Manual | Safety net for long-running disputes that predate the event window |
+
+**Discovery flow**:
+1. On initial run or cache miss: 30-day event scan discovers all markets with dispute activity
+2. Discovered markets are added to the tracked markets list (persisted in event cache)
+3. On each hourly run: incremental event scan finds any *new* markets
+4. All tracked markets are verified on-chain (`isFinalized()`, `getNumParticipants()`)
+5. Finalized or empty markets are removed from tracking
+6. Tracked markets are **never pruned** by the 7-day event window
+
+**Seed file** (`public/data/dispute-markets-seed.json`): A git-committed list of known long-running disputes. Provides a guaranteed baseline when the event cache is lost (GH Actions cache eviction). Updated via PR when significant new disputes are identified.
 
 ### Risk Level Determination
-
-The system assigns risk levels based directly on the fork threshold percentage:
-
-#### Risk Level Assignment
-```
-if risk_percentage == 0%:    RISK_LEVEL = NONE
-if risk_percentage < 10%:    RISK_LEVEL = LOW
-if risk_percentage < 25%:    RISK_LEVEL = MODERATE
-if risk_percentage < 75%:    RISK_LEVEL = HIGH
-if risk_percentage >= 75%:   RISK_LEVEL = CRITICAL
-```
-
-This direct mapping provides clear, understandable risk assessment without complex multi-factor adjustments.
-
-#### Threshold Rationale
-
-The thresholds have been calibrated to provide meaningful risk signals:
-
-- **Critical (≥75%)**: Fork is truly imminent - dispute bonds are close to the 275,000 REP trigger point
-- **High (25-75%)**: Substantial dispute activity that warrants attention but fork is not immediate
-- **Moderate (10-25%)**: Notable dispute activity above normal background levels
-- **Low (<10%)**: Normal operation with minimal dispute risk
-
-These thresholds replace previously conservative levels that would have triggered frequent false alarms during normal dispute resolution. The new levels focus attention on disputes that pose genuine systemic risk to the Augur oracle.
-
-### Risk Levels
 
 | Level | Fork Threshold % | Description | Color |
 |-------|------------------|-------------|--------|
@@ -64,120 +53,54 @@ These thresholds replace previously conservative levels that would have triggere
 | **Low** | <10% | Normal operation, typical dispute activity | Green |
 | **Moderate** | 10-25% | Elevated dispute activity above baseline | Yellow |
 | **High** | 25-75% | Large disputes requiring close monitoring | Orange |
-| **Critical** | ≥75% | Fork trigger imminent, dispute near 275K REP | Red (pulsing) |
+| **Critical** | ≥75% | Fork trigger imminent | Red (pulsing) |
 
 ## Data Sources and Architecture
 
 ### Blockchain Data Collection
 - **Ethereum Mainnet**: Primary data source via public JSON-RPC endpoints
-- **Augur v2 Contracts**: Verified contract addresses from official deployment
-  - Universe: `0xe991247b78f937d7b69cfc00f1a487a293557677`
-  - REPv2 Token: `0x221657776846890989a759ba2973e427dff5c9bb`
-  - Augur Main: `0x75228dce4d82566d93068a8d5d49435216551599`
+- **Augur v2 Contracts**:
+  - Universe (v2 genesis): `0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA`
+  - Augur (v2): `0x23916a8F5C3846e3100e5f587FF14F3098722F5d`
+  - REPv2 Token: `0x221657776846890989a759BA2973e427DfF5C9bB`
   - Cash (DAI): `0xd5524179cb7ae012f5b642c1d6d700bbaa76b96b`
-- **Event Monitoring**: DisputeCrowdsourcerCreated, DisputeCrowdsourcerContribution, DisputeCrowdsourcerCompleted events
 
 ### Infrastructure Design
-- **GitHub Actions**: Hourly automated calculations (sufficient for 7-day dispute windows)
+- **GitHub Actions**: Hourly automated calculations
+- **Event Cache**: Persisted via `actions/cache`, survives between runs. Contains:
+  - Raw events (7-day rolling window, pruned)
+  - Tracked markets list (never pruned, only removed when finalized on-chain)
+- **Seed File**: Git-committed `dispute-markets-seed.json` as cache-miss fallback
 - **Public RPC Endpoints**: No API keys required, fully transparent access
   - Primary: PublicNode (`https://ethereum-rpc.publicnode.com`)
   - Fallbacks: dRPC, 1RPC
   - Optional: `ETH_RPC_URL` env var prepended as primary when set
-- **Static JSON Storage**: Results saved to version-controlled JSON file
+- **Static JSON Output**: Results saved to `public/data/fork-risk.json`
 - **Audit Trail**: All calculations and changes tracked in git history
-- **No Private Infrastructure**: No databases, no API keys, fully auditable
 
 ### Update Frequency
 - **Calculation**: Every hour via GitHub Actions
 - **UI Refresh**: Every 5 minutes (data changes hourly)
-- **Manual Triggers**: Available for testing and immediate updates
-
-### RPC Failover Strategy
-The system attempts to connect to public RPC endpoints in order of preference:
-1. **`ETH_RPC_URL`** (when configured via environment/secret)
-2. **PublicNode** (`https://ethereum-rpc.publicnode.com`)
-3. **dRPC** (`https://eth.drpc.org`)
-4. **1RPC** (`https://1rpc.io/eth`)
-
-Each endpoint is tested with a `getBlockNumber()` call before use. If all endpoints fail, the system reports an error state rather than falling back to mock data. Connection latency and endpoint used are logged for transparency.
+- **Manual Triggers**: Available via `workflow_dispatch`
 
 ## Transparency and Auditability
 
-### Open Source Approach
-1. **Calculation Script**: All logic is open source and auditable
-2. **Git History**: Complete audit trail of all risk calculations
-3. **Public Data**: JSON results available for external verification
-4. **Methodology Documentation**: This document provides full transparency
-
-### Verification Process
 Anyone can verify calculations by:
 1. Reviewing the calculation script: `scripts/calculate-fork-risk.ts`
-2. Checking historical data in git commits
-3. Running calculations independently using the same inputs
-4. Comparing results with the published JSON data
+2. Running the diagnostic probe: `scripts/probe-fork-state.ts <marketAddress>`
+3. Checking the seed file: `public/data/dispute-markets-seed.json`
+4. Comparing on-chain state directly via `market.participants(i).getSize()`
 
 ## Limitations and Considerations
 
-### Current Implementation Status
-**✅ Fully Operational**: This version uses verified Augur v2 contract addresses and real blockchain data:
-
-1. **Dispute Monitoring**: Real-time parsing of `DisputeCrowdsourcerCreated`, `DisputeCrowdsourcerContribution`, and `DisputeCrowdsourcerCompleted` events from Augur contracts
-2. **Accurate Stake Tracking**: Uses actual contributed REP amounts from contribution events (not initial bond sizes)
-3. **Fork Threshold Calculation**: Direct comparison against the 275,000 REP threshold
-
 ### Known Limitations
-1. **Limited Augur Activity**: Augur v2 on mainnet has very low activity due to high gas fees
-2. **Historical Event Limits**: Only monitors events from the last 7 days (sufficient for dispute window timings)
+1. **Discovery blind spot**: A dispute that starts and stalls with zero contributions for 30+ days would be missed. However, meaningful disputes (high enough bond to register on the meter) escalate via bond-doubling rounds, guaranteeing regular contributions within 30 days.
+2. **Event cache volatility**: GH Actions cache can be evicted, causing a 30-day rescan on next run. The seed file mitigates this by providing a guaranteed baseline.
 
 ### Timing Considerations
 - **Dispute Windows**: up to 7 days each (first round: up to 24 hours), hourly monitoring is sufficient
 - **Fork Duration**: Up to 60 days, providing ample warning time
 - **Escalation Speed**: Multiple rounds required, attacks develop over days/weeks
-
-### Risk Factors Not Captured
-- **Coordination Attacks**: Difficult to detect until they occur
-- **External Governance**: Changes to Augur parameters
-- **Market Psychology**: REP holder behavior during stress
-
-## Technical Implementation
-
-### Contract Addresses (Mainnet)
-```json
-{
-  "universe": "0xe991247b78f937d7b69cfc00f1a487a293557677",
-  "augur": "0x75228dce4d82566d93068a8d5d49435216551599",
-  "repToken": "0x221657776846890989a759ba2973e427dff5c9bb",
-  "cash": "0xd5524179cb7ae012f5b642c1d6d700bbaa76b96b"
-}
-```
-
-### Key Events Monitored
-- `DisputeCrowdsourcerCreated`: New dispute bonds created (initialization)
-- `DisputeCrowdsourcerContribution`: REP contributions to existing disputes (PRIMARY for stake amounts)
-- `DisputeCrowdsourcerCompleted`: Dispute bonds filled and escalated
-- `UniverseForked`: Fork has been triggered
-
-### Calculation Schedule
-```yaml
-# GitHub Actions Schedule
-schedule:
-  - cron: '0 * * * *'  # Every hour on the hour
-workflow_dispatch:     # Manual trigger available
-```
-
-## Historical Context
-
-### Augur's Fork History
-- **Genesis Launch**: No forks have occurred in production to date
-- **Theoretical Framework**: Fork mechanism designed as "nuclear option"
-- **Economic Security**: Designed to make attacks prohibitively expensive
-
-### Risk Assessment Evolution
-This methodology may evolve based on:
-- Actual fork events (if they occur)
-- Community feedback and governance decisions  
-- New attack vectors discovered
-- Changes to Augur protocol parameters
 
 ## References
 
@@ -187,6 +110,6 @@ This methodology may evolve based on:
 
 ---
 
-**Last Updated**: March 20, 2026  
-**Version**: 1.0  
+**Last Updated**: April 21, 2026
+**Version**: 2.0
 **Maintained By**: Augur Fork Meter Project

--- a/public/data/dispute-markets-seed.json
+++ b/public/data/dispute-markets-seed.json
@@ -1,0 +1,20 @@
+[
+	{
+		"marketId": "0x963eed85778cc23e2d4636cd4f29eecdf9827e9e",
+		"discoveredAtBlock": 24834534,
+		"lastVerifiedBlock": 0,
+		"source": "seed"
+	},
+	{
+		"marketId": "0x797a858e5264f53c312918bcee99ed59db835c77",
+		"discoveredAtBlock": 24834604,
+		"lastVerifiedBlock": 0,
+		"source": "seed"
+	},
+	{
+		"marketId": "0x190b6aceaf477deb64a6609bfa0ee24acb45a8f2",
+		"discoveredAtBlock": 24834614,
+		"lastVerifiedBlock": 0,
+		"source": "seed"
+	}
+]

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -71,11 +71,19 @@ interface SerializedEventLog {
 	eventType: 'created' | 'contribution' | 'completed'
 }
 
+interface TrackedMarket {
+	marketId: string
+	discoveredAtBlock: number
+	lastVerifiedBlock: number
+	source: 'event' | 'seed'
+}
+
 interface EventCache {
 	version: string
 	lastQueriedBlock: number
 	lastQueriedTimestamp: string
 	oldestEventBlock: number
+	trackedMarkets: TrackedMarket[]
 	events: {
 		created: SerializedEventLog[]
 		contributions: SerializedEventLog[]
@@ -394,6 +402,7 @@ function createEmptyCache(): EventCache {
 		lastQueriedBlock: 0,
 		lastQueriedTimestamp: new Date().toISOString(),
 		oldestEventBlock: 0,
+		trackedMarkets: [],
 		events: {
 			created: [],
 			contributions: [],
@@ -450,6 +459,12 @@ function validateCache(cache: EventCache): boolean {
 		return false
 	}
 
+	// Migrate caches missing trackedMarkets
+	if (!cache.trackedMarkets) {
+		cache.trackedMarkets = []
+		console.log('Migrated cache: added empty trackedMarkets')
+	}
+
 	// Check block number sanity
 	if (cache.lastQueriedBlock < 0 || cache.lastQueriedBlock > 999999999) {
 		console.warn('Cache has invalid block number')
@@ -477,18 +492,33 @@ function serializeEvent(
 	event: ethers.EventLog,
 	eventType: 'created' | 'contribution' | 'completed'
 ): SerializedEventLog {
+	// Args layout differs per event type:
+	//   Created:     universe(args[0]), market(args[1]), crowdsourcer(args[2])
+	//   Contribution: universe(args[0]), reporter(args[1]), market(args[2]), crowdsourcer(args[3])
+	//   Completed:   universe(args[0]), market(args[1]), crowdsourcer(args[2])
+	let marketAddr = ''
+	let crowdAddr = ''
+	if (eventType === 'contribution') {
+		marketAddr = event.args?.[2] || ''
+		crowdAddr = event.args?.[3] || ''
+	} else {
+		marketAddr = event.args?.[1] || ''
+		crowdAddr = event.args?.[2] || ''
+	}
 	return {
 		blockNumber: event.blockNumber,
 		transactionHash: event.transactionHash,
-		disputeCrowdsourcerAddress: event.args?.[2] || '',
-		marketAddress: event.args?.[1] || '',
+		disputeCrowdsourcerAddress: crowdAddr,
+		marketAddress: marketAddr,
 		args: event.args ? event.args.map(arg => String(arg)) : [],
 		eventType
 	}
 }
 
 /**
- * Prune events older than 7 days from cache
+ * Prune events older than 7 days from cache.
+ * Tracked markets are NEVER pruned — they persist until on-chain verification
+ * confirms the market is finalized.
  */
 function pruneOldEvents(cache: EventCache, currentBlock: number): EventCache {
 	const blocksPerDay = 7200
@@ -497,6 +527,7 @@ function pruneOldEvents(cache: EventCache, currentBlock: number): EventCache {
 
 	const prunedCache: EventCache = {
 		...cache,
+		trackedMarkets: cache.trackedMarkets, // never prune
 		events: {
 			created: cache.events.created.filter(e => e.blockNumber >= cutoffBlock),
 			contributions: cache.events.contributions.filter(e => e.blockNumber >= cutoffBlock),
@@ -517,6 +548,67 @@ function pruneOldEvents(cache: EventCache, currentBlock: number): EventCache {
 	return prunedCache
 }
 
+
+/**
+ * Load dispute-markets-seed.json from the repo.
+ * This is a git-committed safety net of known long-running disputes
+ * that survive total cache loss.
+ */
+async function loadSeedMarkets(): Promise<TrackedMarket[]> {
+	const seedPath = path.join(__dirname, '../public/data/dispute-markets-seed.json')
+	try {
+		const data = await fs.readFile(seedPath, 'utf8')
+		const markets: TrackedMarket[] = JSON.parse(data)
+		if (Array.isArray(markets) && markets.length > 0) {
+			console.log(`🌱 Loaded ${markets.length} seed markets from repo`)
+			return markets
+		}
+	} catch {
+		// No seed file — that's fine, events + cache handle discovery
+	}
+	return []
+}
+
+/**
+ * Extract market address from a serialized event, handling the
+ * different args layouts per event type.
+ */
+function extractMarketFromSerializedEvent(event: SerializedEventLog): string | null {
+	try {
+		if (event.eventType === 'contribution') {
+			const marketAddr = event.args?.[2]
+			if (marketAddr) return String(marketAddr).toLowerCase()
+		} else {
+			const marketAddr = event.args?.[1]
+			if (marketAddr) return String(marketAddr).toLowerCase()
+		}
+	} catch {
+		// skip
+	}
+	return null
+}
+
+/**
+ * Extract market address from a live EventLog.
+ * Contribution: market is args[2]
+ * Created/Completed: market is args[1]
+ */
+function extractMarketFromEventLog(event: ethers.EventLog, eventType: 'created' | 'contribution' | 'completed'): string | null {
+	try {
+		if (!event.args || !Array.isArray(event.args)) return null
+		if (eventType === 'contribution') {
+			const addr = event.args[2]
+			if (addr) return String(addr).toLowerCase()
+		} else {
+			const addr = event.args[1]
+			if (addr) return String(addr).toLowerCase()
+		}
+	} catch {
+		// skip
+	}
+	return null
+}
+
 async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Record<string, ethers.Contract>, mode: string = 'incremental'): Promise<DisputeDetails[]> {
 	try {
 		console.log('Querying dispute events for accurate stake calculation...')
@@ -527,28 +619,28 @@ async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Re
 		// Query events in smaller chunks due to RPC block limit (1000 blocks max)
 		const currentBlock = await provider.getBlockNumber()
 		const blocksPerDay = 7200 // Approximate blocks per day (12 second blocks)
-		const searchPeriod = 7 * blocksPerDay // Last 7 days (~50,400 blocks)
-		const fullSearchStartBlock = currentBlock - searchPeriod
+		const discoveryPeriod = 30 * blocksPerDay // 30-day initial scan for market discovery
+		const incrementalPeriod = 7 * blocksPerDay // 7-day for incremental event queries
+		const fullSearchStartBlock = currentBlock - discoveryPeriod
 
 		// Determine query range based on mode and cache
 		let fromBlock: number
 		let newEventsOnly = false
 
 		if (mode === 'full-rebuild' || !cache.lastQueriedBlock || cache.lastQueriedBlock === 0) {
-			// Full 7-day rescan
-			fromBlock = Math.max(currentBlock - searchPeriod, 0)
-			console.log(`[Query] Full 7-day rescan: blocks ${fromBlock} to ${currentBlock}`)
+			// Full 30-day rescan for market discovery
+			fromBlock = Math.max(currentBlock - discoveryPeriod, 0)
+			console.log(`[Query] Full 30-day rescan: blocks ${fromBlock} to ${currentBlock}`)
 		} else {
 			// Incremental: only new blocks since last query
 			fromBlock = Math.max(cache.lastQueriedBlock - FINALITY_DEPTH, 0)
 			newEventsOnly = true
 			const blocksToQuery = currentBlock - fromBlock
 			console.log(`[Query] Incremental: blocks ${fromBlock} to ${currentBlock} (~${blocksToQuery} blocks)`)
-			console.log(`💾 Cache contains ${cache.metadata.totalEventsTracked} events`)
+			console.log(`💾 Cache contains ${cache.metadata.totalEventsTracked} events, ${cache.trackedMarkets.length} tracked markets`)
 		}
 
 		// Initialize event arrays
-		// For incremental queries, start with cached events
 		const allCreatedEvents: ethers.EventLog[] = []
 		const allContributionEvents: ethers.EventLog[] = []
 		const allCompletedEvents: ethers.EventLog[] = []
@@ -600,7 +692,6 @@ async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Re
 				// Detect rate limiting
 				if (isRateLimitError(chunkError)) {
 					console.warn(`⚠️ Rate limit detected on blocks ${start}-${end}, backing off...`)
-					// Exponential backoff for rate limits (2s, 4s, 8s)
 					const backoffDelay = Math.min(2 ** consecutiveFailures * 1000, 10000)
 					console.log(`Waiting ${backoffDelay}ms before continuing...`)
 					await new Promise(resolve => setTimeout(resolve, backoffDelay))
@@ -618,17 +709,14 @@ async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Re
 		}
 
 		console.log(`Chunk query complete: ${successfulChunks}/${totalChunks} successful`)
-
 		console.log(`New events found: ${newEventsFound} (${allCreatedEvents.length} created, ${allContributionEvents.length} contributions, ${allCompletedEvents.length} completed)`)
 
 		// Merge with cached events if this was an incremental query
 		if (newEventsOnly && cache.lastQueriedBlock > 0) {
-			// Load cached events (but filter out events from the re-queried finality window to avoid duplicates)
 			const finalityStartBlock = cache.lastQueriedBlock - FINALITY_DEPTH
 
 			for (const cachedEvent of cache.events.created) {
 				if (cachedEvent.blockNumber < finalityStartBlock) {
-					// Reconstruct minimal EventLog for processing
 					const reconstructed = {
 						blockNumber: cachedEvent.blockNumber,
 						transactionHash: cachedEvent.transactionHash,
@@ -669,6 +757,7 @@ async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Re
 			lastQueriedBlock: currentBlock,
 			lastQueriedTimestamp: new Date().toISOString(),
 			oldestEventBlock: fullSearchStartBlock,
+			trackedMarkets: cache.trackedMarkets || [], // preserve tracked markets
 			events: {
 				created: allCreatedEvents.map(e => serializeEvent(e, 'created')),
 				contributions: allContributionEvents.map(e => serializeEvent(e, 'contribution')),
@@ -681,145 +770,183 @@ async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Re
 			}
 		}
 
-		// Prune old events (older than 7 days)
+		// Prune old events (older than 7 days) — trackedMarkets preserved by pruneOldEvents
 		const prunedCache = pruneOldEvents(updatedCache, currentBlock)
+
+		// === MARKET DISCOVERY ===
+		// Three sources: seed file, cached tracked markets, and fresh events.
+
+		// 1. Load seed markets (git-committed safety net)
+		const seedMarkets = await loadSeedMarkets()
+
+		// 2. Merge all sources into a single tracked markets map
+		const trackedMap = new Map<string, TrackedMarket>()
+
+		// Add seed markets
+		for (const sm of seedMarkets) {
+			trackedMap.set(sm.marketId.toLowerCase(), sm)
+		}
+
+		// Add cached tracked markets (may override seed with newer lastVerifiedBlock)
+		for (const tm of prunedCache.trackedMarkets) {
+			const key = tm.marketId.toLowerCase()
+			const existing = trackedMap.get(key)
+			if (!existing || tm.lastVerifiedBlock > existing.lastVerifiedBlock) {
+				trackedMap.set(key, tm)
+			}
+		}
+
+		// 3. Discover markets from events (fresh + previously cached)
+		const eventMarketIds = new Set<string>()
+		for (const event of allCreatedEvents) {
+			const m = extractMarketFromEventLog(event, 'created')
+			if (m) eventMarketIds.add(m)
+		}
+		for (const event of allContributionEvents) {
+			const m = extractMarketFromEventLog(event, 'contribution')
+			if (m) eventMarketIds.add(m)
+		}
+		for (const event of allCompletedEvents) {
+			const m = extractMarketFromEventLog(event, 'completed')
+			if (m) eventMarketIds.add(m)
+		}
+		// Also extract from cached serialized events (may have been pruned
+		// but their markets should still be tracked)
+		for (const event of cache.events.contributions) {
+			const m = extractMarketFromSerializedEvent(event)
+			if (m) eventMarketIds.add(m)
+		}
+		for (const event of cache.events.completed) {
+			const m = extractMarketFromSerializedEvent(event)
+			if (m) eventMarketIds.add(m)
+		}
+		for (const event of cache.events.created) {
+			const m = extractMarketFromSerializedEvent(event)
+			if (m) eventMarketIds.add(m)
+		}
+
+		// Add event-discovered markets to tracking
+		for (const marketId of eventMarketIds) {
+			if (!trackedMap.has(marketId)) {
+				trackedMap.set(marketId, {
+					marketId,
+					discoveredAtBlock: currentBlock,
+					lastVerifiedBlock: 0,
+					source: 'event'
+				})
+			}
+		}
+
+		console.log(`Market discovery: ${seedMarkets.length} seed + ${prunedCache.trackedMarkets.length} cached + ${eventMarketIds.size} from events → ${trackedMap.size} unique markets`)
+
+		// === ON-CHAIN VERIFICATION & BOND READOUT ===
+		const disputes: DisputeDetails[] = []
+		const marketAbi = [
+			'function getNumParticipants() view returns (uint256)',
+			'function participants(uint256) view returns (address)',
+			'function isFinalized() view returns (bool)',
+		]
+		const participantAbi = [
+			'function getSize() view returns (uint256)',
+		]
+
+		const verifiedMarkets: TrackedMarket[] = []
+
+		for (const [marketId, tracked] of trackedMap) {
+			try {
+				const market = new ethers.Contract(marketId, marketAbi, provider)
+
+				// Check if market is finalized
+				let isFinalized = false
+				try {
+					isFinalized = await market.isFinalized()
+				} catch (_err) {
+					// Assume active if we can't check
+				}
+
+				if (isFinalized) {
+					console.log(`  ✗ ${marketId.slice(0, 10)}... finalized — removed from tracking`)
+					continue
+				}
+
+				const numParticipants = Number(await market.getNumParticipants())
+				if (numParticipants === 0) {
+					console.log(`  ✗ ${marketId.slice(0, 10)}... no participants — removed from tracking`)
+					continue
+				}
+
+				// Read participants from highest index down.
+				// The highest non-zero getSize() is the current/latest dispute round.
+				let largestSize = 0
+				let latestRound = 0
+
+				for (let i = numParticipants - 1; i >= 0; i--) {
+					try {
+						const participantAddr = await market.participants(i)
+						if (!participantAddr || participantAddr === ethers.ZeroAddress) continue
+
+						const participant = new ethers.Contract(participantAddr, participantAbi, provider)
+						const sizeWei = await participant.getSize()
+						const sizeRep = Number(ethers.formatEther(sizeWei))
+
+						if (sizeRep > largestSize) {
+							largestSize = sizeRep
+							latestRound = i
+						}
+					} catch (_err) {
+						// Participant read failed, skip
+					}
+				}
+
+				// Keep tracking this market (verified alive)
+				verifiedMarkets.push({
+					...tracked,
+					lastVerifiedBlock: currentBlock
+				})
+
+				if (largestSize > 0) {
+					disputes.push({
+						marketId,
+						title: `Market ${marketId.substring(0, 10)}...`,
+						disputeBondSize: largestSize,
+						disputeRound: latestRound,
+						daysRemaining: 7,
+					})
+					console.log(`  ✓ ${marketId.slice(0, 10)}... bond=${largestSize.toLocaleString()} REP round=${latestRound}`)
+				}
+			} catch (error) {
+				// Market read failed — keep tracking but don't add to disputes
+				verifiedMarkets.push({
+					...tracked,
+					lastVerifiedBlock: currentBlock
+				})
+				console.warn(`  ⚠ ${marketId.slice(0, 10)}... read error:`, error instanceof Error ? error.message.slice(0, 60) : String(error).slice(0, 60))
+			}
+		}
+
+		// Save verified markets back to cache
+		prunedCache.trackedMarkets = verifiedMarkets
+		console.log(`Tracked markets: ${verifiedMarkets.length} verified alive, ${trackedMap.size - verifiedMarkets.length} pruned (finalized/empty)`)
 
 		// Save cache for next run
 		await saveEventCache(prunedCache)
 
 		// Log cache efficiency metrics
 		if (newEventsOnly) {
-			const blocksQueried = currentBlock - fromBlock
-			const fullQueryBlocks = searchPeriod
-			const queriesSaved = Math.floor(fullQueryBlocks / 1000) - Math.floor(blocksQueried / 1000)
-			console.log(`💰 RPC queries saved: ~${queriesSaved} queries (queried ${blocksQueried} blocks instead of ${fullQueryBlocks})`)
+			const incrementalBlocks = currentBlock - fromBlock
+			const fullQueryBlocks = incrementalPeriod
+			const queriesSaved = Math.floor(fullQueryBlocks / 1000) - Math.floor(incrementalBlocks / 1000)
+			console.log(`💰 RPC queries saved: ~${queriesSaved} queries (queried ${incrementalBlocks} blocks instead of ${fullQueryBlocks})`)
 		}
 
 		console.log(`Total events after pruning: ${prunedCache.metadata.totalEventsTracked}`)
-
-		// Create a map to track dispute crowdsourcer states
-		const disputeStates = new Map<string, {
-			marketId: string,
-			currentStake: number,
-			disputeRound: number,
-			isCompleted: boolean,
-			lastContributionTimestamp: number
-		}>()
-
-		// First, process Created events to initialize disputes
-		for (const event of allCreatedEvents) {
-			try {
-				if (!event.args || !Array.isArray(event.args) || event.args.length < 6) continue
-
-				const [_universe, marketAddress, disputeCrowdsourcerAddress, _payoutNumerators, initialSizeWei, _isInvalid] = event.args
-				const initialSizeRep = Number(ethers.formatEther(initialSizeWei))
-
-				disputeStates.set(disputeCrowdsourcerAddress, {
-					marketId: marketAddress,
-					currentStake: initialSizeRep, // Will be updated by contribution events
-					disputeRound: 1, // Will be updated by contribution events
-					isCompleted: false,
-					lastContributionTimestamp: 0
-				})
-			} catch (error) {
-				console.warn('Error processing created event:', error instanceof Error ? error.message : String(error))
-			}
-		}
-
-		// Second, process Contribution events to get ACTUAL stake amounts
-		for (const event of allContributionEvents) {
-			try {
-				if (!event.args || !Array.isArray(event.args) || event.args.length < 11) continue
-
-				const [
-					_universe, _reporter, marketAddress, disputeCrowdsourcerAddress,
-					_amountStaked, _description, _payoutNumerators,
-					currentStakeWei, _stakeRemaining, disputeRound, timestamp
-				] = event.args
-
-				const currentStakeRep = Number(ethers.formatEther(currentStakeWei))
-				const disputeRoundNum = Number(disputeRound)
-				const timestampNum = Number(timestamp)
-
-				// Update or create dispute state with actual stake
-				const existing = disputeStates.get(disputeCrowdsourcerAddress)
-				if (existing) {
-					// Update with latest contribution data
-					existing.currentStake = currentStakeRep
-					existing.disputeRound = disputeRoundNum
-					existing.lastContributionTimestamp = Math.max(existing.lastContributionTimestamp, timestampNum)
-				} else {
-					// Create new entry if we missed the Created event
-					disputeStates.set(disputeCrowdsourcerAddress, {
-						marketId: marketAddress,
-						currentStake: currentStakeRep,
-						disputeRound: disputeRoundNum,
-						isCompleted: false,
-						lastContributionTimestamp: timestampNum
-					})
-				}
-			} catch (error) {
-				console.warn('Error processing contribution event:', error instanceof Error ? error.message : String(error))
-			}
-		}
-
-		// Third, mark completed disputes
-		for (const event of allCompletedEvents) {
-			try {
-				if (!event.args || !Array.isArray(event.args) || event.args.length < 11) continue
-
-				const [_universe, _marketAddress, disputeCrowdsourcerAddress] = event.args
-				const existing = disputeStates.get(disputeCrowdsourcerAddress)
-				if (existing) {
-					existing.isCompleted = true
-				}
-			} catch (error) {
-				console.warn('Error processing completed event:', error instanceof Error ? error.message : String(error))
-			}
-		}
-
-		// Convert to DisputeDetails array, filtering out completed disputes
-		const disputes: DisputeDetails[] = []
-		for (const [_disputeCrowdsourcerAddress, state] of disputeStates.entries()) {
-			// Only include active (non-completed) disputes
-			if (state.isCompleted) continue
-
-			// Check if market is finalized (skip finalized markets)
-			try {
-				const marketContract = new ethers.Contract(
-					state.marketId,
-					[{
-						constant: true,
-						inputs: [],
-						name: 'isFinalized',
-						outputs: [{ name: '', type: 'bool' }],
-						type: 'function',
-					}],
-					provider,
-				)
-
-				const isFinalized = await marketContract.isFinalized()
-				if (isFinalized) continue
-			} catch (_marketError) {
-				// If we can't check finalization, assume it's active
-			}
-
-			// Create dispute details with ACTUAL stake from contribution events
-			disputes.push({
-				marketId: state.marketId,
-				title: `Market ${state.marketId.substring(0, 10)}...`,
-				disputeBondSize: state.currentStake, // This is the REAL stake amount!
-				disputeRound: state.disputeRound,
-				daysRemaining: 7, // Estimate based on dispute window
-			})
-		}
 
 		// Sort by bond size (largest first) and return top 10
 		const sortedDisputes = disputes.sort(
 			(a, b) => b.disputeBondSize - a.disputeBondSize,
 		)
 
-		console.log(`Processed ${sortedDisputes.length} active disputes from ${disputeStates.size} total dispute crowdsourcers`)
+		console.log(`Processed ${sortedDisputes.length} active markets with disputes`)
 		if (sortedDisputes.length > 0) {
 			console.log(`Largest dispute bond: ${sortedDisputes[0].disputeBondSize.toLocaleString()} REP`)
 		}
@@ -833,7 +960,6 @@ async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Re
 		return []
 	}
 }
-
 function getLargestDisputeBond(disputes: DisputeDetails[]): number {
 	if (disputes.length === 0) return 0
 	return Math.max(...disputes.map((d) => d.disputeBondSize))

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -94,7 +94,6 @@ interface CacheValidationResult {
 }
 
 // Configuration
-const FORK_THRESHOLD_REP = 275000 // 2.5% of 11 million REP
 const CACHE_VERSION = '1.0.0'
 const FINALITY_DEPTH = 32 // Ethereum finality depth (~6.4 minutes)
 const VALIDATION_DEPTH = 8 // blocks (detects corruption within ~2 minutes)
@@ -252,6 +251,20 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 			// Get current blockchain state
 			const blockNumber = await connection.provider.getBlockNumber()
 			console.log(`Block Number: ${blockNumber}`)
+
+			// Read fork threshold from chain (varies per universe)
+			let forkThresholdRep = 275000 // fallback constant
+			try {
+				const thresholdWei = await retryContractCall(
+					() => contracts.universe.getDisputeThresholdForFork(),
+					'universe.getDisputeThresholdForFork()'
+				)
+				forkThresholdRep = Number(ethers.formatEther(thresholdWei))
+				console.log(`Fork Threshold: ${forkThresholdRep} REP (from chain)`)
+			} catch (e) {
+				console.warn(`⚠️ Failed to read fork threshold from chain, using fallback: ${forkThresholdRep} REP`)
+			}
+
 			// Check if universe is already forking with retry logic
 			let isForking = false
 			try {
@@ -266,7 +279,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 
 			if (isForking) {
 				console.log('⚠️ UNIVERSE IS FORKING! Setting maximum risk level')
-				return getForkingResult(blockNumber, connection)
+				return getForkingResult(blockNumber, connection, forkThresholdRep)
 			}
 
 			// Calculate key metrics
@@ -284,7 +297,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 
 			// Calculate risk level
 			const forkThresholdPercent =
-				(largestDisputeBond / FORK_THRESHOLD_REP) * 100
+				(largestDisputeBond / forkThresholdRep) * 100
 			const riskLevel = determineRiskLevel(forkThresholdPercent)
 			const riskPercentage = forkThresholdPercent
 
@@ -306,7 +319,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 				fallbacksAttempted: connection.fallbacksAttempted,
 			},
 			calculation: {
-				forkThreshold: FORK_THRESHOLD_REP,
+				forkThreshold: forkThresholdRep,
 			},
 			cacheValidation,
 			}
@@ -836,21 +849,21 @@ function determineRiskLevel(forkThresholdPercent: number): RiskLevel {
 	return 'low'
 }
 
-function getForkingResult(blockNumber: number, connection: RpcConnection): ForkRiskData {
+function getForkingResult(blockNumber: number, connection: RpcConnection, forkThresholdRep: number): ForkRiskData {
 		return {
 			lastRiskChange: new Date().toISOString(),
 			blockNumber,
 			riskLevel: 'critical',
 			riskPercentage: 100,
 			metrics: {
-				largestDisputeBond: FORK_THRESHOLD_REP, // Fork threshold was reached
+				largestDisputeBond: forkThresholdRep, // Fork threshold was reached
 				forkThresholdPercent: 100,
 				activeDisputes: 0,
 				disputeDetails: [
 					{
 						marketId: 'FORKING',
 						title: 'Universe is currently forking',
-						disputeBondSize: FORK_THRESHOLD_REP,
+						disputeBondSize: forkThresholdRep,
 						disputeRound: 99,
 						daysRemaining: 0,
 					},
@@ -862,7 +875,7 @@ function getForkingResult(blockNumber: number, connection: RpcConnection): ForkR
 				fallbacksAttempted: connection.fallbacksAttempted,
 			},
 			calculation: {
-				forkThreshold: FORK_THRESHOLD_REP,
+				forkThreshold: forkThresholdRep,
 			},
 			cacheValidation: { isHealthy: true },
 		}
@@ -886,7 +899,7 @@ function getErrorResult(errorMessage: string): ForkRiskData {
 				fallbacksAttempted: 0,
 			},
 			calculation: {
-					forkThreshold: FORK_THRESHOLD_REP,
+					forkThreshold: 275000, // fallback threshold
 			},
 		cacheValidation: { isHealthy: false, discrepancy: errorMessage },
 		}

--- a/scripts/probe-fork-state.ts
+++ b/scripts/probe-fork-state.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Probe real on-chain Augur state beyond what calculate-fork-risk.ts sees today.
+ *
+ * - Walks the universe chain from genesis to the current active leaf.
+ * - For each universe reports: isForking, forkingMarket, threshold, REP token.
+ * - For a provided market, enumerates every dispute participant (crowdsourcer)
+ *   and reads live stake/size directly from the crowdsourcer contract.
+ *
+ * Ad-hoc / read-only. No cache writes, no JSON outputs.
+ *
+ * Usage:
+ *   bun scripts/probe-fork-state.ts [marketAddress ...]
+ * Default market: 0x963eed85778cc23e2d4636cd4f29eecdf9827e9e (Artemis II, per blog).
+ */
+
+import { ethers } from 'ethers'
+
+const GENESIS_UNIVERSE = '0xe991247b78f937d7b69cfc00f1a487a293557677'
+const DEFAULT_MARKETS = ['0x963eed85778cc23e2d4636cd4f29eecdf9827e9e']
+
+const RPCS = [
+	process.env.ETH_RPC_URL,
+	'https://ethereum-rpc.publicnode.com',
+	'https://eth.drpc.org',
+	'https://1rpc.io/eth',
+].filter((x): x is string => !!x)
+
+const UNIVERSE_ABI = [
+	'function isForking() view returns (bool)',
+	'function getForkingMarket() view returns (address)',
+	'function getForkEndTime() view returns (uint256)',
+	'function getParentUniverse() view returns (address)',
+	'function getWinningChildUniverse() view returns (address)',
+	'function getDisputeThresholdForFork() view returns (uint256)',
+	'function getForkReputationGoal() view returns (uint256)',
+	'function getReputationToken() view returns (address)',
+	'function getChildUniverse(bytes32 parentPayoutDistributionHash) view returns (address)',
+]
+
+const MARKET_ABI = [
+	'function getUniverse() view returns (address)',
+	'function getNumParticipants() view returns (uint256)',
+	'function participants(uint256 index) view returns (address)',
+	'function getInitialReporter() view returns (address)',
+	'function getWinningReportingParticipant() view returns (address)',
+	'function isFinalized() view returns (bool)',
+	'function getEndTime() view returns (uint256)',
+	'function getNumberOfOutcomes() view returns (uint256)',
+]
+
+const PARTICIPANT_ABI = [
+	'function getStake() view returns (uint256)',
+	'function getSize() view returns (uint256)',
+	'function getPayoutDistributionHash() view returns (bytes32)',
+	'function getPayoutNumerator(uint256 index) view returns (uint256)',
+]
+
+async function connect(): Promise<ethers.JsonRpcProvider> {
+	for (const rpc of RPCS) {
+		try {
+			const p = new ethers.JsonRpcProvider(rpc, 'mainnet')
+			await p.getBlockNumber()
+			console.log(`✓ RPC: ${rpc}`)
+			return p
+		} catch (e) {
+			console.log(`✗ ${rpc}: ${(e as Error).message.slice(0, 80)}`)
+		}
+	}
+	throw new Error('All RPCs failed')
+}
+
+async function safeCall<T>(label: string, fn: () => Promise<T>): Promise<T | null> {
+	try {
+		return await fn()
+	} catch (e) {
+		console.log(`    ${label}: reverted (${(e as Error).message.slice(0, 60)})`)
+		return null
+	}
+}
+
+async function describeUniverse(provider: ethers.JsonRpcProvider, address: string, depth = 0) {
+	const prefix = '  '.repeat(depth)
+	const u = new ethers.Contract(address, UNIVERSE_ABI, provider)
+	console.log(`\n${prefix}▶ Universe ${address}`)
+
+	const parent = await safeCall('parent', () => u.getParentUniverse())
+	const isForking = await safeCall('isForking', () => u.isForking())
+	const forkingMarket = await safeCall('forkingMarket', () => u.getForkingMarket())
+	const forkEnd = await safeCall('forkEndTime', () => u.getForkEndTime())
+	const threshold = await safeCall('threshold', () => u.getDisputeThresholdForFork())
+	const repToken = await safeCall('repToken', () => u.getReputationToken())
+
+	console.log(`${prefix}  parent:        ${parent ?? '?'}`)
+	console.log(`${prefix}  isForking:     ${isForking}`)
+	console.log(`${prefix}  forkingMarket: ${forkingMarket}`)
+	if (forkEnd !== null && Number(forkEnd) > 0) {
+		console.log(`${prefix}  forkEndTime:   ${new Date(Number(forkEnd) * 1000).toISOString()}`)
+	}
+	if (threshold !== null) {
+		console.log(`${prefix}  threshold:     ${ethers.formatEther(threshold)} REP`)
+	}
+	console.log(`${prefix}  repToken:      ${repToken ?? '?'}`)
+
+	// Try to follow to a winning child (only meaningful post-fork)
+	const winner = await safeCall('winningChild', () => u.getWinningChildUniverse())
+	if (winner && winner !== ethers.ZeroAddress) {
+		console.log(`${prefix}  → winningChildUniverse: ${winner}`)
+		await describeUniverse(provider, winner, depth + 1)
+	}
+	return { address, isForking, forkingMarket, threshold, winner }
+}
+
+async function describeMarket(provider: ethers.JsonRpcProvider, marketAddress: string) {
+	console.log(`\n━━━ Market ${marketAddress} ━━━`)
+	const m = new ethers.Contract(marketAddress, MARKET_ABI, provider)
+
+	const code = await provider.getCode(marketAddress)
+	if (code === '0x') {
+		console.log('  (no contract deployed at this address)')
+		return
+	}
+
+	const universe = await safeCall('universe', () => m.getUniverse())
+	const numParticipants = await safeCall('numParticipants', () => m.getNumParticipants())
+	const numOutcomes = await safeCall('numOutcomes', () => m.getNumberOfOutcomes())
+	const isFinalized = await safeCall('isFinalized', () => m.isFinalized())
+	const endTime = await safeCall('endTime', () => m.getEndTime())
+	const winning = await safeCall('winningParticipant', () => m.getWinningReportingParticipant())
+
+	console.log(`  universe:          ${universe}`)
+	console.log(`  numOutcomes:       ${numOutcomes}`)
+	console.log(`  numParticipants:   ${numParticipants}`)
+	console.log(`  isFinalized:       ${isFinalized}`)
+	if (endTime !== null) {
+		console.log(`  endTime:           ${new Date(Number(endTime) * 1000).toISOString()}`)
+	}
+	console.log(`  winningParticipant:${winning ?? 'n/a'}`)
+
+	if (universe) {
+		await describeUniverse(provider, universe, 1)
+	}
+
+	if (numParticipants === null) return
+	const n = Number(numParticipants)
+	console.log(`\n  Dispute participants (${n}):`)
+	let largestStake = 0n
+	for (let i = 0; i < n; i++) {
+		const pAddr = await safeCall(`participants(${i})`, () => m.participants(i))
+		if (!pAddr) continue
+		const c = new ethers.Contract(pAddr, PARTICIPANT_ABI, provider)
+		const stake = (await safeCall('getStake', () => c.getStake())) ?? 0n
+		const size = (await safeCall('getSize', () => c.getSize())) ?? 0n
+		const hash = await safeCall('payoutHash', () => c.getPayoutDistributionHash())
+		const nOut = numOutcomes !== null ? Number(numOutcomes) : 0
+		const numerators: string[] = []
+		for (let k = 0; k < nOut; k++) {
+			const v = await safeCall(`num[${k}]`, () => c.getPayoutNumerator(k))
+			numerators.push(v === null ? '?' : String(v))
+		}
+		const stakeRep = Number(ethers.formatEther(stake))
+		if (stake > largestStake) largestStake = stake
+		console.log(
+			`    [${i}] ${pAddr}  stake=${stakeRep.toLocaleString()} REP  size=${Number(
+				ethers.formatEther(size),
+			).toLocaleString()}  payout=[${numerators.join(',')}]  hash=${String(hash).slice(0, 12)}…`,
+		)
+	}
+	console.log(`\n  ▶ largest participant stake: ${Number(ethers.formatEther(largestStake)).toLocaleString()} REP`)
+}
+
+async function main() {
+	const markets = process.argv.slice(2).length ? process.argv.slice(2) : DEFAULT_MARKETS
+	const provider = await connect()
+	const block = await provider.getBlockNumber()
+	console.log(`Block: ${block}`)
+
+	console.log('\n=============== GENESIS UNIVERSE ===============')
+	await describeUniverse(provider, GENESIS_UNIVERSE)
+
+	for (const market of markets) {
+		await describeMarket(provider, market)
+	}
+}
+
+main().catch((e) => {
+	console.error(e)
+	process.exit(1)
+})


### PR DESCRIPTION
## Problem

The fork risk meter had three compounding issues:

1. **Wrong deployment** — hardcoded to Augur v1 contracts (universe `0xe991...`, Augur `0x7522...`). The actual Augur v2 genesis universe is `0x49244...` with Augur `0x23916...`.
2. **Wrong bond readout** — used an event-based state machine that filtered out disputes after their round completed, showing 0 active disputes even when escalation was ongoing. Then switched to `getNumberOfOutcomes()` instead of `getNumParticipants()`, reading only 3 of 6 participants.
3. **Ephemeral market tracking** — 7-day event window meant markets with dispute activity older than 7 days were invisible. The meter would go blind on any dispute that had not received a contribution in the last week.

## Solution

### Fix 1: Point to Augur v2 (commit 1)
- Universe: `0xe991...` to `0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA` (v2 genesis)
- Augur: `0x7522...` to `0x23916a8F5C3846e3100e5f587FF14F3098722F5d` (v2)
- Fork threshold: hardcoded 275,000 to live `universe.getDisputeThresholdForFork()` (actual: 274,859 REP)
- Diagnostic probe: `scripts/probe-fork-state.ts` for ad-hoc chain inspection

### Fix 2: Authoritative on-chain bond readout (commit 2)
- `getNumParticipants()` (not `getNumberOfOutcomes()`) for participant count
- `participants(i).getSize()` for protocol-correct bond size
- Iterate from highest index down — latest round has the largest bond

### Fix 3: Persistent market tracking (commit 3)
Three-layer persistence:

| Layer | Lifespan | Purpose |
|---|---|---|
| Events (in cache) | 7 days, pruned | Discover new disputes |
| Tracked markets (in cache) | Indefinite until finalized | Remember known disputes across runs |
| Seed file (git-committed) | Manual | Safety net for cache loss |

- 30-day initial event scan for market discovery (was 7-day)
- Tracked markets persisted in event cache, never pruned by event window
- `public/data/dispute-markets-seed.json` — git-committed fallback for long-running disputes
- Markets removed only when on-chain verification shows `isFinalized()`
- Correct market address extraction per event type (contribution has market at args[2], created/completed at args[1])

## Verification

Live chain state (block 24931079):

| Market | Bond | Round | % of threshold | Source |
|--------|------|-------|---|---|
| Artemis II (0x963e...) | 2,162 REP | 5 | 0.79% | seed + event |
| 0x797a... | 0.356 REP | 0 | less than 0.01% | seed |
| 0x190b... | 0.356 REP | 0 | less than 0.01% | seed |

- Previous meter: 0 active disputes (wrong universe + completed filter)
- Now: 3 active markets with correct bond sizes
- Incremental runs query approximately 50 blocks instead of approximately 216,000
