### PR TITLE
feat(fork-stats): approximate dispute bond display

### DIFF
--- a/src/components/ForkStats.tsx
+++ b/src/components/ForkStats.tsx
@@ -4,10 +4,6 @@ import { useForkData } from '../providers/ForkDataProvider'
 export const ForkStats = (): React.JSX.Element => {
 	const { rawData } = useForkData()
 
-	const formatNumber = (num: number): string => {
-		return num.toLocaleString()
-	}
-
 	// Check if there are no active disputes (stable state)
 	const isStable = rawData.metrics.largestDisputeBond === 0
 
@@ -25,7 +21,7 @@ export const ForkStats = (): React.JSX.Element => {
 					System steady - No market disputes
 				</div>
 			) : (
-				<div className="grid md:grid-cols-[8rem_8rem_8rem] md:place-content-center md:gap-y-4">
+				<div className="grid md:grid-cols-[10rem_12rem_10rem] md:place-content-center md:gap-y-4">
 					{/* Panel 1 - Fork Risk */}
 					<div className="text-center">
 						<div className="text-sm uppercase font-display tracking-widest font-light text-muted-foreground">
@@ -41,8 +37,11 @@ export const ForkStats = (): React.JSX.Element => {
   					<div className="text-sm uppercase font-display tracking-widest font-light text-muted-foreground">
 							DISPUTE BOND
 						</div>
-						<div className="uppercase text-primary fx-glow-sm">
-							{formatNumber(rawData.metrics.largestDisputeBond)} REP
+						<div
+							className="uppercase text-primary fx-glow-sm"
+							title={`${rawData.metrics.largestDisputeBond.toLocaleString(undefined, { maximumFractionDigits: 3 })} REP`}
+						>
+							~{Math.round(rawData.metrics.largestDisputeBond).toLocaleString()} REP
 						</div>
 					</div>
 


### PR DESCRIPTION
## Summary

- Dispute bond now renders as `~<rounded> REP` so users aren't confused by the trailing decimals in the raw value.
- Exact value (up to 3 decimals) is exposed via a native `title` tooltip on hover.
- Widened the stats grid from `[8rem_8rem_8rem]` to `[10rem_12rem_10rem]` to accommodate the tilde and longer values. Bond column gets the extra room since it holds the widest string.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Dev server: fork meter shows `~<rounded> REP`, hover tooltip shows full decimal value, three-column row stays centered at md+ widths
- [x] Stable state (no disputes) still renders "System steady" message unchanged