### PR TITLE
feat: replace bond/threshold gauge signal with round-based progress

### DIFF
--- a/docs/fork-mechanics.md
+++ b/docs/fork-mechanics.md
@@ -76,11 +76,13 @@ The bonds are **crowdsourced** — no single user needs to fund the entire amoun
 
 The fork monitor reads live on-chain state to answer one question:
 
-> **How close is the largest active dispute bond to the fork threshold?**
+> **How far through the escalation path is this market?**
 
-This is measured as a percentage: `(largest dispute bond / fork threshold) × 100`. The fork threshold is read live from the contract (`universe.getDisputeThresholdForFork()`), currently ~274,859 REP (2.5% of the REP supply in the v2 genesis universe).
+This is measured as round progress: `(current round / estimated total rounds) × 100`. The current round is the index of the highest funded participant. The estimated total rounds is projected from the bond growth trajectory — using the last few rounds' growth factor to extrapolate when the bond would reach the fork threshold.
 
-The monitor doesn't predict whether a fork will happen. It measures how much stake is committed to disputing outcomes — a mechanical reading of the protocol's state.
+The monitor also computes the bond/threshold percentage `(largest dispute bond / fork threshold) × 100` for informational purposes, but the primary gauge signal and risk labels are derived from round progress. This is because the bond/threshold ratio grows exponentially while round progress is linear — a market at round 7 of ~12 is well past the halfway point, but its bond may only be ~3% of the fork threshold.
+
+The monitor doesn't predict whether a fork will happen. It measures how far the dispute has progressed through the escalation path — a mechanical reading of the protocol's state.
 
 > **Source**: [[augur-v2-protocol-glossary]] → Fork Trigger, Key Constants
 > **Implementation**: [[fork-monitoring-methodology]]

--- a/docs/fork-monitoring-methodology.md
+++ b/docs/fork-monitoring-methodology.md
@@ -14,16 +14,19 @@ tags: [fork-monitoring, methodology, calculation]
 
 The monitor answers one question:
 
-> **What percentage of the fork threshold is the largest active dispute bond?**
+> **How far through its dispute rounds is the market, relative to the estimated total rounds before a fork?**
 
 ```
-threshold % = (largest dispute bond / fork threshold) × 100
+round progress = (current round / estimated total rounds) × 100
 ```
 
+- **Current round**: the index of the highest non-zero participant (0-indexed)
+- **Estimated total rounds**: projected from the bond growth trajectory (see Round Projection below)
 - **Fork threshold**: read live from `universe.getDisputeThresholdForFork()` (~274,859 REP as of April 2026)
-- **Largest dispute bond**: read from `market.participants(i).getSize()` for each active market
 
-The threshold is not hardcoded — it's read from the contract each run.
+The gauge signal is round progress, not bond/threshold percentage. During active disputes, the bond grows exponentially but may be only ~3% of the fork threshold even at round 7 of ~12 — visually invisible. Round progress maps the same state to a linear, intuitive scale.
+
+> **Historical note**: The monitor previously used `(largest dispute bond / fork threshold) × 100` as the gauge signal. This was replaced with round-based progress in May 2026 because the bond/threshold ratio compresses exponential escalation into an invisible sliver during active dispute phases, making the gauge read "LOW" while the dispute was well past the halfway point.
 
 ---
 
@@ -56,11 +59,23 @@ Every tracked market is verified on-chain each run:
 
 1. `market.isFinalized()` → **true**: removed from tracking (dispute resolved)
 2. `market.getNumParticipants()` == 0: **removed** (no dispute activity)
-3. Participants queried from highest index down:
+3. All participants read sequentially (index 0 through N):
    - `market.participants(i).getSize()` → target bond for round *i*
+   - Bond trajectory recorded for projection (see Round Projection below)
    - Highest non-zero participant = current/latest dispute round
    - Largest `getSize()` across all participants = the market's dispute bond
 4. Read error: **kept** in tracking (conservative — don't lose track of a market)
+
+### Round Projection
+
+The script reads ALL participant bonds (not just the largest) to build a bond trajectory: `[b0, b1, b2, …, bn]`. It uses the last 3–4 rounds to compute an average growth factor, then projects forward until the bond would exceed the fork threshold:
+
+```
+avg_growth = mean(b[i] / b[i-1] for recent rounds)
+estimated_total = smallest n where b[n] × avg_growth^(n-current) >= fork_threshold
+```
+
+The projection is conservative — if fewer than 3 rounds exist, or the growth factor diverges (projection exceeds 30 rounds), `estimatedTotalRounds` is `null` and round progress defaults to 0.
 
 ### Why `getSize()` not `getStake()`
 
@@ -136,19 +151,19 @@ Events are only used for *discovery* — once a market is tracked, it stays unti
 
 ---
 
-## Threshold Levels
+## Risk Levels
 
-The UI displays the threshold percentage as a level:
+The UI displays round progress as a risk level:
 
-| Level | Threshold % | Description |
-|-------|-------------|-------------|
+| Level | Round Progress | Description |
+|-------|----------------|-------------|
 | None | 0% | No active disputes |
-| Low | <10% | Normal dispute activity |
-| Moderate | 10–25% | Elevated activity |
-| High | 25–75% | Large disputes requiring attention |
-| Critical | ≥75% | Fork threshold proximity is high |
+| Low | <25% | Early dispute rounds |
+| Moderate | 25–50% | Mid-escalation |
+| High | 50–75% | Late-stage dispute |
+| Critical | ≥75% | Approaching fork threshold |
 
-These levels are display categories. The monitor measures a constant — the ratio of bond to threshold — and presents it for human consumption.
+These levels are display categories derived from round progress. The bond/threshold percentage is still computed and stored in the data, but the primary gauge signal and risk labels use round progress.
 
 ---
 

--- a/docs/technical-architecture.md
+++ b/docs/technical-architecture.md
@@ -62,9 +62,10 @@ Layout.astro (Base HTML shell)
 
 ### Data Flow
 1. `ForkDataProvider` fetches `/data/fork-risk.json` on mount
-2. Single metric: largest active dispute bond / 275,000 REP
-3. Auto-refresh every 5 minutes
-4. `ForkMockProvider` wraps for demo scenarios
+2. Primary gauge signal: `roundProgress` (current round / estimated total rounds × 100)
+3. Bond/threshold percentage still computed and stored, but used only for informational display
+4. Auto-refresh every 5 minutes
+5. `ForkMockProvider` wraps for demo scenarios
 
 **Data Source:** `fork-risk.json` is generated hourly by GitHub Actions. See [[fork-monitoring-pipeline]] for the monitoring workflow.
 
@@ -126,19 +127,20 @@ public/               # Static assets (fonts, images, data)
 Interactive components use `client:load` for immediate hydration. Static content (layouts, navigation chrome, blog cards) renders as pure Astro with zero JS.
 
 ### Fork Gauge Visual Scaling
-Non-linear mapping for intuitive display:
-- 0% actual → 0% gauge fill
-- 5% actual → ~25% gauge fill
-- 25% actual → ~50% gauge fill
-- 75% actual → ~90% gauge fill
+Linear mapping — round progress maps directly to gauge fill:
+- 0% round progress → 0% gauge fill
+- 50% round progress → 50% gauge fill
+- 100% round progress → 100% gauge fill
+
+No non-linear stretching. The gauge is a straightforward half-circle arc where fill equals the round progress percentage.
 
 ### Progressive Disclosure
 - **No disputes**: "System steady — No market disputes"
 - **Active disputes**: Dispute bond, threshold %, dispute round
 - **Demo mode**: Additional controls and current values
 
-### Threshold Calculation
+### Risk Calculation
 ```typescript
-const forkThresholdPercent = (largestActiveDisputeBond / forkThreshold) * 100
+const roundProgress = (currentRound / estimatedTotalRounds) * 100
 ```
-Where `forkThreshold` is read live from `universe.getDisputeThresholdForFork()`. See [[fork-monitoring-methodology]] for the full calculation.
+Where `currentRound` is the highest non-zero participant index and `estimatedTotalRounds` is projected from the bond growth trajectory. See [[fork-monitoring-methodology]] for the full calculation.

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -24,6 +24,8 @@ interface DisputeDetails {
 	title: string
 	disputeBondSize: number
 	disputeRound: number
+	estimatedTotalRounds: number | null
+	roundProgress: number | null
 	daysRemaining: number
 }
 
@@ -38,6 +40,9 @@ interface Metrics {
 	forkThresholdPercent: number
 	activeDisputes: number
 	disputeDetails: DisputeDetails[]
+	currentRound: number
+	estimatedTotalRounds: number | null
+	roundProgress: number
 }
 
 interface Calculation {
@@ -59,6 +64,40 @@ interface ForkRiskData {
 		isHealthy: boolean
 		discrepancy?: string
 	}
+}
+
+/**
+ * Project total rounds based on bond growth trajectory.
+ * Uses the last few rounds to average the growth factor,
+ * then projects forward until bond exceeds threshold.
+ */
+function projectTotalRounds(
+	participantBonds: number[],
+	threshold: number,
+): { estimatedTotalRounds: number; growthFactor: number } | null {
+	if (participantBonds.length < 3) return null
+
+	// Use last 3-4 rounds for stable growth factor
+	const recentBonds = participantBonds.slice(-4)
+	const growthFactors: number[] = []
+	for (let i = 1; i < recentBonds.length; i++) {
+		if (recentBonds[i - 1] > 0) {
+			growthFactors.push(recentBonds[i] / recentBonds[i - 1])
+		}
+	}
+	if (growthFactors.length === 0) return null
+
+	const avgGrowth = growthFactors.reduce((a, b) => a + b, 0) / growthFactors.length
+	let bond = recentBonds[recentBonds.length - 1]
+	let round = participantBonds.length - 1
+
+	while (bond < threshold) {
+		bond *= avgGrowth
+		round++
+		if (round > 30) return null // diverging
+	}
+
+	return { estimatedTotalRounds: round, growthFactor: Math.round(avgGrowth * 100) / 100 }
 }
 
 // Cache interfaces for incremental event caching
@@ -122,13 +161,7 @@ interface RpcConnection {
 	fallbacksAttempted: number
 }
 
-// Risk level thresholds (percentage of fork threshold)
-const RISK_LEVELS = {
-	LOW: 10, // <10% of fork threshold
-	MODERATE: 25, // 10-25% of threshold
-	HIGH: 75, // 25-75% of threshold
-	CRITICAL: 75, // >75% of threshold
-}
+
 
 /**
  * Retry wrapper for contract calls with exponential backoff
@@ -291,8 +324,16 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 			}
 
 			// Calculate key metrics
-			const activeDisputes = await getActiveDisputes(connection.provider, contracts, mode)
+			const activeDisputes = await getActiveDisputes(connection.provider, contracts, mode, forkThresholdRep)
 			const largestDisputeBond = getLargestDisputeBond(activeDisputes)
+
+			// Derive round-based metrics from the largest dispute
+			const topDispute = activeDisputes.length > 0
+				? activeDisputes.reduce((a, b) => a.disputeBondSize > b.disputeBondSize ? a : b)
+				: null
+			const currentRound = topDispute?.disputeRound ?? 0
+			const estimatedTotalRounds = topDispute?.estimatedTotalRounds ?? null
+			const roundProgress = topDispute?.roundProgress ?? 0
 
 			// Validate cache health
 			const cache = await loadEventCache()
@@ -303,39 +344,43 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 				console.error('⚠️  Consider triggering Cache Rebuild job to repair the cache')
 			}
 
-			// Calculate risk level
+			// Calculate risk level based on round progress
 			const forkThresholdPercent =
 				(largestDisputeBond / forkThresholdRep) * 100
-			const riskLevel = determineRiskLevel(forkThresholdPercent)
-			const riskPercentage = forkThresholdPercent
+			const riskLevel = determineRiskLevel(roundProgress)
+			const riskPercentage = roundProgress
 
 			// Prepare results
 			const results: ForkRiskData = {
-			lastRiskChange: new Date().toISOString(),
-			blockNumber,
-			riskLevel,
-			riskPercentage: Math.min(100, Math.max(0, riskPercentage)),
-			metrics: {
-				largestDisputeBond,
-				forkThresholdPercent: Math.round(forkThresholdPercent * 100) / 100,
-				activeDisputes: activeDisputes.length,
-				disputeDetails: activeDisputes.slice(0, 5), // Top 5 disputes
-			},
-			rpcInfo: {
-				endpoint: connection.endpoint,
-				latency: connection.latency,
-				fallbacksAttempted: connection.fallbacksAttempted,
-			},
-			calculation: {
-				forkThreshold: forkThresholdRep,
-			},
-			cacheValidation,
+				lastRiskChange: new Date().toISOString(),
+				blockNumber,
+				riskLevel,
+				riskPercentage: Math.min(100, Math.max(0, riskPercentage)),
+				metrics: {
+					largestDisputeBond,
+					forkThresholdPercent: Math.round(forkThresholdPercent * 100) / 100,
+					activeDisputes: activeDisputes.length,
+					disputeDetails: activeDisputes.slice(0, 5),
+					currentRound,
+					estimatedTotalRounds,
+					roundProgress: Math.round(roundProgress * 10) / 10,
+				},
+				rpcInfo: {
+					endpoint: connection.endpoint,
+					latency: connection.latency,
+					fallbacksAttempted: connection.fallbacksAttempted,
+				},
+				calculation: {
+					forkThreshold: forkThresholdRep,
+				},
+				cacheValidation,
 			}
 
 			console.log('Calculation completed successfully')
 			console.log(`Risk Level: ${riskLevel}`)
+			console.log(`Round Progress: ${currentRound}/${estimatedTotalRounds ?? '?'} (${roundProgress.toFixed(1)}%)`)
 			console.log(`Largest Dispute Bond: ${largestDisputeBond} REP`)
-			console.log(`Fork Threshold: ${forkThresholdPercent.toFixed(2)}%`)
+			console.log(`Bond/Threshold: ${forkThresholdPercent.toFixed(2)}%`)
 			console.log(`RPC Used: ${connection.endpoint} (${connection.latency}ms)`)
 			console.log(`Block Number: ${blockNumber}`)
 
@@ -609,7 +654,7 @@ function extractMarketFromEventLog(event: ethers.EventLog, eventType: 'created' 
 	return null
 }
 
-async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Record<string, ethers.Contract>, mode: string = 'incremental'): Promise<DisputeDetails[]> {
+async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Record<string, ethers.Contract>, mode: string = 'incremental', forkThresholdRep: number = 275000): Promise<DisputeDetails[]> {
 	try {
 		console.log('Querying dispute events for accurate stake calculation...')
 
@@ -875,26 +920,30 @@ async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Re
 					continue
 				}
 
-				// Read participants from highest index down.
-				// The highest non-zero getSize() is the current/latest dispute round.
+				// Read ALL participants to build bond trajectory for projection
+				const allBonds: number[] = []
 				let largestSize = 0
 				let latestRound = 0
 
-				for (let i = numParticipants - 1; i >= 0; i--) {
+				for (let i = 0; i < numParticipants; i++) {
 					try {
 						const participantAddr = await market.participants(i)
-						if (!participantAddr || participantAddr === ethers.ZeroAddress) continue
+						if (!participantAddr || participantAddr === ethers.ZeroAddress) {
+							allBonds.push(0)
+							continue
+						}
 
 						const participant = new ethers.Contract(participantAddr, participantAbi, provider)
 						const sizeWei = await participant.getSize()
 						const sizeRep = Number(ethers.formatEther(sizeWei))
+						allBonds.push(sizeRep)
 
 						if (sizeRep > largestSize) {
 							largestSize = sizeRep
 							latestRound = i
 						}
 					} catch (_err) {
-						// Participant read failed, skip
+						allBonds.push(0)
 					}
 				}
 
@@ -905,14 +954,23 @@ async function getActiveDisputes(provider: ethers.JsonRpcProvider, contracts: Re
 				})
 
 				if (largestSize > 0) {
+					// Run projection for this market
+					const projection = projectTotalRounds(allBonds, forkThresholdRep)
+					const estimatedTotalRounds = projection?.estimatedTotalRounds ?? null
+					const roundProgress = estimatedTotalRounds
+						? (latestRound / estimatedTotalRounds) * 100
+						: 0
+
 					disputes.push({
 						marketId,
 						title: `Market ${marketId.substring(0, 10)}...`,
 						disputeBondSize: largestSize,
 						disputeRound: latestRound,
+						estimatedTotalRounds,
+						roundProgress,
 						daysRemaining: 7,
 					})
-					console.log(`  ✓ ${marketId.slice(0, 10)}... bond=${largestSize.toLocaleString()} REP round=${latestRound}`)
+					console.log(`  ✓ ${marketId.slice(0, 10)}... bond=${largestSize.toLocaleString()} REP round=${latestRound}/${estimatedTotalRounds ?? '?'} (${roundProgress.toFixed(1)}%)`)
 				}
 			} catch (error) {
 				// Market read failed — keep tracking but don't add to disputes
@@ -967,11 +1025,11 @@ function getLargestDisputeBond(disputes: DisputeDetails[]): number {
 
 
 
-function determineRiskLevel(forkThresholdPercent: number): RiskLevel {
-	if (forkThresholdPercent === 0) return 'none'
-	if (forkThresholdPercent > RISK_LEVELS.CRITICAL) return 'critical'
-	if (forkThresholdPercent >= RISK_LEVELS.HIGH) return 'high'
-	if (forkThresholdPercent >= RISK_LEVELS.MODERATE) return 'moderate'
+function determineRiskLevel(roundProgress: number): RiskLevel {
+	if (roundProgress === 0) return 'none'
+	if (roundProgress >= 100) return 'critical'
+	if (roundProgress >= 75) return 'high'
+	if (roundProgress >= 25) return 'moderate'
 	return 'low'
 }
 
@@ -982,7 +1040,7 @@ function getForkingResult(blockNumber: number, connection: RpcConnection, forkTh
 			riskLevel: 'critical',
 			riskPercentage: 100,
 			metrics: {
-				largestDisputeBond: forkThresholdRep, // Fork threshold was reached
+				largestDisputeBond: forkThresholdRep,
 				forkThresholdPercent: 100,
 				activeDisputes: 0,
 				disputeDetails: [
@@ -991,9 +1049,14 @@ function getForkingResult(blockNumber: number, connection: RpcConnection, forkTh
 						title: 'Universe is currently forking',
 						disputeBondSize: forkThresholdRep,
 						disputeRound: 99,
+						estimatedTotalRounds: null,
+						roundProgress: 100,
 						daysRemaining: 0,
 					},
 				],
+				currentRound: 99,
+				estimatedTotalRounds: null,
+				roundProgress: 100,
 			},
 			rpcInfo: {
 				endpoint: connection.endpoint,
@@ -1018,6 +1081,9 @@ function getErrorResult(errorMessage: string): ForkRiskData {
 				forkThresholdPercent: 0,
 				activeDisputes: 0,
 				disputeDetails: [],
+				currentRound: 0,
+				estimatedTotalRounds: null,
+				roundProgress: 0,
 			},
 				rpcInfo: {
 				endpoint: null,
@@ -1025,7 +1091,7 @@ function getErrorResult(errorMessage: string): ForkRiskData {
 				fallbacksAttempted: 0,
 			},
 			calculation: {
-					forkThreshold: 275000, // fallback threshold
+					forkThreshold: 275000,
 			},
 		cacheValidation: { isHealthy: false, discrepancy: errorMessage },
 		}

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -42,7 +42,7 @@ interface Metrics {
 	disputeDetails: DisputeDetails[]
 	currentRound: number
 	estimatedTotalRounds: number | null
-	roundProgress: number
+	roundProgress: number | null
 }
 
 interface Calculation {
@@ -55,7 +55,7 @@ interface ForkRiskData {
 	lastRiskChange: string
 	blockNumber?: number
 	riskLevel: RiskLevel
-	riskPercentage: number
+	riskPercentage: number | null
 	metrics: Metrics
 	rpcInfo: RpcInfo
 	calculation: Calculation
@@ -333,7 +333,8 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 				: null
 			const currentRound = topDispute?.disputeRound ?? 0
 			const estimatedTotalRounds = topDispute?.estimatedTotalRounds ?? null
-			const roundProgress = topDispute?.roundProgress ?? 0
+			// null means projection unavailable — active dispute but can't estimate progress
+			const roundProgress: number | null = topDispute?.roundProgress ?? null
 
 			// Validate cache health
 			const cache = await loadEventCache()
@@ -355,7 +356,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 				lastRiskChange: new Date().toISOString(),
 				blockNumber,
 				riskLevel,
-				riskPercentage: Math.min(100, Math.max(0, riskPercentage)),
+				riskPercentage: riskPercentage !== null ? Math.min(100, Math.max(0, riskPercentage)) : null,
 				metrics: {
 					largestDisputeBond,
 					forkThresholdPercent: Math.round(forkThresholdPercent * 100) / 100,
@@ -363,7 +364,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 					disputeDetails: activeDisputes.slice(0, 5),
 					currentRound,
 					estimatedTotalRounds,
-					roundProgress: Math.round(roundProgress * 10) / 10,
+					roundProgress: roundProgress !== null ? Math.round(roundProgress * 10) / 10 : null,
 				},
 				rpcInfo: {
 					endpoint: connection.endpoint,
@@ -378,7 +379,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 
 			console.log('Calculation completed successfully')
 			console.log(`Risk Level: ${riskLevel}`)
-			console.log(`Round Progress: ${currentRound}/${estimatedTotalRounds ?? '?'} (${roundProgress.toFixed(1)}%)`)
+			console.log(`Round Progress: ${currentRound}/${estimatedTotalRounds ?? '?'} (${roundProgress !== null ? `${roundProgress.toFixed(1)}%` : 'projection unavailable'})`)
 			console.log(`Largest Dispute Bond: ${largestDisputeBond} REP`)
 			console.log(`Bond/Threshold: ${forkThresholdPercent.toFixed(2)}%`)
 			console.log(`RPC Used: ${connection.endpoint} (${connection.latency}ms)`)
@@ -1025,10 +1026,11 @@ function getLargestDisputeBond(disputes: DisputeDetails[]): number {
 
 
 
-function determineRiskLevel(roundProgress: number): RiskLevel {
+function determineRiskLevel(roundProgress: number | null): RiskLevel {
+	if (roundProgress === null) return 'unknown'
 	if (roundProgress === 0) return 'none'
-	if (roundProgress >= 100) return 'critical'
-	if (roundProgress >= 75) return 'high'
+	if (roundProgress >= 75) return 'critical'
+	if (roundProgress >= 50) return 'high'
 	if (roundProgress >= 25) return 'moderate'
 	return 'low'
 }

--- a/src/components/ForkDisplay.tsx
+++ b/src/components/ForkDisplay.tsx
@@ -30,7 +30,7 @@ const ForkDisplay: React.FC = () => {
   const [isVisible, setIsVisible] = useState(false)
 
   // Use the fork risk hook to get real data
-  const { gaugeData, lastUpdated, isLoading, error } = useForkData()
+  const { gaugeData, riskLevel, lastUpdated, isLoading, error } = useForkData()
 
   // Subscribe to animation state
   useEffect(() => {
@@ -58,7 +58,7 @@ const ForkDisplay: React.FC = () => {
         {error && <div className="mb-4 text-orange-400">Warning: {error}</div>}
 
         {/* Gauge with Details Card - ForkDetailsCard wraps the gauge */}
-        <ForkDetailsCard gauge={<ForkGauge percentage={gaugeData.percentage} />} />
+        <ForkDetailsCard gauge={<ForkGauge percentage={gaugeData.percentage} riskLevel={riskLevel.level.toLowerCase()} />} />
 
         <ForkStats />
 

--- a/src/components/ForkGauge.tsx
+++ b/src/components/ForkGauge.tsx
@@ -18,19 +18,17 @@ const updateArc = (percentage: number): string => {
 	return `M 80 200 A 120 120 0 0 1 ${endX} ${endY}`
 }
 
-const getRiskLevel = (percentage: number): string => {
-	if (percentage === 0) return 'NO RISK'
-	if (percentage < 25) return 'LOW'
-	if (percentage < 50) return 'MEDIUM'
-	if (percentage < 75) return 'HIGH'
-	return 'EXTREME'
+const RISK_COLORS: Record<string, string> = {
+	none: 'var(--color-green-400)',
+	low: 'var(--color-green-400)',
+	moderate: 'var(--color-yellow-400)',
+	high: 'var(--color-orange-400)',
+	critical: 'var(--color-red-500)',
+	unknown: 'var(--color-green-400)',
 }
 
-const getRiskColor = (percentage: number): string => {
-	if (percentage < 25) return 'var(--color-green-400)'
-	if (percentage < 50) return 'var(--color-yellow-400)'
-	if (percentage < 75) return 'var(--color-orange-400)'
-	return 'var(--color-red-500)'
+const getRiskColor = (riskLevel: string): string => {
+	return RISK_COLORS[riskLevel] || 'var(--color-green-400)'
 }
 
 const getNeedleEndpoint = (percentage: number): { x: number; y: number } => {
@@ -47,10 +45,11 @@ const getNeedleEndpoint = (percentage: number): { x: number; y: number } => {
 
 const ForkGaugeComponent = ({
 	percentage,
+	riskLevel: riskLevelProp,
 }: GaugeDisplayProps): React.JSX.Element => {
 	const arcPath = useMemo(() => updateArc(percentage), [percentage])
-	const riskColor = useMemo(() => getRiskColor(percentage), [percentage])
-	const riskLevel = useMemo(() => getRiskLevel(percentage), [percentage])
+	const riskLevel = riskLevelProp ?? 'none'
+	const riskColor = useMemo(() => getRiskColor(riskLevel), [riskLevel])
 	const needleEndpoint = useMemo(() => getNeedleEndpoint(percentage), [percentage])
 
 	const prefersReducedMotion = typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
@@ -162,7 +161,7 @@ const ForkGaugeComponent = ({
 					fontWeight="bold"
 					className={cn('text-4xl font-display fx-glow-sm', `fx-glow-[${riskColor}]`)}
 				>
-					{riskLevel}
+					{riskLevel === 'none' ? 'NO RISK' : riskLevel.toUpperCase()}
 				</text>
 			</svg>
 

--- a/src/components/ForkGauge.tsx
+++ b/src/components/ForkGauge.tsx
@@ -3,78 +3,45 @@ import { cn } from '../lib/utils'
 import type { GaugeDisplayProps } from '../types/gauge'
 
 /**
- * Convert fork threshold percentage to visual gauge percentage
- * Maps the actual risk to intuitive visual representation
+ * Calculate arc path endpoint for a given fill percentage (0-100).
+ * Maps percentage to angle from 180° to 0° (π to 0 radians).
  */
-const getVisualPercentage = (forkThresholdPercent: number): number => {
-	// No minimum fill - 0% risk shows 0% visual fill
-	const MIN_VISUAL_FILL = 0
-
-	if (forkThresholdPercent === 0) {
-		// No visual fill when no risk detected
-		return MIN_VISUAL_FILL
-	} else if (forkThresholdPercent <= 10) {
-		// 0-10% fork threshold = 0-25% gauge (Low risk zone)
-		// Linear scaling from 0% to 25%
-		return MIN_VISUAL_FILL + ((forkThresholdPercent / 10) * (25 - MIN_VISUAL_FILL))
-	} else if (forkThresholdPercent <= 25) {
-		// 10-25% fork threshold = 25-50% gauge (Medium risk zone)
-		return 25 + ((forkThresholdPercent - 10) / 15) * 25
-	} else if (forkThresholdPercent <= 75) {
-		// 25-75% fork threshold = 50-90% gauge (High risk zone)
-		return 50 + ((forkThresholdPercent - 25) / 50) * 40
-	} else {
-		// 75%+ fork threshold = 90-100% gauge (Extreme risk zone)
-		return Math.min(100, 90 + ((forkThresholdPercent - 75) / 25) * 10)
-	}
-}
-
-const updateArc = (actualPercentage: number): string => {
-	// Use visual percentage for arc display
-	const visualPercentage = getVisualPercentage(actualPercentage)
-
-	// Calculate the end point of the arc based on visual percentage
-	// Map percentage to angle from 180° to 0° (π to 0 radians)
-	const angle = Math.PI - (visualPercentage / 100) * Math.PI
+const updateArc = (percentage: number): string => {
+	const angle = Math.PI - (percentage / 100) * Math.PI
 	const centerX = 200
 	const centerY = 200
 	const radius = 120
 
-	// Calculate end point
 	const endX = centerX + radius * Math.cos(angle)
 	const endY = centerY - radius * Math.sin(angle)
 
-	// Create arc path based on visual percentage (can be 0% for no fill)
 	return `M 80 200 A 120 120 0 0 1 ${endX} ${endY}`
 }
 
-const getRiskLevel = (forkThresholdPercent: number): string => {
-	if (forkThresholdPercent === 0) return 'NO RISK'
-	if (forkThresholdPercent < 10) return 'LOW'
-	if (forkThresholdPercent < 25) return 'MEDIUM'
-	if (forkThresholdPercent < 75) return 'HIGH'
+const getRiskLevel = (percentage: number): string => {
+	if (percentage === 0) return 'NO RISK'
+	if (percentage < 25) return 'LOW'
+	if (percentage < 50) return 'MEDIUM'
+	if (percentage < 75) return 'HIGH'
 	return 'EXTREME'
 }
 
-const getRiskColor = (forkThresholdPercent: number): string => {
-	// Use the site's existing color variables
-	if (forkThresholdPercent < 10) return 'var(--color-green-400)'
-	if (forkThresholdPercent < 25) return 'var(--color-yellow-400)'
-	if (forkThresholdPercent < 75) return 'var(--color-orange-400)'
+const getRiskColor = (percentage: number): string => {
+	if (percentage < 25) return 'var(--color-green-400)'
+	if (percentage < 50) return 'var(--color-yellow-400)'
+	if (percentage < 75) return 'var(--color-orange-400)'
 	return 'var(--color-red-500)'
 }
 
-// Calculate needle endpoint to match the arc endpoint
-const getNeedleEndpoint = (forkThresholdPercent: number): {x: number, y: number} => {
-	const visualPercentage = getVisualPercentage(forkThresholdPercent)
-	const angle = Math.PI - (visualPercentage / 100) * Math.PI
+const getNeedleEndpoint = (percentage: number): { x: number; y: number } => {
+	const angle = Math.PI - (percentage / 100) * Math.PI
 	const centerX = 200
 	const centerY = 200
-	const radius = 100 // Reduced from 120 to create gap from arc edge
+	const radius = 100
 
 	return {
 		x: centerX + radius * Math.cos(angle),
-		y: centerY - radius * Math.sin(angle)
+		y: centerY - radius * Math.sin(angle),
 	}
 }
 

--- a/src/components/ForkStats.tsx
+++ b/src/components/ForkStats.tsx
@@ -1,18 +1,28 @@
 import type React from 'react'
 import { useForkData } from '../providers/ForkDataProvider'
 
+const getRiskLabel = (roundProgress: number): string => {
+	if (roundProgress === 0) return 'NONE'
+	if (roundProgress < 25) return 'LOW'
+	if (roundProgress < 50) return 'MEDIUM'
+	if (roundProgress < 75) return 'HIGH'
+	return 'EXTREME'
+}
+
 export const ForkStats = (): React.JSX.Element => {
 	const { rawData } = useForkData()
 
-	// Check if there are no active disputes (stable state)
 	const isStable = rawData.metrics.largestDisputeBond === 0
-
-	// Get the largest dispute details if available
 	const largestDispute = rawData.metrics.disputeDetails?.length > 0
 		? rawData.metrics.disputeDetails.reduce((largest, current) =>
 				current.disputeBondSize > largest.disputeBondSize ? current : largest
 			)
 		: null
+
+	const riskLabel = getRiskLabel(rawData.metrics.roundProgress)
+	const roundDisplay = rawData.metrics.estimatedTotalRounds
+		? `${rawData.metrics.currentRound}/${rawData.metrics.estimatedTotalRounds}`
+		: `${rawData.metrics.currentRound}`
 
 	return (
 		<div className="w-full mb-1">
@@ -28,7 +38,7 @@ export const ForkStats = (): React.JSX.Element => {
 							FORK RISK
 						</div>
 						<div className="uppercase text-primary fx-glow-sm">
-							{rawData.metrics.forkThresholdPercent.toFixed(1)}%
+							{riskLabel}
 						</div>
 					</div>
 
@@ -51,11 +61,11 @@ export const ForkStats = (): React.JSX.Element => {
 							DISPUTE ROUND
 						</div>
 						<div className="uppercase text-primary fx-glow-sm">
-							{largestDispute?.disputeRound || 1}
+							{roundDisplay}
 						</div>
 					</div>
 
-					{/* Market Address - properly constrained for truncation */}
+					{/* Market Address */}
 					{largestDispute && (
 						<div className="text-center md:col-span-full">
   						<div className="text-sm uppercase font-display tracking-widest font-light text-muted-foreground">

--- a/src/components/ForkStats.tsx
+++ b/src/components/ForkStats.tsx
@@ -15,7 +15,7 @@ export const ForkStats = (): React.JSX.Element => {
 	const roundDisplay = rawData.metrics.roundProgress === null
 		? `${rawData.metrics.currentRound}/?`
 		: rawData.metrics.estimatedTotalRounds
-			? `${rawData.metrics.currentRound}/${rawData.metrics.estimatedTotalRounds}`
+			? `${rawData.metrics.currentRound}/~${rawData.metrics.estimatedTotalRounds}`
 			: `${rawData.metrics.currentRound}`
 
 	return (

--- a/src/components/ForkStats.tsx
+++ b/src/components/ForkStats.tsx
@@ -1,16 +1,8 @@
 import type React from 'react'
 import { useForkData } from '../providers/ForkDataProvider'
 
-const getRiskLabel = (roundProgress: number): string => {
-	if (roundProgress === 0) return 'NONE'
-	if (roundProgress < 25) return 'LOW'
-	if (roundProgress < 50) return 'MEDIUM'
-	if (roundProgress < 75) return 'HIGH'
-	return 'EXTREME'
-}
-
 export const ForkStats = (): React.JSX.Element => {
-	const { rawData } = useForkData()
+	const { rawData, riskLevel } = useForkData()
 
 	const isStable = rawData.metrics.largestDisputeBond === 0
 	const largestDispute = rawData.metrics.disputeDetails?.length > 0
@@ -19,10 +11,12 @@ export const ForkStats = (): React.JSX.Element => {
 			)
 		: null
 
-	const riskLabel = getRiskLabel(rawData.metrics.roundProgress)
-	const roundDisplay = rawData.metrics.estimatedTotalRounds
-		? `${rawData.metrics.currentRound}/${rawData.metrics.estimatedTotalRounds}`
-		: `${rawData.metrics.currentRound}`
+	const riskLabel = riskLevel.level === 'No Risk' ? 'NONE' : riskLevel.level === 'Unknown' ? 'PROJECTION UNAVAILABLE' : riskLevel.level.toUpperCase()
+	const roundDisplay = rawData.metrics.roundProgress === null
+		? `${rawData.metrics.currentRound}/?`
+		: rawData.metrics.estimatedTotalRounds
+			? `${rawData.metrics.currentRound}/${rawData.metrics.estimatedTotalRounds}`
+			: `${rawData.metrics.currentRound}`
 
 	return (
 		<div className="w-full mb-1">

--- a/src/providers/ForkDataProvider.tsx
+++ b/src/providers/ForkDataProvider.tsx
@@ -25,7 +25,7 @@ const ForkDataContext = createContext<ForkDataContextValue | undefined>(
 )
 
 const convertToGaugeData = (data: ForkRiskData): GaugeData => ({
-	percentage: data.riskPercentage, // Pass actual percentage, let GaugeDisplay handle visual scaling
+	percentage: data.riskPercentage ?? 0,
 	repStaked: data.metrics.largestDisputeBond,
 	activeDisputes: data.metrics.activeDisputes,
 })
@@ -49,8 +49,11 @@ const convertToRiskLevel = (data: ForkRiskData): RiskLevel => {
 		case 'critical':
 			level = 'Critical'
 			break
+		case 'unknown':
+			level = 'Unknown'
+			break
 		default:
-			level = 'No Risk'
+			level = 'Unknown'
 	}
 
 	return { level }

--- a/src/providers/ForkDataProvider.tsx
+++ b/src/providers/ForkDataProvider.tsx
@@ -83,6 +83,9 @@ export const ForkDataProvider = ({
 			largestDisputeBond: 0,
 			forkThresholdPercent: 0,
 			activeDisputes: 0,
+			currentRound: 0,
+			estimatedTotalRounds: null,
+			roundProgress: 0,
 			disputeDetails: [],
 		},
 		calculation: {

--- a/src/types/gauge.ts
+++ b/src/types/gauge.ts
@@ -5,21 +5,21 @@ export interface GaugeData {
 }
 
 export interface RiskLevel {
-	level: 'No Risk' | 'Low' | 'Moderate' | 'High' | 'Critical'
+	level: 'No Risk' | 'Low' | 'Moderate' | 'High' | 'Critical' | 'Unknown'
 }
 
 export interface ForkRiskData {
 	lastRiskChange: string
 	blockNumber?: number
 	riskLevel: 'none' | 'low' | 'moderate' | 'high' | 'critical' | 'unknown'
-	riskPercentage: number
+	riskPercentage: number | null
 	metrics: {
 		largestDisputeBond: number
 		forkThresholdPercent: number
 		activeDisputes: number
 		currentRound: number
 		estimatedTotalRounds: number | null
-		roundProgress: number
+		roundProgress: number | null
 		disputeDetails: Array<{
 			marketId: string
 			title: string
@@ -47,6 +47,7 @@ export interface ForkRiskData {
 
 export interface GaugeDisplayProps {
 	percentage: number
+	riskLevel?: string
 	onPercentageChange?: (percentage: number) => void
 }
 

--- a/src/types/gauge.ts
+++ b/src/types/gauge.ts
@@ -17,11 +17,16 @@ export interface ForkRiskData {
 		largestDisputeBond: number
 		forkThresholdPercent: number
 		activeDisputes: number
+		currentRound: number
+		estimatedTotalRounds: number | null
+		roundProgress: number
 		disputeDetails: Array<{
 			marketId: string
 			title: string
 			disputeBondSize: number
 			disputeRound: number
+			estimatedTotalRounds: number | null
+			roundProgress: number | null
 			daysRemaining: number
 		}>
 	}

--- a/src/utils/demoDataGenerator.ts
+++ b/src/utils/demoDataGenerator.ts
@@ -66,6 +66,8 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 		title: string
 		disputeBondSize: number
 		disputeRound: number
+		estimatedTotalRounds: number | null
+		roundProgress: number | null
 		daysRemaining: number
 	}>
 
@@ -76,6 +78,8 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 			title: getDemoMarketTitle(i),
 			disputeBondSize: i === 0 ? largestDisputeBond : generateVariedBondSize(largestDisputeBond, scenario),
 			disputeRound: Math.floor(Math.random() * 3) + 1,
+			estimatedTotalRounds: null,
+			roundProgress: null,
 			daysRemaining: Math.floor(Math.random() * 6) + 1,
 		}))
 	} else {
@@ -110,6 +114,9 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 			largestDisputeBond,
 			forkThresholdPercent: Math.round(forkThresholdPercent * 100) / 100,
 			activeDisputes,
+			currentRound: disputeDetails.length > 0 ? disputeDetails[0].disputeRound : 0,
+			estimatedTotalRounds: null,
+			roundProgress: Math.round(forkThresholdPercent * 10) / 10,
 			disputeDetails,
 		},
 		rpcInfo: {

--- a/src/utils/demoDataGenerator.ts
+++ b/src/utils/demoDataGenerator.ts
@@ -14,6 +14,17 @@ export enum DisputeBondScenario {
 	ELEVATED_RISK = 'elevated_risk'
 }
 
+// Representative round data per scenario
+const SCENARIO_ROUNDS: Record<Exclude<DisputeBondScenario, DisputeBondScenario.NO_DISPUTES>, {
+	currentRound: number
+	estimatedTotalRounds: number
+}> = {
+	[DisputeBondScenario.LOW_RISK]: { currentRound: 3, estimatedTotalRounds: 12 },
+	[DisputeBondScenario.MODERATE_RISK]: { currentRound: 7, estimatedTotalRounds: 12 },
+	[DisputeBondScenario.HIGH_RISK]: { currentRound: 9, estimatedTotalRounds: 12 },
+	[DisputeBondScenario.ELEVATED_RISK]: { currentRound: 11, estimatedTotalRounds: 12 },
+}
+
 /**
  * Generate realistic ForkRiskData based on dispute bond scenario
  * Only available in development mode
@@ -27,6 +38,8 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 	let largestDisputeBond: number
 	let riskLevel: ForkRiskLevel
 	let activeDisputes: number
+	let currentRound = 0
+	let estimatedTotalRounds: number | null = null
 	
 	// Generate dispute bond scenarios aligned with risk levels
 	switch (scenario) {
@@ -36,27 +49,27 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 			break
 			
 		case DisputeBondScenario.LOW_RISK:
-			// Low risk bonds: 0.4-10% of threshold (1100-27500 REP)
 			largestDisputeBond = 1100 + Math.floor(Math.random() * 26400)
-			activeDisputes = Math.floor(Math.random() * 3) + 1 // 1-3 disputes
+			activeDisputes = Math.floor(Math.random() * 3) + 1
+			;({ currentRound, estimatedTotalRounds } = SCENARIO_ROUNDS[scenario])
 			break
 			
 		case DisputeBondScenario.MODERATE_RISK:
-			// Medium risk bonds: 10-25% of threshold (27500-68750 REP)
 			largestDisputeBond = 27500 + Math.floor(Math.random() * 41250)
-			activeDisputes = Math.floor(Math.random() * 4) + 2 // 2-5 disputes
+			activeDisputes = Math.floor(Math.random() * 4) + 2
+			;({ currentRound, estimatedTotalRounds } = SCENARIO_ROUNDS[scenario])
 			break
 			
 		case DisputeBondScenario.HIGH_RISK:
-			// High risk bonds: 25-75% of threshold (68750-206250 REP)
 			largestDisputeBond = 68750 + Math.floor(Math.random() * 137500)
-			activeDisputes = Math.floor(Math.random() * 5) + 3 // 3-7 disputes
+			activeDisputes = Math.floor(Math.random() * 5) + 3
+			;({ currentRound, estimatedTotalRounds } = SCENARIO_ROUNDS[scenario])
 			break
 			
 		case DisputeBondScenario.ELEVATED_RISK:
-			// Extreme risk bonds: 75-98% of threshold (206250-269500 REP)
 			largestDisputeBond = 206250 + Math.floor(Math.random() * 63250)
-			activeDisputes = Math.floor(Math.random() * 8) + 4 // 4-11 disputes
+			activeDisputes = Math.floor(Math.random() * 8) + 4
+			;({ currentRound, estimatedTotalRounds } = SCENARIO_ROUNDS[scenario])
 			break
 	}
 
@@ -72,13 +85,12 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 	}>
 
 	if (activeDisputes > 0) {
-		// Generate realistic dispute details focused on the bond sizes
 		disputeDetails = Array.from({ length: Math.min(activeDisputes, 5) }, (_, i) => ({
 			marketId: `0x${Math.random().toString(16).substring(2, 42).padStart(40, '0')}`,
 			title: getDemoMarketTitle(i),
 			disputeBondSize: i === 0 ? largestDisputeBond : generateVariedBondSize(largestDisputeBond, scenario),
-			disputeRound: Math.floor(Math.random() * 3) + 1,
-			estimatedTotalRounds: null,
+			disputeRound: i === 0 ? currentRound : Math.floor(Math.random() * 3) + 1,
+			estimatedTotalRounds: i === 0 ? estimatedTotalRounds : null,
 			roundProgress: null,
 			daysRemaining: Math.floor(Math.random() * 6) + 1,
 		}))
@@ -86,37 +98,38 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 		disputeDetails = []
 	}
 
-	const now = new Date()
 	const forkThresholdPercent = (largestDisputeBond / FORK_THRESHOLD_REP) * 100
-	
-	// Determine risk level based on actual fork threshold percentage
-	if (forkThresholdPercent === 0) {
+	const roundProgress = activeDisputes > 0 && estimatedTotalRounds
+		? Math.round((currentRound / estimatedTotalRounds) * 1000) / 10
+		: activeDisputes > 0 ? null : 0
+
+	// Determine risk level from round progress
+	if (roundProgress === null) {
+		riskLevel = 'unknown'
+	} else if (roundProgress === 0) {
 		riskLevel = 'none'
-	} else if (forkThresholdPercent < 10) {
-		riskLevel = 'low'
-	} else if (forkThresholdPercent < 25) {
-		riskLevel = 'moderate'
-	} else if (forkThresholdPercent < 75) {
-		riskLevel = 'high'
-	} else {
+	} else if (roundProgress >= 75) {
 		riskLevel = 'critical'
+	} else if (roundProgress >= 50) {
+		riskLevel = 'high'
+	} else if (roundProgress >= 25) {
+		riskLevel = 'moderate'
+	} else {
+		riskLevel = 'low'
 	}
-	
-	// Use the actual calculated percentage
-	const riskPercentage = forkThresholdPercent
 
 	return {
-		lastRiskChange: now.toISOString(),
+		lastRiskChange: new Date().toISOString(),
 		blockNumber: Math.floor(Math.random() * 1000000) + 20000000,
 		riskLevel,
-		riskPercentage: Math.round(riskPercentage * 100) / 100,
+		riskPercentage: roundProgress,
 		metrics: {
 			largestDisputeBond,
 			forkThresholdPercent: Math.round(forkThresholdPercent * 100) / 100,
 			activeDisputes,
-			currentRound: disputeDetails.length > 0 ? disputeDetails[0].disputeRound : 0,
-			estimatedTotalRounds: null,
-			roundProgress: Math.round(forkThresholdPercent * 10) / 10,
+			currentRound,
+			estimatedTotalRounds,
+			roundProgress,
 			disputeDetails,
 		},
 		rpcInfo: {
@@ -136,13 +149,13 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 const generateVariedBondSize = (largestBond: number, scenario: DisputeBondScenario): number => {
 	switch (scenario) {
 		case DisputeBondScenario.LOW_RISK:
-			return Math.floor(largestBond * (0.2 + Math.random() * 0.6)) // 20%-80% of largest
+			return Math.floor(largestBond * (0.2 + Math.random() * 0.6))
 		case DisputeBondScenario.MODERATE_RISK:
-			return Math.floor(largestBond * (0.3 + Math.random() * 0.5)) // 30%-80% of largest
+			return Math.floor(largestBond * (0.3 + Math.random() * 0.5))
 		case DisputeBondScenario.HIGH_RISK:
-			return Math.floor(largestBond * (0.4 + Math.random() * 0.4)) // 40%-80% of largest
+			return Math.floor(largestBond * (0.4 + Math.random() * 0.4))
 		case DisputeBondScenario.ELEVATED_RISK:
-			return Math.floor(largestBond * (0.5 + Math.random() * 0.3)) // 50%-80% of largest
+			return Math.floor(largestBond * (0.5 + Math.random() * 0.3))
 		default:
 			return Math.floor(largestBond * 0.5)
 	}


### PR DESCRIPTION
## Problem

The fork gauge displayed `forkThresholdPercent` (bond ÷ threshold) as its primary signal. During the Artemis II dispute — round 7 of ~12 — the gauge showed **LOW (3.15%)** because exponential bond growth keeps the ratio tiny until the final rounds. The page CTA was screaming "THE FORK IS HERE!" while the meter said everything was fine.

Stakeholder feedback also flagged liability concerns with displaying a raw percentage that could be misinterpreted as a fork probability prediction.

## Solution

Replace the bond/threshold percentage with **round-based progress**: `currentRound / estimatedTotalRounds × 100`.

| | Before | After |
|---|---|---|
| **Signal** | bond ÷ threshold | current round ÷ estimated total |
| **Artemis II (rd 7/~12)** | 3.15% → LOW | 58% → HIGH |
| **Display** | `3.2%` | `HIGH` (risk label) |
| **Round shown** | `7` | `7/12` |

### Round projection

The script reads ALL participant bonds (not just the largest) to build a bond trajectory. It averages the growth factor from the last 3–4 rounds, then projects forward until the bond would exceed the fork threshold. If fewer than 3 rounds exist or the projection diverges (>30 rounds), `estimatedTotalRounds` is `null` and the gauge surfaces "PROJECTION UNAVAILABLE" instead of silently reading green.

### Why empirical projection, not the protocol max of 20 rounds

The whitepaper proves a worst case of 20 rounds (pure doubling each round). Real disputes grow slower because multiple outcomes dilute escalation. Using 20 as the ceiling would make round 7 of ~12 show as 35% (LOW) — the exact problem we are fixing. The empirical approach reflects the actual growth rate of the specific dispute.

### Risk labels

Risk level is computed once in the pipeline and consumed everywhere (gauge, stats panel). No independent recalculation in the UI.

| Level | Round Progress | Boundaries |
|---|---|---|
| NONE | 0% | No active disputes |
| LOW | <25% | Early dispute rounds |
| MODERATE | 25–50% | Mid-escalation |
| HIGH | 50–75% | Late-stage dispute |
| CRITICAL | ≥75% | Approaching fork threshold |
| UNKNOWN | projection unavailable | <3 rounds or diverging estimate |

## Changes

**Pipeline** (`calculate-fork-risk.ts`)
- Add `projectTotalRounds()` — projects total rounds from bond growth trajectory
- Read all participant bonds to build trajectory (was: highest-only)
- Derive `riskLevel` from `roundProgress` (25/50/75 boundaries)
- Null projection → `unknown` risk level instead of silent zero
- New output fields: `currentRound`, `estimatedTotalRounds`, `roundProgress`

**Types** (`gauge.ts`)
- Add new fields to `ForkRiskData` and dispute details
- `riskPercentage` and `roundProgress` now nullable

**Gauge** (`ForkGauge.tsx`)
- Remove non-linear stretch (`getVisualPercentage`) — round progress maps directly to arc fill
- Reads `riskLevel` from provider instead of computing independently
- Color lookup table keyed by risk level string

**Stats** (`ForkStats.tsx`)
- Reads `riskLevel` from provider instead of computing independently
- Replaces percentage display with risk label from pipeline
- Shows round count as `current/total` format
- Null projection → "PROJECTION UNAVAILABLE", round shows `N/?`

**Demo** (`demoDataGenerator.ts`)
- Hardcoded representative rounds per scenario (3/12, 7/12, 9/12, 11/12)
- Risk levels computed from round progress, not bond/threshold percentage

**Docs**
- `fork-monitoring-methodology.md` — Core Measurement, Round Projection, Risk Levels
- `fork-mechanics.md` — "What the Fork Monitor Observes"
- `technical-architecture.md` — Data Flow, Visual Scaling, Risk Calculation

## Verification

- ✅ Typecheck: 0 errors
- ✅ Lint: 0 new warnings
- ✅ Build: clean