### PR TITLE
fix: align docs and learn content with round-based fork meter

### DIFF
--- a/docs/fork-monitoring-methodology.md
+++ b/docs/fork-monitoring-methodology.md
@@ -94,7 +94,7 @@ The Augur v2 contract emits two event types used for discovery. Their argument p
 | `DisputeCrowdsourcerContribution` | universe | reporter | **market** | crowdsourcer |
 | `DisputeCrowdsourcerCompleted` | universe | **market** | crowdsourcer | — |
 
-`DisputeCrowdsourcerCreated` is **not emitted** by the Augur v2 contract. Discovery relies on Contribution events.
+`DisputeCrowdsourcerCreated` is also queried for discovery. Contribution events are the primary source; Created events provide additional coverage.
 
 ---
 

--- a/docs/technical-architecture.md
+++ b/docs/technical-architecture.md
@@ -33,8 +33,8 @@ Layout.astro (Base HTML shell)
 │   │   │   ├── ForkGauge.tsx (SVG visualization)
 │   │   │   ├── ForkStats.tsx (progressive disclosure)
 │   │   │   ├── ForkDisplay.tsx (layout)
-│   │   │   ├── ForkControls.tsx (demo mode)
-│   │   │   └── ForkDetailsCard.tsx (expanded metrics)
+│   │   │   ├── ForkDetailsCard.tsx (dialog with expanded metrics + ForkAsciiArt)
+│   │   │   └── ForkControls.tsx (demo mode, F2 toggle)
 │   │   ├── Intro.tsx (client:load)
 │   │   └── FeaturedBlogs.astro
 │   │       └── BlogPostCard.astro
@@ -89,7 +89,7 @@ Risk level colors for ForkGauge:
 --color-green-500   /* Gauge gradient stop */
 --color-yellow-400  /* MODERATE risk */
 --color-orange-400  /* HIGH risk */
---color-red-500     /* ELEVATED risk */
+--color-red-500     /* CRITICAL risk */
 ```
 
 ### Custom Utilities

--- a/src/content/learn/fork/disputes-and-bonds.mdx
+++ b/src/content/learn/fork/disputes-and-bonds.mdx
@@ -88,38 +88,40 @@ The 275,000 REP threshold was chosen as a balance:
 
 ## How Fork Risk is Calculated
 
-The fork meter shows a simple calculation:
+The fork meter tracks the dispute's progress through the escalation path:
 
 <ProseCard class="text-center">
-(Largest Dispute Bond ÷ 275,000 REP) × 100 = Fork Risk %
+(Current Round ÷ Estimated Total Rounds) × 100 = Fork Risk %
 </ProseCard>
 
 ### Understanding the Formula
 
-**Largest Dispute Bond**: This is the single largest bond currently active across all markets. Why track the largest? Because it determines how close we are to the fork threshold.
+**Current Round**: The highest dispute round that has been funded so far. Each round corresponds to a crowdsourcer — when someone fills the bond for round 3, the dispute is at round 3.
 
-**Example**: If the largest active dispute is 150,000 REP, the next challenger would need to post ~300,000 REP to dispute it—which exceeds 275,000 and triggers a fork immediately.
+**Estimated Total Rounds**: Projected from the bond growth trajectory. Since bonds grow exponentially each round, the script extrapolates how many more rounds it would take before the bond reaches the 275,000 REP fork threshold.
 
 ### Two Calculation Examples
 
 <ProseCard>
 **EXAMPLE 1: LOW RISK**
 
-Current largest dispute bond: **15,000 REP**
+Current dispute round: **3**
+Estimated total rounds: **~12**
 
-(15,000 ÷ 275,000) × 100 = **5.5% risk**
+(3 ÷ 12) × 100 = **25% risk**
 
-*Interpretation: Disputes are active but still far from fork. The next dispute would need ~30,000 REP.*
+*Interpretation: Early rounds. Bonds are still small relative to the fork threshold. Many more escalations needed before a fork is possible.*
 </ProseCard>
 
 <ProseCard>
 **EXAMPLE 2: HIGH RISK**
 
-Current largest dispute bond: **200,000 REP**
+Current dispute round: **9**
+Estimated total rounds: **~12**
 
-(200,000 ÷ 275,000) × 100 = **73% risk**
+(9 ÷ 12) × 100 = **75% risk**
 
-*Interpretation: Close to fork. The next dispute would need ~400,000 REP, exceeding the threshold. Fork is likely with one more escalation.*
+*Interpretation: Late-stage dispute. Only a few more rounds of escalation remain before the bond would reach the fork threshold.*
 </ProseCard>
 
 ## What Happens When Fork Conditions Are Met?
@@ -149,8 +151,8 @@ Once a dispute bond reaches or exceeds 275,000 REP:
 ## Key Takeaways
 
 - **Disputes escalate:** Each new dispute doubles the bond size (approximately)
-- **Forks are triggered mechanically:** When the largest bond hits 275,000 REP
-- **Risk is measurable:** The fork formula lets you calculate exactly how close we are
+- **Forks are triggered mechanically:** When the dispute bond hits 275,000 REP
+- **Risk is measurable:** The meter tracks how far through the escalation path the dispute has progressed
 - **Escalation is expensive:** High-stakes disputes require serious financial commitment
 - **Fork is ultimate resolution:** When community disagreement is severe, REP holders decide
 

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -35,24 +35,24 @@ Forks are Augur's ultimate security mechanism. They ensure that:
 
 ## How to Monitor Fork Risk
 
-The fork meter shows **how close we are to a fork** by tracking the largest dispute bond:
+The fork meter tracks **how far through the escalation path the largest dispute has progressed**:
 
 <ProseCard class="text-center">
 The Formula
 
-**(Largest Dispute Bond ÷ 275,000 REP) × 100 = Risk %**
+**(Current Dispute Round ÷ Estimated Total Rounds) × 100 = Risk %**
 </ProseCard>
 
-The percentage tells you how much of the way to fork we are:
+The percentage tells you how far along the path to a fork the dispute has reached:
 
 <ProseCard>
 | LEVEL | RANGE | WHAT IT MEANS |
 |-------|-------|--------------|
 | NO RISK | 0% | No disputes. Normal trading. |
-| LOW | 0-10% | Early disputes. Fork unlikely. |
-| MEDIUM | 10-25% | Serious disputes. Monitor closely. |
-| HIGH | 25-75% | Large bonds active. Fork possible. |
-| EXTREME | 75-100%+ | Fork imminent or triggered. |
+| LOW | &lt;25% | Early dispute rounds. Fork unlikely. |
+| MODERATE | 25-50% | Mid-escalation. Monitor closely. |
+| HIGH | 50-75% | Late-stage dispute. Fork possible. |
+| CRITICAL | ≥75% | Approaching fork threshold. |
 </ProseCard>
 
 ## What Happens If a Fork Occurs

--- a/src/content/learn/fork/what-to-do.mdx
+++ b/src/content/learn/fork/what-to-do.mdx
@@ -15,15 +15,15 @@ import ProseCard from '../../../components/ProseCard.astro'
 | LEVEL | SITUATION | YOUR ACTION |
 |-------|-----------|-------------|
 | No Risk (0%) | No disputes active | Trade normally. Check meter occasionally. |
-| Low (0-10%) | Early disputes | Identify which markets are disputed. Understand the disagreement. |
-| Medium (10-25%) | Disputes escalating | Calculate your exposure. Think about exit strategies if needed. |
-| High (25-75%) | Large bonds active | Monitor daily. Consider reducing exposure. Prepare for fork governance. |
-| Extreme (75%+) | Fork imminent | Take action now. Prepare to choose a fork. Engage with community. |
+| Low (&lt;25%) | Early disputes | Identify which markets are disputed. Understand the disagreement. |
+| Moderate (25-50%) | Disputes escalating | Calculate your exposure. Think about exit strategies if needed. |
+| High (50-75%) | Large bonds active | Monitor daily. Consider reducing exposure. Prepare for fork governance. |
+| Critical (≥75%) | Fork imminent | Take action now. Prepare to choose a fork. Engage with community. |
 </ProseCard>
 
-## High Risk (25-75%) — Take Action
+## High Risk (50-75%) — Take Action
 
-The gap to fork threshold is narrowing. Fork is increasingly likely with continued escalation.
+The dispute has passed the halfway point. Fork is increasingly likely with continued escalation.
 
 **What you should do:**
 
@@ -34,9 +34,9 @@ The gap to fork threshold is narrowing. Fork is increasingly likely with continu
 - **Avoid new large bets** — Don't enter high-risk markets during escalation
 - **Know your positions** — Understand exactly how a fork would affect you
 
-## Extreme Risk (75%+) — Fork Is Likely
+## Critical Risk (≥75%) — Fork Is Likely
 
-Fork threshold is nearly reached. A fork is imminent or may have been triggered. This is the highest-stakes scenario.
+The dispute is in its final rounds. A fork is imminent or may have been triggered. This is the highest-stakes scenario.
 
 **What you must do:**
 


### PR DESCRIPTION
## Problem

The fork meter was refactored from bond/threshold percentage to round-based progress in `122e9c5` (May 2026), but user-facing learn pages and some internal docs still described the old calculation.

The old formula `(largest dispute bond / 275,000 REP) × 100` was still shown on three `/learn/fork` pages, and the risk level table used stale labels (`MEDIUM`, `EXTREME`) and thresholds (`0-10%`, `10-25%`, `25-75%`, `75%+`).

## Changes

### Internal docs (2 files)

| File | Fix |
|------|-----|
| `docs/fork-monitoring-methodology.md` | `DisputeCrowdsourcerCreated` is actively queried by the script — removed false claim that it is "not emitted" by the contract |
| `docs/technical-architecture.md` | Fixed `ELEVATED` → `CRITICAL` risk label in CSS comment; updated component hierarchy to reflect `ForkDetailsCard` as dialog with `ForkAsciiArt` and `ForkControls` F2 toggle |

### User-facing `/learn/fork` pages (3 files)

| File | Fix |
|------|-----|
| `learn/fork/index.mdx` | Updated formula and risk level table to round progress (Low `<25%`, Moderate `25-50%`, High `50-75%`, Critical `≥75%`) |
| `learn/fork/disputes-and-bonds.mdx` | Rewrote "How Fork Risk is Calculated" section with round-based formula, explanation of current round / estimated total rounds, and updated calculation examples |
| `learn/fork/what-to-do.mdx` | Updated risk labels and thresholds in overview table and section headers |

## What was NOT changed

All whitepaper-accurate protocol mechanics are untouched:
- 275,000 REP fork threshold
- Bond escalation mechanics
- Fork process (60-day migration, child universes)
- Dispute bond formula
- Any protocol reference docs or whitepaper summaries

The only thing that changed is **how the meter is described** — reflecting the round-based progress calculation that the gauge actually uses.

## Verification

- ✅ `astro check` — 0 errors, 0 warnings
- ✅ `astro build` — clean