### PR TITLE
fix: correct Discord invite in migration guide

### DIFF
--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -84,7 +84,7 @@ Go to [the migration page](https://6.augurfork.eth.limo/#/migration?market=0x963
 
 Select the correct answer to the Augur market **"Will the Artemis II Mission successfully liftoff in the first week of April?"**. The correct answer is the one that will result in a more valuable REP token, which is usually the truthful answer.
 
-If you are unsure what to pick, research and debate on the [Augur Discord](https://discord.gg/qxdxRV8S). If you select the wrong answer, you should expect to receive a different REP token that has no value.
+If you are unsure what to pick, research and debate on the [Augur Discord](https://discord.com/invite/CdCSYk9GwH). If you select the wrong answer, you should expect to receive a different REP token that has no value.
 
 <Image src={step05} alt="Migration outcome selection" />
 
@@ -108,4 +108,4 @@ Refresh possible claims, check all boxes, then redeem fork disputes. This will g
 
 ---
 
-For additional help, visit the **moon-fork** channel on the [Augur Discord server](https://discord.gg/qxdxRV8S) or read [The Augur Fork Is Here](https://www.augur.net/blog/the-augur-fork-is-here/).
+For additional help, visit the **moon-fork** channel on the [Augur Discord server](https://discord.com/invite/CdCSYk9GwH) or read [The Augur Fork Is Here](https://www.augur.net/blog/the-augur-fork-is-here/).


### PR DESCRIPTION
Two instances of the old Discord link (`discord.gg/qxdxRV8S`) in the migration guide pointed to a dead invite. Updated both to `https://discord.com/invite/CdCSYk9GwH`.