### PR TITLE
ci: bump artifact actions to Node 24 versions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -55,7 +55,7 @@ jobs:
           CALCULATION_MODE: 'incremental'
 
       - name: Upload fork-risk data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fork-risk-data
           path: public/data/fork-risk.json
@@ -80,7 +80,7 @@ jobs:
         run: npm ci
 
       - name: Download fork-risk data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: fork-risk-data
           path: public/data
@@ -102,7 +102,7 @@ jobs:
           PUBLIC_GA_ID: ${{ vars.PUBLIC_GA_ID }}
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist/
 
@@ -118,7 +118,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: github-pages
 


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 → v8, `actions/upload-pages-artifact` v4 → v5 in `.github/workflows/build-and-deploy.yml`.
- Clears the Node 20 deprecation warnings currently shown on every workflow run.
- The `upload-pages-artifact` bump also resolves the transitive SHA-pinned `upload-artifact` warning, since v5 internally bundles `upload-artifact` v7.

## Why
GitHub forces Node 24 on **June 16, 2026** and removes Node 20 in fall 2026 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Node 24 became the default in `upload-artifact` v6 and `download-artifact` v7.

## Breaking-change review
- `download-artifact` v5 breaking only affects single-artifact-downloads **by ID**; we download by `name` — no impact.
- v6/v7 require runner ≥ 2.327.1 — GitHub-hosted `ubuntu-latest` satisfies this.
- `download-artifact` v8 errors on hash mismatch by default — security improvement.

## Test plan
- [x] Workflow runs successfully on this PR (build job).
- [x] No Node 20 deprecation warnings appear in the run annotations.
- [x] After merge: scheduled `risk-monitor` run and `deploy` job both succeed on main.