### PR TITLE
docs: fix drift after CSS-driven animation refactor and migration guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,6 +23,7 @@ Start here to find the right doc. Read deeper only when the task calls for it.
 | [Technical Architecture](technical-architecture.md) | React/TypeScript component hierarchy, state management (Context API), UI patterns, visual rendering |
 | [FAQ Feature](faq-feature.md) | FAQ page design, route, collapsible Q&A, landing page/footer integration |
 | [Blog Feature](blog-feature.md) | Blog frontmatter schema, MDX integration, RSS feed, Learn section |
+| [Migration Guide Feature](migration-guide-feature.md) | Moon Fork migration guide, step-by-step REP migration, MigrationGuideLayout |
 
 ## Whitepaper Summaries
 

--- a/docs/faq-feature.md
+++ b/docs/faq-feature.md
@@ -55,13 +55,13 @@ Collapsible Q&A styled to match the terminal aesthetic via `.faq-item` and `.faq
 
 ## Landing Page Integration
 
-`src/components/HeroBanner.astro` — FAQ is the **first item** in `#menu-items-container`:
+The FAQ page is linked from two places on the landing page:
 
-- **Copy:** `THE FORK IS HERE! OWN REP? ACT NOW.`
-- **Style:** `text-loud-foreground` + persistent `fx-glow` (always on, not hover-only) to distinguish urgency
-- **ID:** `id="first-menu-item"` for keyboard focus targeting after hero animation
+1. **`MigrationCta.tsx`** — a red-bordered CTA block that links to `/learn/fork/migration/` (the migration guide). This is rendered in the FAQ page itself as an inline call-to-action.
 
-Mission and Team links follow below.
+2. **`src/components/Footer.astro`** — FAQ link in the `>_ KB` section.
+
+The hero no longer contains a direct FAQ link. The original urgent hero item (`THE FORK IS HERE! OWN REP? ACT NOW.`) was removed when the hero was refactored to CSS-driven animation. The migration guide in `learn/fork/migration/` now serves as the primary entry point for fork/migration content.
 
 ## Footer Integration
 

--- a/docs/fork-monitoring-methodology.md
+++ b/docs/fork-monitoring-methodology.md
@@ -162,6 +162,7 @@ The UI displays round progress as a risk level:
 | Moderate | 25–50% | Mid-escalation |
 | High | 50–75% | Late-stage dispute |
 | Critical | ≥75% | Approaching fork threshold |
+| Unknown | null | Projection unavailable (fewer than 3 rounds or divergent growth) |
 
 These levels are display categories derived from round progress. The bond/threshold percentage is still computed and stored in the data, but the primary gauge signal and risk labels use round progress.
 

--- a/docs/migration-guide-feature.md
+++ b/docs/migration-guide-feature.md
@@ -1,0 +1,64 @@
+---
+title: Migration Guide Feature
+tags: [migration, feature, learn, fork]
+---
+
+# Migration Guide Feature
+
+> The Moon Fork migration guide: a step-by-step walkthrough for REP holders who must migrate before the deadline.
+
+## Overview
+
+The migration guide lives at `/learn/fork/migration/` and uses a dedicated **MigrationGuideLayout** with an urgent, red-coded header. It's part of the `learn` content collection but renders with a different layout than other learn articles.
+
+## Route & Files
+
+| Component | Location |
+|-----------|----------|
+| Content (MDX) | `src/content/learn/fork/migration.mdx` |
+| Layout | `src/layouts/MigrationGuideLayout.astro` |
+| Step images | `src/assets/migration/step-01.png` through `step-06.png` |
+| CTA component | `src/components/MigrationCta.tsx` |
+| Route handler | `src/pages/learn/[...slug].astro` (conditional layout switch) |
+
+## Layout Selection
+
+`src/pages/learn/[...slug].astro` checks `entry.slug` and routes to the appropriate layout:
+
+```astro
+{entry.slug === 'fork/migration' ? (
+  <MigrationGuideLayout title={title} description={description}>
+    <Content />
+  </MigrationGuideLayout>
+) : (
+  <LearnLayout title={title} description={description}>
+    <Content />
+  </LearnLayout>
+)}
+```
+
+## MigrationGuideLayout
+
+A dedicated layout distinct from [[technical-architecture]]'s standard LearnLayout:
+
+- **Header**: Red-bordered alert box with `CRITICAL · MIGRATION IMMINENT` eyebrow and deadline display (default: "AUGUST 1, 2026")
+- **Navigation**: Uses the same `LearnNavigation.tsx` sidebar with migration guide as the first/critical topic
+- **Prose**: Same typographic treatment as LearnLayout articles
+
+## MigrationCta Component
+
+`src/components/MigrationCta.tsx` — a reusable red-bordered CTA block that links to `/learn/fork/migration/` by default. Props:
+
+| Prop | Type | Default | Purpose |
+|------|------|---------|---------|
+| `href` | string | `/learn/fork/migration/` | Link target |
+| `eyebrow` | string | required | Small label above title |
+| `title` | string | required | Main CTA heading |
+| `description` | string | required | Body text |
+| `className` | string | `''` | Extra Tailwind classes |
+
+## Cross-References
+
+- [[technical-architecture]] — overall component hierarchy
+- [[fork-mechanics]] — what a fork is and why migration is needed
+- [[blog-feature]] — the content collection system

--- a/docs/technical-architecture.md
+++ b/docs/technical-architecture.md
@@ -20,22 +20,21 @@ The site is built with:
 ## Component Hierarchy
 
 ```
-Layout.astro (Base HTML shell)
+Layout.astro (Base HTML shell — toggles html.boot class for CSS-driven intro)
 ├── Header / Footer / SocialLinks (Astro components)
 ├── Pages
 │   ├── index.astro (Homepage)
-│   │   ├── HeroBanner.astro
+│   │   ├── Intro.tsx (client:load — CRT boot overlay, removes html.boot on complete)
+│   │   ├── HeroBanner.tsx (client:load — CSS-animated entrance via .hero-* classes)
 │   │   │   ├── PerspectiveGridTunnel.tsx (client:load)
-│   │   │   ├── Typewriter.tsx / TypewriterSequence.tsx (client:load)
-│   │   │   └── ScrollIndicator.tsx (client:load)
-│   │   ├── ForkMonitor.tsx (client:load — Fork Gauge island)
-│   │   │   ├── ForkDataProvider.tsx (data fetching)
-│   │   │   ├── ForkGauge.tsx (SVG visualization)
-│   │   │   ├── ForkStats.tsx (progressive disclosure)
-│   │   │   ├── ForkDisplay.tsx (layout)
-│   │   │   ├── ForkDetailsCard.tsx (dialog with expanded metrics + ForkAsciiArt)
-│   │   │   └── ForkControls.tsx (demo mode, F2 toggle)
-│   │   ├── Intro.tsx (client:load)
+│   │   │   ├── PageHeader.tsx (social links + back nav)
+│   │   │   └── ForkMonitor.tsx (client:load — Fork Gauge island)
+│   │   │       ├── ForkDataProvider.tsx (data fetching)
+│   │   │       ├── ForkGauge.tsx (SVG visualization)
+│   │   │       ├── ForkStats.tsx (progressive disclosure)
+│   │   │       ├── ForkDisplay.tsx (layout)
+│   │   │       ├── ForkDetailsCard.tsx (dialog with expanded metrics + ForkAsciiArt)
+│   │   │       └── ForkControls.tsx (demo mode, F2 toggle)
 │   │   └── FeaturedBlogs.astro
 │   │       └── BlogPostCard.astro
 │   ├── blog/index.astro → BlogPostCard.astro
@@ -44,8 +43,9 @@ Layout.astro (Base HTML shell)
 │   │   ├── BlogNavigation.tsx (client:load)
 │   │   ├── BlogCTA.tsx (client:load)
 │   │   └── SocialShareButtons.astro
-│   ├── learn/[...slug].astro → LearnLayout.astro
+│   ├── learn/[...slug].astro → LearnLayout.astro or MigrationGuideLayout.astro
 │   │   ├── ProseCard.astro
+│   │   ├── MigrationCta.tsx (fork/migration CTA block)
 │   │   └── LearnNavigation.tsx (client:load)
 │   ├── mission.astro → TimelineSection.astro
 │   └── team.astro → TeamCard.astro
@@ -53,8 +53,13 @@ Layout.astro (Base HTML shell)
 
 ## State Management
 
-### Nanostores (Global State)
-- `animationStore.ts` — tracks hero animation state across components
+### CSS-Driven Animation (Landing Page)
+The hero/intro animation sequence is CSS-driven — no JavaScript state machine. A synchronous `<script is:inline>` in **Layout.astro** toggles `html.boot` based on:
+- Whether the current page is the landing page (`pathname === basePath`)
+- `sessionStorage.getItem('skipIntro')` (set after first boot or skip)
+- `prefers-reduced-motion` media query
+
+When `.boot` is present, the CRT overlay (`#crt-overlay`) is shown and all hero entrance animations are suppressed via `html.boot .hero-* { animation: none; opacity: 0 }`. When **Intro.tsx** completes (or skip is pressed), it removes `.boot`, which triggers all CSS `animation` declarations from delay 0.
 
 ### React Context (Island-scoped)
 - `ForkDataProvider.tsx` — provides fork risk data to the gauge island
@@ -63,9 +68,10 @@ Layout.astro (Base HTML shell)
 ### Data Flow
 1. `ForkDataProvider` fetches `/data/fork-risk.json` on mount
 2. Primary gauge signal: `roundProgress` (current round / estimated total rounds × 100)
-3. Bond/threshold percentage still computed and stored, but used only for informational display
-4. Auto-refresh every 5 minutes
-5. `ForkMockProvider` wraps for demo scenarios
+3. `riskPercentage` may be `null` when the round projection is unavailable (fewer than 3 rounds or divergent growth) — the risk level becomes `unknown`
+4. Bond/threshold percentage still computed and stored, but used only for informational display
+5. Auto-refresh every 5 minutes
+6. `ForkMockProvider` wraps for demo scenarios
 
 **Data Source:** `fork-risk.json` is generated hourly by GitHub Actions. See [[fork-monitoring-pipeline]] for the monitoring workflow.
 
@@ -106,13 +112,13 @@ Risk level colors for ForkGauge:
 
 ```
 src/
+├── assets/           # Bundled images (migration step screenshots)
 ├── components/       # Astro + React components
 ├── content/          # MDX content collections (blog, learn)
-├── layouts/          # Layout.astro, BlogLayout.astro, LearnLayout.astro
+├── layouts/          # Layout.astro, BlogLayout.astro, LearnLayout.astro, MigrationGuideLayout.astro
 ├── lib/              # Shared utilities
 ├── pages/            # Astro file-based routing
 ├── providers/        # React context providers
-├── stores/           # Nanostores
 ├── styles/           # global.css (single source of truth for theme)
 ├── types/            # TypeScript type definitions
 └── utils/            # Helper functions
@@ -136,8 +142,8 @@ No non-linear stretching. The gauge is a straightforward half-circle arc where f
 
 ### Progressive Disclosure
 - **No disputes**: "System steady — No market disputes"
-- **Active disputes**: Dispute bond, threshold %, dispute round
-- **Demo mode**: Additional controls and current values
+- **Active disputes**: Est. time to fork, dispute bond (approximate), dispute round (current/~estimated), market title + address
+- **Unknown projection**: When round projection is unavailable, shows "PROJECTION UNAVAILABLE"
 
 ### Risk Calculation
 ```typescript


### PR DESCRIPTION
## Drift Fix

Docs review after `ec336ba` (CSS-driven intro/hero animation) and `63f1271` (Moon Fork migration guide).

### Changes

**`technical-architecture.md`** (high severity)
- Remove deleted `animationStore.ts` / `stores/` references
- Document CSS-driven `html.boot` animation mechanism (replaces Nanostores state machine)
- Add `MigrationGuideLayout.astro`, `MigrationCta.tsx`, `assets/` to component hierarchy and file structure
- Document nullable `riskPercentage` and `unknown` risk level
- Update progressive disclosure to match current ForkStats display (est. time to fork, ~bond, round display)

**`faq-feature.md`** (high severity)
- Remove description of deleted hero FAQ link (`THE FORK IS HERE!` menu item)
- Document current entry points: Footer KB section + MigrationCta component

**`fork-monitoring-methodology.md`** (low severity)
- Add `Unknown` risk level (null projection) to risk levels table

**`INDEX.md`** (medium severity)
- Add Migration Guide Feature entry to Architecture & UI section

**`migration-guide-feature.md`** (new)
- Document the Moon Fork migration guide feature: MigrationGuideLayout, MigrationCta, layout selection logic in the learn route handler