### PR TITLE
feat: ForkActiveCard helper for during-fork state

### DIFF
--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -64,6 +64,18 @@ interface ForkRiskData {
 		isHealthy: boolean
 		discrepancy?: string
 	}
+	forkActive?: {
+		forkingMarket: string
+		forkEndTime: number
+		forkReputationGoal: number
+		universeRepSupply: number
+		outcomes: Array<{
+			index: number
+			label: string
+			childUniverse: string | null
+			migratedRep: number
+		}>
+	}
 }
 
 /**
@@ -321,7 +333,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 
 			if (isForking) {
 				console.log('⚠️ UNIVERSE IS FORKING! Setting maximum risk level')
-				return getForkingResult(blockNumber, connection, forkThresholdRep)
+				return await getForkingResult(blockNumber, connection, forkThresholdRep, contracts.universe)
 			}
 
 			// Calculate key metrics
@@ -1061,7 +1073,100 @@ function determineRiskLevel(roundProgress: number | null): RiskLevel {
 	return 'low'
 }
 
-function getForkingResult(blockNumber: number, connection: RpcConnection, forkThresholdRep: number): ForkRiskData {
+const FORK_ACTIVE_UNIVERSE_ABI = [
+	'function getForkingMarket() view returns (address)',
+	'function getForkEndTime() view returns (uint256)',
+	'function getForkReputationGoal() view returns (uint256)',
+	'function getReputationToken() view returns (address)',
+	'function getChildUniverse(bytes32 parentPayoutDistributionHash) view returns (address)',
+]
+const FORK_ACTIVE_MARKET_ABI = [
+	'function getNumberOfOutcomes() view returns (uint256)',
+	'function getNumTicks() view returns (uint256)',
+]
+const FORK_ACTIVE_ERC20_ABI = [
+	'function totalSupply() view returns (uint256)',
+]
+
+function positionalLabel(index: number, numOutcomes: number): string {
+	if (numOutcomes === 3) {
+		return ['Invalid', 'No', 'Yes'][index] ?? `Outcome ${index}`
+	}
+	return index === 0 ? 'Invalid' : `Outcome ${index}`
+}
+
+async function fetchForkActiveDetails(
+	provider: ethers.JsonRpcProvider,
+	universe: ethers.Contract,
+): Promise<ForkRiskData['forkActive'] | undefined> {
+	try {
+		const u = new ethers.Contract(await universe.getAddress(), FORK_ACTIVE_UNIVERSE_ABI, provider)
+
+		const [forkingMarket, forkEndTimeRaw, forkRepGoalWei, repTokenAddr] = await Promise.all([
+			u.getForkingMarket(),
+			u.getForkEndTime(),
+			u.getForkReputationGoal(),
+			u.getReputationToken(),
+		])
+
+		const repToken = new ethers.Contract(repTokenAddr, FORK_ACTIVE_ERC20_ABI, provider)
+		const universeRepSupplyWei = await repToken.totalSupply()
+
+		const market = new ethers.Contract(forkingMarket, FORK_ACTIVE_MARKET_ABI, provider)
+		const [numOutcomesRaw, numTicksRaw] = await Promise.all([
+			market.getNumberOfOutcomes(),
+			market.getNumTicks(),
+		])
+		const numOutcomes = Number(numOutcomesRaw)
+		const numTicks = BigInt(numTicksRaw)
+
+		const outcomes = await Promise.all(
+			Array.from({ length: numOutcomes }, async (_, k) => {
+				const numerators = Array.from({ length: numOutcomes }, (_, j) => (j === k ? numTicks : 0n))
+				const payoutHash = ethers.keccak256(
+					ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [numerators]),
+				)
+				const childAddr: string = await u.getChildUniverse(payoutHash)
+				const isZero = !childAddr || /^0x0+$/i.test(childAddr)
+				let migratedRep = 0
+				let childRepLabel: string | null = null
+				if (!isZero) {
+					childRepLabel = childAddr
+					const childUniverse = new ethers.Contract(childAddr, FORK_ACTIVE_UNIVERSE_ABI, provider)
+					const childRepAddr = await childUniverse.getReputationToken()
+					const childRep = new ethers.Contract(childRepAddr, FORK_ACTIVE_ERC20_ABI, provider)
+					const supplyWei = await childRep.totalSupply()
+					migratedRep = Number(ethers.formatEther(supplyWei))
+				}
+				return {
+					index: k,
+					label: positionalLabel(k, numOutcomes),
+					childUniverse: childRepLabel,
+					migratedRep,
+				}
+			}),
+		)
+
+		return {
+			forkingMarket,
+			forkEndTime: Number(forkEndTimeRaw),
+			forkReputationGoal: Number(ethers.formatEther(forkRepGoalWei)),
+			universeRepSupply: Number(ethers.formatEther(universeRepSupplyWei)),
+			outcomes,
+		}
+	} catch (e) {
+		console.warn(`⚠️ Failed to fetch forkActive details: ${(e as Error).message}`)
+		return undefined
+	}
+}
+
+async function getForkingResult(
+	blockNumber: number,
+	connection: RpcConnection,
+	forkThresholdRep: number,
+	universe: ethers.Contract,
+): Promise<ForkRiskData> {
+		const forkActive = await fetchForkActiveDetails(connection.provider, universe)
 		return {
 			lastRiskChange: new Date().toISOString(),
 			blockNumber,
@@ -1095,6 +1200,7 @@ function getForkingResult(blockNumber: number, connection: RpcConnection, forkTh
 				forkThreshold: forkThresholdRep,
 			},
 			cacheValidation: { isHealthy: true },
+			forkActive,
 		}
 	}
 

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -315,7 +315,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 				)
 				forkThresholdRep = Number(ethers.formatEther(thresholdWei))
 				console.log(`Fork Threshold: ${forkThresholdRep} REP (from chain)`)
-			} catch (e) {
+			} catch (_e) {
 				console.warn(`⚠️ Failed to read fork threshold from chain, using fallback: ${forkThresholdRep} REP`)
 			}
 

--- a/scripts/probe-fork-state.ts
+++ b/scripts/probe-fork-state.ts
@@ -47,6 +47,12 @@ const MARKET_ABI = [
 	'function isFinalized() view returns (bool)',
 	'function getEndTime() view returns (uint256)',
 	'function getNumberOfOutcomes() view returns (uint256)',
+	'function getNumTicks() view returns (uint256)',
+]
+
+const ERC20_ABI = [
+	'function totalSupply() view returns (uint256)',
+	'function symbol() view returns (string)',
 ]
 
 const PARTICIPANT_ABI = [
@@ -89,6 +95,7 @@ async function describeUniverse(provider: ethers.JsonRpcProvider, address: strin
 	const forkingMarket = await safeCall('forkingMarket', () => u.getForkingMarket())
 	const forkEnd = await safeCall('forkEndTime', () => u.getForkEndTime())
 	const threshold = await safeCall('threshold', () => u.getDisputeThresholdForFork())
+	const repGoal = await safeCall('repGoal', () => u.getForkReputationGoal())
 	const repToken = await safeCall('repToken', () => u.getReputationToken())
 
 	console.log(`${prefix}  parent:        ${parent ?? '?'}`)
@@ -100,7 +107,17 @@ async function describeUniverse(provider: ethers.JsonRpcProvider, address: strin
 	if (threshold !== null) {
 		console.log(`${prefix}  threshold:     ${ethers.formatEther(threshold)} REP`)
 	}
+	if (repGoal !== null) {
+		console.log(`${prefix}  repGoal(>50%): ${ethers.formatEther(repGoal)} REP`)
+	}
 	console.log(`${prefix}  repToken:      ${repToken ?? '?'}`)
+	if (repToken && repToken !== ethers.ZeroAddress) {
+		const t = new ethers.Contract(repToken, ERC20_ABI, provider)
+		const supply = await safeCall('repToken.totalSupply', () => t.totalSupply())
+		if (supply !== null) {
+			console.log(`${prefix}  repSupply:     ${Number(ethers.formatEther(supply)).toLocaleString()} REP`)
+		}
+	}
 
 	// Try to follow to a winning child (only meaningful post-fork)
 	const winner = await safeCall('winningChild', () => u.getWinningChildUniverse())
@@ -139,6 +156,37 @@ async function describeMarket(provider: ethers.JsonRpcProvider, marketAddress: s
 
 	if (universe) {
 		await describeUniverse(provider, universe, 1)
+	}
+
+	const numTicks = await safeCall('numTicks', () => m.getNumTicks())
+	if (universe && numOutcomes !== null && numTicks !== null) {
+		const nOut = Number(numOutcomes)
+		const ticks = BigInt(numTicks)
+		console.log(`\n  Per-outcome child universes (numTicks=${ticks.toString()}):`)
+		const u = new ethers.Contract(universe, UNIVERSE_ABI, provider)
+		for (let k = 0; k < nOut; k++) {
+			const numerators: bigint[] = Array.from({ length: nOut }, (_, i) =>
+				i === k ? ticks : 0n,
+			)
+			const encoded = ethers.solidityPacked(Array(nOut).fill('uint256'), numerators)
+			const hash = ethers.keccak256(encoded)
+			const child = await safeCall(`getChildUniverse(${k})`, () => u.getChildUniverse(hash))
+			const label = `outcome[${k}] payout=[${numerators.join(',')}]`
+			if (!child || child === ethers.ZeroAddress) {
+				console.log(`    ${label} → child: 0x0 (not created)`)
+				continue
+			}
+			console.log(`    ${label} → child: ${child}`)
+			const childU = new ethers.Contract(child, UNIVERSE_ABI, provider)
+			const childRep = await safeCall('  child.repToken', () => childU.getReputationToken())
+			if (childRep && childRep !== ethers.ZeroAddress) {
+				const t = new ethers.Contract(childRep, ERC20_ABI, provider)
+				const supply = await safeCall('  child.totalSupply', () => t.totalSupply())
+				if (supply !== null) {
+					console.log(`      migrated REP: ${Number(ethers.formatEther(supply)).toLocaleString()}`)
+				}
+			}
+		}
 	}
 
 	if (numParticipants === null) return

--- a/src/components/ForkActiveCard.tsx
+++ b/src/components/ForkActiveCard.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from 'react'
+import { useForkData } from '../providers/ForkDataProvider'
+
+const OUTCOME_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F'] as const
+
+const formatRep = (n: number): string => Math.round(n).toLocaleString()
+
+const getCountdownParts = (endUnix: number, nowMs: number) => {
+	const secs = Math.max(0, endUnix - Math.floor(nowMs / 1000))
+	return {
+		d: Math.floor(secs / 86400),
+		h: Math.floor((secs % 86400) / 3600),
+		m: Math.floor((secs % 3600) / 60),
+		s: Math.floor(secs % 60),
+	}
+}
+
+const pad = (n: number, w = 2) => String(n).padStart(w, '0')
+
+export const ForkActiveCard = (): React.JSX.Element | null => {
+	const { rawData } = useForkData()
+	const fork = rawData.forkActive
+	const [now, setNow] = useState<number>(() => Date.now())
+
+	useEffect(() => {
+		const id = setInterval(() => setNow(Date.now()), 1000)
+		return () => clearInterval(id)
+	}, [])
+
+	if (!fork) return null
+
+	const totalMigrated = fork.outcomes.reduce((s, o) => s + o.migratedRep, 0)
+	const goalPercent = Math.min(100, (fork.forkReputationGoal / fork.universeRepSupply) * 100)
+	const unmigrated = Math.max(0, fork.universeRepSupply - totalMigrated)
+
+	// Each segment is sized as fraction of universe supply (not of migrated total),
+	// so the bar grows as migration progresses and the goal tick remains anchored.
+	// Opacity is ranked by migrated REP — brightest for the leading universe.
+	const SHADES = ['#2ae7a8', '#1f9d72', '#15614a', '#0e3d30', '#0a2620', '#071916']
+	const rankByMigrated = [...fork.outcomes]
+		.map((o, i) => ({ i, m: o.migratedRep }))
+		.sort((a, b) => b.m - a.m)
+		.reduce<Record<number, number>>((acc, { i }, rank) => {
+			acc[i] = rank
+			return acc
+		}, {})
+	const segments = fork.outcomes.map((o, i) => ({
+		...o,
+		letter: OUTCOME_LETTERS[i] ?? '?',
+		widthPercent: (o.migratedRep / fork.universeRepSupply) * 100,
+		color: SHADES[rankByMigrated[i] ?? 0] ?? SHADES[SHADES.length - 1],
+	}))
+
+	const t = getCountdownParts(fork.forkEndTime, now)
+	const timerCells: Array<{ value: string; label: string }> = [
+		{ value: pad(t.d, 2), label: 'DAYS' },
+		{ value: pad(t.h), label: 'HRS' },
+		{ value: pad(t.m), label: 'MIN' },
+		{ value: pad(t.s), label: 'SEC' },
+	]
+
+	return (
+		<div className="w-full max-w-xl mx-auto px-4 text-left font-mono text-sm">
+			<div className="flex justify-between items-center mb-4">
+				<div className="text-xs uppercase tracking-widest text-primary">FORK // ACTIVE</div>
+				<a
+					href="/learn/fork/migration/"
+					title="How to migrate REP"
+					aria-label="How to migrate REP"
+					className="inline-flex items-center gap-1.5 text-xs uppercase tracking-widest text-muted-foreground hover:text-primary transition"
+				>
+					<span className="inline-flex items-center justify-center w-5 h-5 tracking-tight leading-none rounded-full border border-current">?</span>
+					help
+				</a>
+			</div>
+
+			<div
+				className="mb-2 bg-foreground/30"
+				style={{
+					clipPath: `polygon(14px 0, 100% 0, 100% calc(100% - 14px), calc(100% - 14px) 100%, 0 100%, 0 14px)`,
+				}}
+			>
+				<div className="flex gap-px p-px">
+					{timerCells.map((cell, i) => {
+						const isFirst = i === 0
+						const isLast = i === timerCells.length - 1
+						const cellClip = isFirst
+							? 'polygon(14px 0, 100% 0, 100% 100%, 0 100%, 0 14px)'
+							: isLast
+								? 'polygon(0 0, 100% 0, 100% calc(100% - 14px), calc(100% - 14px) 100%, 0 100%)'
+								: undefined
+						return (
+							<div
+								key={cell.label}
+								className="flex-1 flex flex-col items-center justify-center py-3 bg-background"
+								style={{
+									clipPath: cellClip,
+									// backgroundImage: 'linear-gradient(rgba(42,231,168,0.04), rgba(42,231,168,0.04))',
+								}}
+							>
+								<div className="text-3xl font-display text-primary tabular-nums leading-none">
+									{cell.value}
+								</div>
+								<div className="text-[10px] uppercase tracking-widest text-muted-foreground mt-1">
+									{cell.label}
+								</div>
+							</div>
+						)
+					})}
+				</div>
+			</div>
+			<div className="text-center text-muted-foreground mb-6">
+				remaining in 60-day migration window
+			</div>
+
+			<div className="mb-4 pt-5">
+				<div className="relative">
+					<div
+						className="relative h-6 w-full mb-1 overflow-hidden"
+						style={{
+							backgroundImage:
+								'repeating-linear-gradient(-45deg, rgba(255,255,255,0.04) 0 4px, transparent 4px 8px)',
+							backgroundColor: 'rgba(255,255,255,0.02)',
+						}}
+					>
+						{segments.reduce<{ nodes: React.ReactNode[]; offset: number }>(
+							(acc, seg) => {
+								acc.nodes.push(
+									<div
+										key={seg.index}
+										className="absolute top-0 bottom-0 border-r border-background/30 text-[10px] text-background flex items-center justify-center"
+										style={{ left: `${acc.offset}%`, width: `${seg.widthPercent}%`, backgroundColor: seg.color }}
+										title={`${seg.label}: ${formatRep(seg.migratedRep)} REP`}
+									>
+										{seg.widthPercent > 3 ? seg.letter : ''}
+									</div>,
+								)
+								acc.offset += seg.widthPercent
+								return acc
+							},
+							{ nodes: [], offset: 0 },
+						).nodes}
+					</div>
+
+					<div
+						className="pointer-events-none absolute -top-2 bottom-1 border-l border-dashed border-primary"
+						style={{ left: `${goalPercent}%` }}
+						title={`Early-resolution goal: ${formatRep(fork.forkReputationGoal)} REP`}
+					>
+						<div className="absolute -top-4 -translate-x-1/2 text-[10px] text-primary whitespace-nowrap">
+							▼ goal
+						</div>
+					</div>
+				</div>
+
+				<div className="flex justify-between text-[10px] text-muted-foreground mb-4">
+					<span>0</span>
+					<span>{formatRep(fork.universeRepSupply)} REP</span>
+				</div>
+
+				<ul className="flex flex-wrap justify-center gap-x-3 gap-y-1 mb-3 text-xs text-muted-foreground">
+					{segments.map(seg => (
+						<li key={seg.index} className="tabular-nums flex items-center gap-1.5">
+							<span
+								className="inline-block w-2.5 h-2.5"
+								style={{ backgroundColor: seg.color }}
+							/>
+							<span className="text-primary">{seg.letter}</span>
+							{seg.label} ({seg.widthPercent.toFixed(1)}%)
+						</li>
+					))}
+				</ul>
+
+				<div className="text-xs text-center text-muted-foreground">
+					{((unmigrated / fork.universeRepSupply) * 100).toFixed(1)}% unmigrated
+				</div>
+			</div>
+
+		</div>
+	)
+}
+
+export default ForkActiveCard

--- a/src/components/ForkActiveCard.tsx
+++ b/src/components/ForkActiveCard.tsx
@@ -62,7 +62,7 @@ export const ForkActiveCard = (): React.JSX.Element | null => {
 	return (
 		<div className="w-full max-w-xl mx-auto px-4 text-left font-mono text-sm">
 			<div className="flex justify-between items-center mb-4">
-				<div className="text-xs uppercase tracking-widest text-primary">FORK // ACTIVE</div>
+				<div className="text-xs uppercase tracking-widest text-primary">{"FORK // ACTIVE"}</div>
 				<a
 					href="/learn/fork/migration/"
 					title="How to migrate REP"

--- a/src/components/ForkControls.tsx
+++ b/src/components/ForkControls.tsx
@@ -108,6 +108,38 @@ export const ForkControls = (): React.JSX.Element | null => {
 				>
 					Extreme Risk (75%+)
 				</button>
+
+				<button
+					type="button"
+					onClick={() => generateScenario(DisputeBondScenario.ACTIVE_FORK)}
+					className="block w-full text-left text-xs bg-purple-900/30 hover:bg-purple-900/40 px-2 py-1 rounded"
+				>
+					Active Fork — Early (~30%)
+				</button>
+
+				<button
+					type="button"
+					onClick={() => generateScenario(DisputeBondScenario.ACTIVE_FORK_MID)}
+					className="block w-full text-left text-xs bg-purple-900/30 hover:bg-purple-900/40 px-2 py-1 rounded"
+				>
+					Active Fork — Mid (~57%)
+				</button>
+
+				<button
+					type="button"
+					onClick={() => generateScenario(DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL)}
+					className="block w-full text-left text-xs bg-purple-900/30 hover:bg-purple-900/40 px-2 py-1 rounded"
+				>
+					Active Fork — Near Goal (~86%)
+				</button>
+
+				<button
+					type="button"
+					onClick={() => generateScenario(DisputeBondScenario.ACTIVE_FORK_RESOLVED)}
+					className="block w-full text-left text-xs bg-purple-900/40 hover:bg-purple-900/50 px-2 py-1 rounded"
+				>
+					Active Fork — Resolved (Yes &gt; goal)
+				</button>
 			</div>
 
 			<div className="mt-3 text-xs text-muted-foreground">

--- a/src/components/ForkDisplay.tsx
+++ b/src/components/ForkDisplay.tsx
@@ -3,6 +3,7 @@ import { ForkGauge } from './ForkGauge'
 import { ForkStats } from './ForkStats'
 import { ForkControls } from './ForkControls'
 import { ForkDetailsCard } from './ForkDetailsCard'
+import { ForkActiveCard } from './ForkActiveCard'
 import { useForkData } from '../providers/ForkDataProvider'
 
 // Helper function to format timestamps as relative time
@@ -25,7 +26,8 @@ function formatRelativeTime(isoTimestamp: string): string {
 }
 
 const ForkDisplay: React.FC = () => {
-  const { gaugeData, riskLevel, lastUpdated, isLoading, error } = useForkData()
+  const { gaugeData, riskLevel, lastUpdated, isLoading, error, rawData } = useForkData()
+  const isForking = rawData.metrics.disputeDetails[0]?.marketId === 'FORKING'
 
   return (
     <>
@@ -34,18 +36,24 @@ const ForkDisplay: React.FC = () => {
 
         {error && <div className="mb-4 text-orange-400">Warning: {error}</div>}
 
-        {/* Gauge with Details Card - ForkDetailsCard wraps the gauge */}
-        <ForkDetailsCard gauge={<ForkGauge percentage={gaugeData.percentage} riskLevel={riskLevel.level.toLowerCase()} />} />
+        {isForking ? (
+          <ForkActiveCard />
+        ) : (
+          <>
+            {/* Gauge with Details Card - ForkDetailsCard wraps the gauge */}
+            <ForkDetailsCard gauge={<ForkGauge percentage={gaugeData.percentage} riskLevel={riskLevel.level.toLowerCase()} />} />
 
-        <ForkStats />
+            <ForkStats />
 
-        <button
-          type="button"
-          className="text-sm cursor-help text-center text-muted-foreground hover:underline hover:text-foreground focus:underline focus:text-foreground underline-offset-2 outline-none"
-          title={`Last changed: ${formatRelativeTime(lastUpdated)}`}
-        >
-          <span>* levels are monitored hourly</span>
-        </button>
+            <button
+              type="button"
+              className="text-sm cursor-help text-center text-muted-foreground hover:underline hover:text-foreground focus:underline focus:text-foreground underline-offset-2 outline-none"
+              title={`Last changed: ${formatRelativeTime(lastUpdated)}`}
+            >
+              <span>* levels are monitored hourly</span>
+            </button>
+          </>
+        )}
       </div>
 
       {/* Demo overlay - only visible in development */}

--- a/src/types/gauge.ts
+++ b/src/types/gauge.ts
@@ -42,6 +42,18 @@ export interface ForkRiskData {
 		isHealthy: boolean
 		discrepancy?: string
 	}
+	forkActive?: {
+		forkingMarket: string
+		forkEndTime: number
+		forkReputationGoal: number
+		universeRepSupply: number
+		outcomes: Array<{
+			index: number
+			label: string
+			childUniverse: string | null
+			migratedRep: number
+		}>
+	}
 	error?: string
 }
 

--- a/src/utils/demoDataGenerator.ts
+++ b/src/utils/demoDataGenerator.ts
@@ -9,13 +9,17 @@ const FORK_THRESHOLD_REP = 275000 // 2.5% of 11 million REP
 export enum DisputeBondScenario {
 	NO_DISPUTES = 'no_disputes',
 	LOW_RISK = 'low_risk',
-	MODERATE_RISK = 'moderate_risk', 
+	MODERATE_RISK = 'moderate_risk',
 	HIGH_RISK = 'high_risk',
-	ELEVATED_RISK = 'elevated_risk'
+	ELEVATED_RISK = 'elevated_risk',
+	ACTIVE_FORK = 'active_fork',
+	ACTIVE_FORK_MID = 'active_fork_mid',
+	ACTIVE_FORK_NEAR_GOAL = 'active_fork_near_goal',
+	ACTIVE_FORK_RESOLVED = 'active_fork_resolved'
 }
 
 // Representative round data per scenario
-const SCENARIO_ROUNDS: Record<Exclude<DisputeBondScenario, DisputeBondScenario.NO_DISPUTES>, {
+const SCENARIO_ROUNDS: Record<Exclude<DisputeBondScenario, DisputeBondScenario.NO_DISPUTES | DisputeBondScenario.ACTIVE_FORK | DisputeBondScenario.ACTIVE_FORK_MID | DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL | DisputeBondScenario.ACTIVE_FORK_RESOLVED>, {
 	currentRound: number
 	estimatedTotalRounds: number
 }> = {
@@ -33,6 +37,15 @@ export const generateDemoForkRiskData = (scenario: DisputeBondScenario): ForkRis
 	// Only allow demo data generation in development
 	if (import.meta.env.PROD) {
 		throw new Error('Demo data generation is only available in development mode')
+	}
+
+	if (
+		scenario === DisputeBondScenario.ACTIVE_FORK ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_MID ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_RESOLVED
+	) {
+		return generateActiveForkDemo(scenario)
 	}
 
 	let largestDisputeBond: number
@@ -177,6 +190,80 @@ const getDemoMarketTitle = (index: number): string => {
 	]
 	
 	return titles[index % titles.length]
+}
+
+// Moon Fork active-fork simulation. Numbers approximate the discovery
+// snapshot from probe-fork-state.ts: 8.17M REP universe supply, ~50%
+// early-resolution goal, three outcomes with partial migration.
+const ACTIVE_FORK_MIGRATIONS: Record<
+	DisputeBondScenario.ACTIVE_FORK | DisputeBondScenario.ACTIVE_FORK_MID | DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL | DisputeBondScenario.ACTIVE_FORK_RESOLVED,
+	{ invalid: number; no: number; yes: number; daysRemaining: number }
+> = {
+	[DisputeBondScenario.ACTIVE_FORK]: { invalid: 87_002, no: 892_341, yes: 1_604_228, daysRemaining: 53 },
+	[DisputeBondScenario.ACTIVE_FORK_MID]: { invalid: 210_500, no: 1_870_000, yes: 2_540_000, daysRemaining: 38 },
+	[DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL]: { invalid: 312_000, no: 1_420_000, yes: 5_310_000, daysRemaining: 21 },
+	[DisputeBondScenario.ACTIVE_FORK_RESOLVED]: { invalid: 198_000, no: 940_000, yes: 5_620_000, daysRemaining: 12 },
+}
+
+const generateActiveForkDemo = (
+	scenario:
+		| DisputeBondScenario.ACTIVE_FORK
+		| DisputeBondScenario.ACTIVE_FORK_MID
+		| DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL
+		| DisputeBondScenario.ACTIVE_FORK_RESOLVED = DisputeBondScenario.ACTIVE_FORK
+): ForkRiskData => {
+	const universeRepSupply = 8_174_577
+	const forkReputationGoal = 5_497_186
+	const forkThreshold = 274_859
+	const { invalid, no, yes, daysRemaining } = ACTIVE_FORK_MIGRATIONS[scenario]
+	const forkEndTime = Math.floor(Date.now() / 1000) + daysRemaining * 24 * 60 * 60 + 14 * 60 * 60
+
+	const outcomes = [
+		{ index: 0, label: 'Invalid', childUniverse: '0xinvalid000000000000000000000000000000000', migratedRep: invalid },
+		{ index: 1, label: 'No', childUniverse: '0xno0000000000000000000000000000000000000000', migratedRep: no },
+		{ index: 2, label: 'Yes', childUniverse: '0xyes000000000000000000000000000000000000000', migratedRep: yes },
+	]
+
+	return {
+		lastRiskChange: new Date().toISOString(),
+		blockNumber: 25_185_608,
+		riskLevel: 'critical',
+		riskPercentage: 100,
+		metrics: {
+			largestDisputeBond: forkThreshold,
+			forkThresholdPercent: 100,
+			activeDisputes: 0,
+			currentRound: 99,
+			estimatedTotalRounds: null,
+			roundProgress: 100,
+			disputeDetails: [
+				{
+					marketId: 'FORKING',
+					title: 'Universe is currently forking',
+					disputeBondSize: forkThreshold,
+					disputeRound: 99,
+					estimatedTotalRounds: null,
+					roundProgress: 100,
+					weeksRemaining: 0,
+				},
+			],
+		},
+		rpcInfo: {
+			endpoint: 'Demo Mode - Active Fork Simulation',
+			latency: 120,
+			fallbacksAttempted: 0,
+		},
+		calculation: {
+			forkThreshold,
+		},
+		forkActive: {
+			forkingMarket: '0x963eed85778cc23e2d4636cd4f29eecdf9827e9e',
+			forkEndTime,
+			forkReputationGoal,
+			universeRepSupply,
+			outcomes,
+		},
+	}
 }
 
 // Scenario generator functions (development only)


### PR DESCRIPTION
## Summary

- Adds `ForkActiveCard` — a borderless during-fork helper that replaces the pre-fork escalation gauge once `universe.isForking()` flips true (sentinel: `disputeDetails[0].marketId === 'FORKING'`).
- Wires `scripts/calculate-fork-risk.ts` `getForkingResult()` to read the on-chain fork-active fields and emit a new `forkActive` block in `fork-risk.json`.
- Demo wiring (F2 in dev): four Moon Fork scenarios — Early / Mid / Near Goal / Resolved — for testing the card visually before a real fork.

## What the card shows

- **Digital countdown** (D / H / M / S boxed cells with diagonal cuts) to `forkEndTime`, ticking 1s locally — `forkEndTime` is absolute Unix, so it survives pipeline refreshes.
- **Single stacked bar** of per-outcome migrated REP, scaled to *universe REP supply* (not migration total) so the bar grows as migration progresses and the goal tick stays anchored.
- **Ranked shades** — brightest segment is the migration leader.
- **Dashed `▼ goal` tick** at `forkReputationGoal / universeRepSupply` (>50% early-resolution threshold).
- **Outcome legend** one-liner: `■ A Invalid (X%)  ■ B No (Y%)  ■ C Yes (Z%)`.
- **Help** link (top-right, dim) to `/learn/fork/migration/`.

## Pipeline change

`calculate-fork-risk.ts` `getForkingResult()` is now async and calls a new `fetchForkActiveDetails(provider, universe)` helper which:

1. Reads `getForkingMarket()` / `getForkEndTime()` / `getForkReputationGoal()` / universe REP `totalSupply()` (parallel).
2. Reads `getNumberOfOutcomes()` + `getNumTicks()` from the forking market.
3. For each outcome `k`: builds payout numerator vector, computes `keccak256(AbiCoder.encode(['uint256[]'], [numerators]))`, calls `universe.getChildUniverse(hash)`, and reads `child.getReputationToken().totalSupply()` for migrated REP.

Outcome labels are positional (3-outcome → `Invalid / No / Yes`; otherwise → `Invalid / Outcome N`). This helper is not a migration tool — it's a visibility surface. The pipeline emits no extra cost when not forking; on-chain reads only happen inside the `isForking` branch.

ABI methods not in `contracts/augur-abis.json` are declared inline as `FORK_ACTIVE_*_ABI` constants.

## Discovery basis

`scripts/probe-fork-state.ts` was extended in the same pass to enumerate per-outcome `getChildUniverse` and read `getForkReputationGoal` + REP `totalSupply` across the universe tree, confirming:
- Children are lazily deployed at fork init — `0x0` for all outcomes pre-fork.
- `getForkReputationGoal()` and universe `totalSupply()` are always readable.
- Moon Fork universe sits at 8.17M REP (not 11M genesis) — partial migration is the norm.

Full notes: `spaces/lituus/wiki/fork-active-data.md`.

## Test plan

- [x] `bun dev` → press **F2** → click each Active Fork scenario; card renders with correct numbers and the bar/goal/legend stay in sync.
- [x] `bunx astro check` passes (currently 0 errors / 0 warnings).
- [x] Manual deploy to CF demo worker (`bun run deploy`) with a hand-crafted `public/data/fork-risk.json` containing `forkActive` confirms end-to-end rendering — already verified at `tease.bytebros.workers.dev`.
- [ ] When a real fork occurs, `calculate-fork-risk.ts` populates `forkActive` from chain reads and the live site swaps automatically.