### PR TITLE
fix: correct child universe lookup in fork risk script

### DIFF
--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -1086,13 +1086,24 @@ const FORK_ACTIVE_MARKET_ABI = [
 ]
 const FORK_ACTIVE_ERC20_ABI = [
 	'function totalSupply() view returns (uint256)',
+	'function symbol() view returns (string)',
 ]
 
 function positionalLabel(index: number, numOutcomes: number): string {
-	if (numOutcomes === 3) {
-		return ['Invalid', 'No', 'Yes'][index] ?? `Outcome ${index}`
-	}
-	return index === 0 ? 'Invalid' : `Outcome ${index}`
+	// Fallback label — actual outcome names are market-specific and
+	// derived from the child universe's REP token symbol (e.g. REPv2_Yes_1).
+	if (index === 0) return 'Invalid'
+	return `Outcome ${index}`
+}
+
+/**
+ * Parse outcome label from REP token symbol.
+ * Augur V2 child universe REP tokens follow: REPv2_<Label>_<Index>
+ * e.g. "REPv2_Yes_1" → "Yes"
+ */
+function labelFromTokenSymbol(symbol: string): string | null {
+	const match = symbol.match(/^REPv2_(.+)_(\d+)$/)
+	return match ? match[1] : null
 }
 
 async function fetchForkActiveDetails(
@@ -1123,24 +1134,36 @@ async function fetchForkActiveDetails(
 		const outcomes = await Promise.all(
 			Array.from({ length: numOutcomes }, async (_, k) => {
 				const numerators = Array.from({ length: numOutcomes }, (_, j) => (j === k ? numTicks : 0n))
+				// Augur V2 uses keccak256(abi.encodePacked(numerators...)) — each element
+				// packed as a raw uint256, no length prefix. This differs from
+				// keccak256(abi.encode(uint256[])) which includes offset + length.
+				const packedTypes = Array.from({ length: numOutcomes }, () => 'uint256')
 				const payoutHash = ethers.keccak256(
-					ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [numerators]),
+					ethers.solidityPacked(packedTypes, numerators),
 				)
 				const childAddr: string = await u.getChildUniverse(payoutHash)
 				const isZero = !childAddr || /^0x0+$/i.test(childAddr)
 				let migratedRep = 0
 				let childRepLabel: string | null = null
+				let label = positionalLabel(k, numOutcomes)
 				if (!isZero) {
 					childRepLabel = childAddr
 					const childUniverse = new ethers.Contract(childAddr, FORK_ACTIVE_UNIVERSE_ABI, provider)
 					const childRepAddr = await childUniverse.getReputationToken()
 					const childRep = new ethers.Contract(childRepAddr, FORK_ACTIVE_ERC20_ABI, provider)
-					const supplyWei = await childRep.totalSupply()
+					const [supplyWei, symbol] = await Promise.all([
+						childRep.totalSupply(),
+						childRep.symbol().catch(() => null as string | null),
+					])
 					migratedRep = Number(ethers.formatEther(supplyWei))
+					if (symbol) {
+						const parsed = labelFromTokenSymbol(symbol)
+						if (parsed) label = parsed
+					}
 				}
 				return {
 					index: k,
-					label: positionalLabel(k, numOutcomes),
+					label,
 					childUniverse: childRepLabel,
 					migratedRep,
 				}


### PR DESCRIPTION
## Problem

`fetchForkActiveDetails` in `calculate-fork-risk.ts` was computing the payout distribution hash incorrectly, causing `getChildUniverse(hash)` to return `address(0)` for all fork outcomes. This meant `fork-risk.json` always showed `migratedRep: 0` and `childUniverse: null` for every outcome — no migration data was flowing to the UI.

## Root Cause

**Two bugs:**

1. **Wrong hash encoding** — Used `keccak256(abi.encode(uint256[]))` which includes an offset + length prefix. Augur V2 actually uses `keccak256(abi.encodePacked(uint256, uint256, ...))` — raw packed uint256 values with no prefix.

2. **Wrong outcome labels** — Hardcoded `[Invalid, No, Yes]` for 3-outcome markets, but the actual mapping is market-specific (this fork has Yes at index 1, not 2).

## Fix

- Changed hash computation to `ethers.solidityPacked()` (which matches Solidity's `abi.encodePacked`)
- Outcome labels now read from the child universe's REP token symbol (e.g. `REPv2_Yes_1` → `"Yes"`) with a positional fallback

## Verification

Ran `npm run build:fork-data` against mainnet:

```
Before:
  [0] Invalid    child=null    migrated=0.0 REP
  [1] No         child=null    migrated=0.0 REP
  [2] Yes        child=null    migrated=0.0 REP

After:
  [0] Invalid    child=null                                             migrated=0.0 REP
  [1] Yes        child=0x281171519Fb41540528398d8ED3EA257f0F32A9f       migrated=2,793,590.9 REP
  [2] Outcome 2  child=null                                             migrated=0.0 REP
```

- [x] `npm run build:fork-data` produces correct data
- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] Site build passes (`npm run build`)
- [x] Only `scripts/calculate-fork-risk.ts` modified