### PR TITLE
Remove Telegram links

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -44,11 +44,6 @@ import { withBase } from "../lib/utils";
                 DISCORD
               </Button>
             </li>
-            <li>
-              <Button variant="link" href="https://t.me/augurlituus">
-                TELEGRAM
-              </Button>
-            </li>
           </ul>
         </div>
         <!-- Column 3: REP -->

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -224,10 +224,6 @@ import { withBase } from "../lib/utils";
                 DISCORD
               </a>
               <span class="text-muted-foreground">•</span>
-              <a href="https://t.me/augurlituus" class="text-loud-foreground hover:text-primary transition-colors">
-                TELEGRAM
-              </a>
-              <span class="text-muted-foreground">•</span>
               <a href="https://github.com/AugurProject/" class="text-loud-foreground hover:text-primary transition-colors">
                 GITHUB
               </a>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -172,10 +172,6 @@ import { withBase } from "../lib/utils";
                 DISCORD
               </a>
               <span class="text-muted-foreground">•</span>
-              <a href="https://t.me/augurlituus" class="text-loud-foreground hover:text-primary transition-colors">
-                TELEGRAM
-              </a>
-              <span class="text-muted-foreground">•</span>
               <a href="https://github.com/AugurProject/" class="text-loud-foreground hover:text-primary transition-colors">
                 GITHUB
               </a>


### PR DESCRIPTION
## Summary

- Removes the Telegram (`t.me/augurlituus`) link from the footer social list
- Removes the Telegram link and its bullet separator from the contact section in `/terms` and `/privacy`

## Test plan

- [ ] Footer no longer shows a TELEGRAM entry under SOCIAL
- [ ] Terms of Service contact links show DISCORD and GITHUB only
- [ ] Privacy Policy contact links show DISCORD and GITHUB only