### PR TITLE
Update mission timeline with Moon Fork escalation + migration

### DIFF
--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -117,11 +117,31 @@ import { withBase } from "../lib/utils";
             <p>The escalation game is underway, with REP staked on competing outcomes over multiple rounds. A 2-month migration window will open in June where all REP holders must migrate their tokens 1:1 into the new universe. The fork demonstrates an oracle security model where dishonest positions lose capital and honest positions profit — truth enforced by economic incentives, not centralized actors.</p>
           </TimelineSection>
 
+          <TimelineSection title="Escalation Game" date="May 16, 2026">
+            <h3>Phase 1: Dispute in Progress</h3>
+            <p>The fork's first phase—the <strong>Escalation Game</strong>—ran through April and May, with REP staked on competing outcomes across successive rounds. Status at the midpoint:</p>
+            <ul>
+              <li><strong>Round 5 of 8:</strong> stakes double each round, escalating toward a fork threshold of 2.5% of REP supply</li>
+              <li><strong>Carried to the fork:</strong> Micah Zoltu staked enough to escalate the dispute to the fork backstop rather than resolve it early</li>
+              <li><strong>+40% payout:</strong> winning stakers earn a 40% return from the losing pot, drawing capital toward the undisputed outcome</li>
+            </ul>
+            <p>With rounds nearing their limit, the fork backstop—Phase 2—was three weeks out.</p>
+          </TimelineSection>
+
+          <TimelineSection title="Migration Window Opens" date="June 2026">
+            <h3>Phase 2: Mandatory Migration</h3>
+            <p>In early June, the fork backstop activated and Augur forked into competing universes—one per outcome. The <strong>2-month migration window is now open</strong>; every REP holder must migrate their tokens 1:1 into a chosen universe before it closes in early August.</p>
+            <ul>
+              <li><strong>Deadline—early August:</strong> REP holders are being notified to migrate before the window closes; tokens left behind are stranded in the old universe</li>
+              <li><strong>Exchange support:</strong> the Lituus Foundation is coordinating with exchanges to migrate on behalf of users</li>
+            </ul>
+            <p>This is the first live run of Augur's fork backstop—the security model's final layer, where REP migration determines which universe carries the canonical outcome.</p>
+          </TimelineSection>
+
           <TimelineSection title="The Fork and Beyond" date="2026" isLast>
             <h3>Execution Begins</h3>
             <p>Full development of <strong>Augur Lituus</strong> begins this year, with continued focus on a unified REP infrastructure across both the B2C and B2B tracks.</p>
-            <p>The migration window for the Moon Fork opens in June. The Lituus Foundation is coordinating with exchanges to support migration on behalf of users, and migration tooling is available at <a href="https://6.augurfork.eth.limo/" target="_blank" rel="noopener noreferrer">6.augurfork.eth.limo</a>.</p>
-            <p>Future official Augur development, funded by the foundation, will continue on the fork corresponding with truth.</p>
+            <p>With the Moon Fork demonstrating Augur's security model under real conditions, future official Augur development—funded by the Foundation—will continue on the fork corresponding with truth.</p>
           </TimelineSection>
         </div>
       </div>


### PR DESCRIPTION
## What

Extends the reboot timeline on the Mission page to cover the current Moon Fork state.

- **Escalation Game** (May 16, 2026) — new milestone reporting Phase 1 status: Round 5 of 8, +40% payout, escalation toward the fork backstop. Sourced from the [Phase 1: The Escalation Game](https://www.augur.net/blog/phase-1-the-escalation-game/) post.
- **Migration Window Opens** (June 2026) — new milestone: fork backstop activated, forked into competing universes, 1:1 migration window now open through early August.
- **The Fork and Beyond** — reframed to present tense now that the fork has triggered; moved migration logistics into the dedicated June entry to avoid duplication.

## Sourcing note

The Escalation Game entry is fully backed by the May 16 blog post. The "fork executed / migration now open" framing in the June entry reflects current status rather than a published source (no June post exists yet); adjust if that status changes.