### PR TITLE
feat: add exchange migration support list to migration guide

### DIFF
--- a/src/components/ExchangeSupportCard.astro
+++ b/src/components/ExchangeSupportCard.astro
@@ -1,0 +1,87 @@
+---
+/**
+ * ExchangeSupportCard — prominent container for CEX migration support info.
+ * Beveled corner via gradient (matching ClippedCardGradient technique).
+ * Amber accent signals "pending / pay attention" without red urgency.
+ */
+---
+
+<div class="exchange-card">
+  <div class="exchange-card-content">
+    <div class="exchange-card-heading">
+      <span class="dot pulse" aria-hidden="true"></span>
+      <span>Exchange Support</span>
+    </div>
+    <div class="exchange-card-body">
+      <slot />
+    </div>
+  </div>
+</div>
+
+<style>
+  .exchange-card {
+    display: grid;
+    grid-template-areas: "card";
+    position: relative;
+    margin: 1.5rem 0;
+  }
+
+  /* Border layer — beveled corner via gradient */
+  .exchange-card::before {
+    content: '';
+    grid-area: card;
+    background: linear-gradient(225deg, transparent 10px, var(--color-orange-400) 0);
+  }
+
+  /* Background layer — same bevel, 1px margin reveals the border */
+  .exchange-card::after {
+    content: '';
+    grid-area: card;
+    margin: 1px;
+    background: linear-gradient(225deg, transparent 10px, var(--color-background) 0);
+  }
+
+  /* Content sits above both layers */
+  .exchange-card-content {
+    grid-area: card;
+    position: relative;
+    z-index: 1;
+  }
+
+  .exchange-card-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1.5rem;
+    font-family: var(--font-display);
+    font-size: 0.85rem;
+    letter-spacing: var(--font-display-tracking);
+    text-transform: uppercase;
+    color: var(--color-orange-400);
+    border-bottom: 1px solid color-mix(in oklch, var(--color-orange-400) 20%, transparent);
+  }
+
+  .exchange-card-body {
+    padding: 1.5rem;
+  }
+
+  .dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    background: var(--color-orange-400);
+    flex-shrink: 0;
+  }
+
+  .dot.pulse {
+    animation: dot-pulse 2s ease-in-out infinite;
+  }
+
+  @keyframes dot-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .dot.pulse { animation: none; }
+  }
+</style>

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -5,6 +5,7 @@ description: "Step-by-step REP migration guide. Migrate before August 1, 2026 or
 
 import { Image } from 'astro:assets'
 import ProseCard from '../../../components/ProseCard.astro'
+import ExchangeSupportCard from '../../../components/ExchangeSupportCard.astro'
 import step01 from '../../../assets/migration/step-01.png'
 import step02 from '../../../assets/migration/step-02.png'
 import step03 from '../../../assets/migration/step-03.png'
@@ -40,9 +41,26 @@ If your REP is not on Ethereum (exchanges, L2s), send it to your Ethereum addres
 Sometimes wallets will not automatically detect your REP. You can manually add tokens by pasting the token address:
 
 - **REPv2** — [`0x221657776846890989a759ba2973e427dff5c9bb`](https://etherscan.io/token/0x221657776846890989a759ba2973e427dff5c9bb)
-- **REPv1** — [`0x1985365e9f78359a9B6AD760e32412f4a445E862`](https://etherscan.io/address/0x1985365e9f78359a9B6AD760e32412f4a445E862)
+- **REPv1** — [`0x1985365e9f78359a9B6AD760e32412f4a445E862`](https://etherscan.io/token/0x1985365e9f78359a9B6AD760e32412f4a445E862)
 
 If you have REP in multiple places, send it all to a single Ethereum address on the original Ethereum. Don't forget REP you might have on Layer 2, Coinbase, or other exchanges. You must own your Ethereum address — an Ethereum address is yours if you have the private key.
+
+<ExchangeSupportCard>
+
+The following exchanges have indicated they plan to support migration, but have not yet officially announced it. **Do not wait** — withdraw to your own wallet and migrate yourself if you can.
+
+| Exchange | Status |
+|----------|--------|
+| [Kraken](https://kraken.com/) | Pending |
+| [Gate.io](https://gate.com/) | Pending |
+| [Upbit](https://upbit.com/) | Pending |
+| [Coinbase](https://coinbase.com/) | Pending |
+| [OKX](https://okx.com/) | Pending |
+| [Bitpanda](https://bitpanda.com/) | Pending |
+
+Any exchange not listed above has not indicated support. If your REP is on an unlisted exchange, withdraw and migrate yourself.
+
+</ExchangeSupportCard>
 
 ### 1. Open the migration site
 


### PR DESCRIPTION
## Summary

Six exchanges have indicated they plan to support REP migration but have not yet officially announced: Kraken, Gate.io, Upbit, Coinbase, OKX, Bitpanda.

### Changes

- **New  component** — beveled-corner container with amber accent and animated pulse dot. Sits between ProseCard (subtle) and MigrationCta (red urgency) in the visual hierarchy.
- **Added to Step 0** (Consolidate your REP) in the migration guide — right where exchange users are already told to withdraw.
- All exchanges marked **Pending** with clear guidance not to wait.
- **Fix:** REPv1 etherscan link now uses `/token/` consistently with REPv2.

### Test plan

- [x] Verify card renders with beveled corner, amber border, and pulse dot
- [x] Verify all 6 exchange links work and open correct sites
- [x] Verify card sits between Step 0 text and Step 1
- [ ] Check on mobile — table should be scrollable
- [ ] Verify `prefers-reduced-motion` disables pulse animation
- [ ] Confirm both etherscan links use `/token/` path