### PR TITLE
Externalize exchange support list to public JSON

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Generate exchange support data
+        run: npm run build:exchange-data
+
       - name: Build site
         run: npm run build
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ dev-debug.log
 
 # Generated fork risk data and cache
 public/data/fork-risk.json
+public/data/exchange-support.json
 public/cache/
 
 # TypeScript build cache

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,6 +21,7 @@ Start here to find the right doc. Read deeper only when the task calls for it.
 | Doc | When to Read |
 |---|---|
 | [Technical Architecture](technical-architecture.md) | React/TypeScript component hierarchy, state management (Context API), UI patterns, visual rendering |
+| [Public Data Endpoints](public-data-endpoints.md) | Structured JSON endpoints at /data/*.json for external consumers — schemas, conventions, adding new endpoints |
 | [FAQ Feature](faq-feature.md) | FAQ page design, route, collapsible Q&A, landing page/footer integration |
 | [Blog Feature](blog-feature.md) | Blog frontmatter schema, MDX integration, RSS feed, Learn section |
 | [Migration Guide Feature](migration-guide-feature.md) | Moon Fork migration guide, step-by-step REP migration, MigrationGuideLayout |

--- a/docs/public-data-endpoints.md
+++ b/docs/public-data-endpoints.md
@@ -1,0 +1,136 @@
+---
+title: Public Data Endpoints
+tags: [data, api, external-consumers, fork-risk, exchange-support]
+---
+
+# Public Data Endpoints
+
+Augur.net serves structured JSON at stable URLs under `/data/` for external consumers: exchanges, dashboards, fork trackers, community explorers, and integrator tools.
+
+## Convention
+
+Every endpoint carries:
+
+| Field | Type | Description |
+|---|---|---|
+| `generatedAt` | `string` (ISO 8601) | When the data was last computed. Poll this to detect staleness. |
+| `schemaVersion` | `string` | Semantic version of the response shape. Increments on breaking changes. |
+
+Adding a field is safe. Renaming or removing a top-level field is a breaking change — coordinate with known consumers.
+
+Data files that need both public serving and build-time import live in `scripts/` as a TypeScript module, then are written to `public/data/` via a dedicated npm script (`npm run build:exchange-data`). The build-time import pulls the module's exports directly; the CLI mode writes the JSON.
+
+## Endpoints
+
+### `/data/fork-risk.json`
+
+Live fork status from on-chain Augur contracts. Updated hourly by CI.
+
+```
+GET /data/fork-risk.json
+Refresh: every hour (GitHub Actions cron: 0 * * * *)
+Pipeline: scripts/calculate-fork-risk.ts
+```
+
+#### Top-level fields
+
+| Field | Type | Description |
+|---|---|---|
+| `generatedAt` | `string` (ISO 8601) | Last pipeline run timestamp |
+| `schemaVersion` | `string` | Response shape version |
+| `blockNumber` | `number` | Ethereum block at time of calculation |
+| `riskLevel` | `enum` | `none` \| `low` \| `moderate` \| `high` \| `critical` \| `unknown` |
+| `riskPercentage` | `number \| null` | Round progress as percentage (0–100). `null` when projection unavailable. |
+| `metrics` | `object` | Dispute and escalation metrics (below) |
+| `rpcInfo` | `object` | RPC endpoint used, latency, fallback count |
+| `calculation` | `object` | `forkThreshold` — REP threshold that triggers fork |
+| `cacheValidation` | `object` | Cache health: `isHealthy: boolean`, optional `discrepancy` |
+| `forkActive` | `object \| null` | Present only when fork is live (below) |
+| `error` | `string \| null` | Error message if pipeline failed |
+
+#### `metrics`
+
+| Field | Type | Description |
+|---|---|---|
+| `largestDisputeBond` | `number` | Largest active dispute bond in REP |
+| `forkThresholdPercent` | `number` | Bond size as percentage of fork threshold |
+| `activeDisputes` | `number` | Count of disputes with active bonds |
+| `disputeDetails` | `array` | Active dispute entries (up to 5), each with `marketId`, `title`, `disputeBondSize`, `disputeRound`, `estimatedTotalRounds`, `roundProgress`, `weeksRemaining` |
+| `currentRound` | `number` | Round number of the largest dispute |
+| `estimatedTotalRounds` | `number \| null` | Projected rounds to reach fork threshold. `null` if projection unavailable. |
+| `roundProgress` | `number \| null` | `currentRound / estimatedTotalRounds` as percentage. `null` if projection unavailable. |
+
+#### `forkActive`
+
+Present and non-null only when a fork is live. Absent (`null` or missing) otherwise.
+
+| Field | Type | Description |
+|---|---|---|
+| `forkingMarket` | `string` (address) | Augur market that triggered the fork |
+| `forkEndTime` | `number` (unix seconds) | Fork window end |
+| `forkReputationGoal` | `number` | REP needed for >50% early resolution |
+| `universeRepSupply` | `number` | Total REP supply in the forking universe |
+| `outcomes` | `array` | Per-outcome child universes and migration tallies |
+
+`outcomes[]` entries:
+
+| Field | Type | Description |
+|---|---|---|
+| `index` | `number` | Outcome index (0 = Invalid, 1+ = outcome labels) |
+| `label` | `string` | Human-readable outcome label |
+| `childUniverse` | `string \| null` | Child universe address, or `null` if none created |
+| `migratedRep` | `number` | REP migrated to this outcome so far |
+
+**Risk level thresholds**: `none` (0%), `low` (1–24%), `moderate` (25–49%), `high` (50–74%), `critical` (75–100%). When `forkActive` is present, `riskLevel` is always `critical` and `roundProgress` is `100`.
+
+For pipeline internals, see [[fork-monitoring-pipeline]].
+
+---
+
+### `/data/exchange-support.json`
+
+CEX migration support status for the Moon Fork. Manually updated.
+
+```
+GET /data/exchange-support.json
+Refresh: manual
+```
+
+#### Top-level fields
+
+| Field | Type | Description |
+|---|---|---|
+| `generatedAt` | `string` (ISO 8601) | When the data was last manually updated |
+| `schemaVersion` | `string` | Response shape version |
+| `description` | `string` | Human-readable context for the data set |
+| `exchanges` | `array` | Exchange status entries (below) |
+
+#### `exchanges[]`
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `string` | Exchange display name |
+| `url` | `string` | Exchange website |
+| `status` | `enum` | `pending` \| `confirmed` \| `supporting` \| `completed` \| `declined` |
+| `notes` | `string \| null` | Optional context about the status |
+
+#### Status values
+
+| Value | Meaning |
+|---|---|
+| `pending` | In discussions; no commitment yet |
+| `confirmed` | Exchange has publicly announced support |
+| `supporting` | Exchange is actively processing migrations |
+| `completed` | Migration support is finished |
+| `declined` | Exchange explicitly declined to support |
+
+**Update procedure**: edit the `EXCHANGES` array in `scripts/generate-exchange-support.ts`, then run `npm run build:exchange-data` to regenerate `public/data/exchange-support.json`.
+
+---
+
+## Related
+
+- [[fork-monitoring-pipeline]] — CI pipeline details for fork-risk.json
+- [[migration-guide-feature]] — exchange list consumption in the migration guide
+- `scripts/calculate-fork-risk.ts` — pipeline script (in-repo)
+- `src/components/ExchangeSupportCard.astro` — UI component consuming exchange data

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "build": "astro build",
     "build:gh-pages": "GITHUB_ACTIONS=true GITHUB_REPOSITORY=AugurProject/augur-reboot-website astro build",
     "build:fork-data": "node --experimental-strip-types scripts/calculate-fork-risk.ts",
+    "build:exchange-data": "node --experimental-strip-types scripts/generate-exchange-support.ts",
     "preview": "astro build && wrangler dev",
     "astro": "astro",
-    "deploy": "astro build && wrangler deploy",
+    "deploy": "npm run build:exchange-data && astro build && wrangler deploy",
     "cf-typegen": "wrangler types",
     "typecheck": "astro check",
     "lint": "biome lint"

--- a/scripts/generate-exchange-support.ts
+++ b/scripts/generate-exchange-support.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * Exchange Migration Support List
+ *
+ * Source of truth for CEX exchange migration support status.
+ * Edit the EXCHANGES array below to add or update exchanges.
+ *
+ * Dual purpose:
+ *   - Named exports for build-time imports (MDX content files)
+ *   - CLI mode: writes public/data/exchange-support.json for public serving
+ *
+ * Run: npm run build:exchange-data
+ * Import: import { exchanges } from 'scripts/generate-exchange-support'
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const __root = path.resolve(__dirname, '..')
+
+// ──────────────────────────────────────────────
+// DATA — single source of truth
+// Status values: pending | confirmed | supporting | completed | declined
+// Edit this array. That's it.
+// Later: can be replaced with dynamic API calls.
+// ──────────────────────────────────────────────
+
+export type ExchangeStatus = 'pending' | 'confirmed' | 'supporting' | 'completed' | 'declined'
+
+export interface Exchange {
+	name: string
+	url: string
+	status: ExchangeStatus
+	notes: string | null
+}
+
+const EXCHANGES: Exchange[] = [
+	{
+		name: 'Kraken',
+		url: 'https://kraken.com',
+		status: 'pending',
+		notes: 'In discussions; support not yet confirmed',
+	},
+	{
+		name: 'Gate.io',
+		url: 'https://gate.com',
+		status: 'pending',
+		notes: 'In discussions; support not yet confirmed',
+	},
+	{
+		name: 'Upbit',
+		url: 'https://upbit.com',
+		status: 'pending',
+		notes: 'In discussions; support not yet confirmed',
+	},
+	{
+		name: 'Coinbase',
+		url: 'https://coinbase.com',
+		status: 'pending',
+		notes: 'In discussions; support not yet confirmed',
+	},
+	{
+		name: 'OKX',
+		url: 'https://okx.com',
+		status: 'pending',
+		notes: 'In discussions; support not yet confirmed',
+	},
+	{
+		name: 'Bitpanda',
+		url: 'https://bitpanda.com',
+		status: 'pending',
+		notes: 'In discussions; support not yet confirmed',
+	},
+]
+
+const DESCRIPTION =
+	'Exchange migration support status for the Augur Moon Fork. REP holders should withdraw to their own wallet and migrate if their exchange is not listed as supporting.'
+const SCHEMA_VERSION = '1.0.0'
+
+export { EXCHANGES as exchanges, DESCRIPTION as description, SCHEMA_VERSION as schemaVersion }
+
+// ──────────────────────────────────────────────
+// CLI — writes public/data/exchange-support.json
+// ──────────────────────────────────────────────
+
+if (process.argv[1]?.endsWith('generate-exchange-support.ts')) {
+	const outputDir = path.resolve(__root, 'public', 'data')
+	const outputFile = path.resolve(outputDir, 'exchange-support.json')
+
+	mkdirSync(outputDir, { recursive: true })
+
+	const data = {
+		generatedAt: new Date().toISOString(),
+		description: DESCRIPTION,
+		exchanges: EXCHANGES,
+		schemaVersion: SCHEMA_VERSION,
+	}
+
+	writeFileSync(outputFile, `${JSON.stringify(data, null, 2)}\n`)
+}

--- a/src/components/ExchangeSupportCard.astro
+++ b/src/components/ExchangeSupportCard.astro
@@ -3,7 +3,27 @@
  * ExchangeSupportCard — prominent container for CEX migration support info.
  * Beveled corner via gradient (matching ClippedCardGradient technique).
  * Amber accent signals "pending / pay attention" without red urgency.
+ *
+ * Accepts structured exchange data via the `exchanges` prop.
+ * Falls back to `<slot/>` content if no prop is provided (backward compat).
  */
+
+export interface Exchange {
+  name: string
+  url: string
+  status: 'pending' | 'confirmed' | 'supporting' | 'completed' | 'declined'
+  notes?: string
+}
+
+const { exchanges } = Astro.props as { exchanges?: Exchange[] }
+
+const statusLabel: Record<string, string> = {
+  pending: 'Pending',
+  confirmed: 'Confirmed',
+  supporting: 'Supporting',
+  completed: 'Completed',
+  declined: 'Declined',
+}
 ---
 
 <div class="exchange-card">
@@ -13,7 +33,26 @@
       <span>Exchange Support</span>
     </div>
     <div class="exchange-card-body">
-      <slot />
+      {exchanges ? (
+        <>
+          <p class="mb-4">The following exchanges have indicated they plan to support migration, but have not yet officially announced it. <strong>Do not wait</strong> — withdraw to your own wallet and migrate yourself if you can.</p>
+          <div class="exchange-table">
+            <div class="exchange-table-row exchange-table-header">
+              <span>Exchange</span>
+              <span class="status-column">Status</span>
+            </div>
+            {exchanges.map((ex) => (
+              <div class="exchange-table-row">
+                <a href={ex.url} target="_blank" rel="noopener noreferrer">{ex.name}</a>
+                <span class={`status-column status-${ex.status}`}>{statusLabel[ex.status] ?? ex.status}</span>
+              </div>
+            ))}
+          </div>
+          <p class="mt-4 text-sm" style="opacity: 0.7">Any exchange not listed above has not indicated support. If your REP is on an unlisted exchange, withdraw and migrate yourself.</p>
+        </>
+      ) : (
+        <slot />
+      )}
     </div>
   </div>
 </div>
@@ -63,6 +102,57 @@
 
   .exchange-card-body {
     padding: 1.5rem;
+  }
+
+  .exchange-table {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid color-mix(in oklch, var(--color-orange-400) 30%, transparent);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .exchange-table-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid color-mix(in oklch, var(--color-orange-400) 15%, transparent);
+  }
+
+  .exchange-table-row:last-child {
+    border-bottom: none;
+  }
+
+  .exchange-table-header {
+    background: color-mix(in oklch, var(--color-orange-400) 10%, transparent);
+    font-family: var(--font-display);
+    font-size: 0.8rem;
+    letter-spacing: var(--font-display-tracking);
+    text-transform: uppercase;
+    color: var(--color-orange-400);
+  }
+
+  .exchange-table-row a {
+    color: var(--color-foreground);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: color-mix(in oklch, var(--color-orange-400) 40%, transparent);
+  }
+
+  .exchange-table-row a:hover {
+    color: var(--color-orange-400);
+  }
+
+  .status-column {
+    font-family: var(--font-display);
+    font-size: 0.8rem;
+    letter-spacing: var(--font-display-tracking);
+    text-transform: uppercase;
+  }
+
+  .status-pending {
+    color: var(--color-orange-400);
   }
 
   .dot {

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -7,6 +7,7 @@ import { Image } from 'astro:assets'
 import ProseCard from '../../../components/ProseCard.astro'
 import ExchangeSupportCard from '../../../components/ExchangeSupportCard.astro'
 import step01 from '../../../assets/migration/step-01.png'
+import { exchanges } from '../../../../scripts/generate-exchange-support'
 import step02 from '../../../assets/migration/step-02.png'
 import step03 from '../../../assets/migration/step-03.png'
 import step04 from '../../../assets/migration/step-04.png'
@@ -45,22 +46,7 @@ Sometimes wallets will not automatically detect your REP. You can manually add t
 
 If you have REP in multiple places, send it all to a single Ethereum address on the original Ethereum. Don't forget REP you might have on Layer 2, Coinbase, or other exchanges. You must own your Ethereum address — an Ethereum address is yours if you have the private key.
 
-<ExchangeSupportCard>
-
-The following exchanges have indicated they plan to support migration, but have not yet officially announced it. **Do not wait** — withdraw to your own wallet and migrate yourself if you can.
-
-| Exchange | Status |
-|----------|--------|
-| [Kraken](https://kraken.com/) | Pending |
-| [Gate.io](https://gate.com/) | Pending |
-| [Upbit](https://upbit.com/) | Pending |
-| [Coinbase](https://coinbase.com/) | Pending |
-| [OKX](https://okx.com/) | Pending |
-| [Bitpanda](https://bitpanda.com/) | Pending |
-
-Any exchange not listed above has not indicated support. If your REP is on an unlisted exchange, withdraw and migrate yourself.
-
-</ExchangeSupportCard>
+<ExchangeSupportCard exchanges={exchanges} />
 
 ### 1. Open the migration site
 


### PR DESCRIPTION
## Problem

The exchange migration support list (Kraken, Gate.io, Upbit, etc.) was hardcoded as a Markdown table inside `src/content/learn/fork/migration.mdx`. To update it, someone had to edit the guide itself. External sites had no way to pull this data.

## Solution

Externalize the list using a TypeScript script as the single source of truth, following the same public data endpoint pattern as `fork-risk.json`. The script exports data for build-time imports and writes `public/data/exchange-support.json` when run as CLI.

### What changed

| File | Action |
|------|--------|
| `scripts/generate-exchange-support.ts` | **Created** — source of truth: static exchanges array, exports for MDX imports, CLI writes public endpoint |
| `src/components/ExchangeSupportCard.astro` | **Updated** — accepts `exchanges` prop, renders structured table; falls back to `<slot/>` |
| `src/content/learn/fork/migration.mdx` | **Updated** — imports `{ exchanges }` from script, passes to component; removed hardcoded table |
| `package.json` | Added `build:exchange-data` script; `deploy` chains it before build |
| `.github/workflows/build-and-deploy.yml` | Added `npm run build:exchange-data` step before astro build |
| `.gitignore` | Added `public/data/exchange-support.json` (build artifact) |
| `docs/public-data-endpoints.md` | Integrator reference documenting both endpoints |

### Data shape

```json
{
  "generatedAt": "2026-06-16T00:00:00Z",
  "description": "Exchange migration support status for the Augur Moon Fork...",
  "exchanges": [
    { "name": "Kraken", "url": "https://kraken.com", "status": "pending", "notes": "..." }
  ],
  "schemaVersion": "1.0.0"
}
```

Status values: `pending` | `confirmed` | `supporting` | `completed` | `declined`

Every endpoint carries `generatedAt` (ISO 8601) and `schemaVersion` — downstream consumers poll and detect staleness.

### Public endpoint

`https://augur.net/data/exchange-support.json`

### To update the list

Edit the `EXCHANGES` array in `scripts/generate-exchange-support.ts`. One file. No duplication. Run `npm run build:exchange-data` to regenerate the public endpoint.

### Related

- Folio: [public data endpoints convention](https://github.com/jubalm/folio/pull/42)
- Precedent: `fork-risk.json` at same URL pattern