### PR TITLE
Remove withBase utility (no-op with custom domain)

### DIFF
--- a/src/components/FeaturedBlogs.astro
+++ b/src/components/FeaturedBlogs.astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
 import type { ImageMetadata } from 'astro';
-import { withBase } from '../lib/utils';
 import PostCard from './PostCard.astro';
 import { BlogCTA } from './BlogCTA';
 
@@ -53,7 +52,7 @@ const secondaryWithImages = secondaryPosts.map(post => ({
             day: '2-digit'
           })}
           image={featuredImage}
-          href={withBase(`/blog/${featuredPost.slug}`)}
+          href={`/blog/${featuredPost.slug}`}
           featured
         />
       )}
@@ -70,13 +69,13 @@ const secondaryWithImages = secondaryPosts.map(post => ({
                 day: '2-digit'
               })}
               image={image}
-              href={withBase(`/blog/${post.slug}`)}
+              href={`/blog/${post.slug}`}
             />
           ))}
         </div>
       )}
 
       <div class="flex justify-center pt-4 md:pt-6">
-          <BlogCTA client:idle href={withBase('/blog')}>View all posts</BlogCTA>
+          <BlogCTA client:idle href="/blog">View all posts</BlogCTA>
       </div>
 </section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,6 @@
 ---
 import { AugurLogo } from "./icons.tsx";
 import Button from "./ui/Button.tsx";
-import { withBase } from "../lib/utils";
 ---
 
 <footer class="relative px-4 md:px-8 mt-4">
@@ -13,7 +12,7 @@ import { withBase } from "../lib/utils";
         <!-- Column 1: Logo & Tagline -->
         <div class="md:col-span-2 lg:col-span-1 lg:place-content-end">
             <div class="text-center lg:w-max">
-                <Button variant="link" href={withBase('/')} className="flex flex-col gap-y-2 group">
+                <Button variant="link" href="/" className="flex flex-col gap-y-2 group">
                     <!-- Footer Logo (White) -->
                     <AugurLogo className="text-8xl" />
                     <span class:list={[
@@ -115,7 +114,7 @@ import { withBase } from "../lib/utils";
           <h4 class="text-muted-foreground mb-4 font-display">&gt;_ KB</h4>
           <ul class="space-y-2">
             <li>
-              <Button variant="link" href={withBase('/faq')}>
+              <Button variant="link" href="/faq">
                 FORK & MIGRATION FAQ
               </Button>
             </li>
@@ -133,10 +132,10 @@ import { withBase } from "../lib/utils";
     >
       <p class="font-display text-foreground">© 2026 AUGUR. ALL RIGHTS RESERVED.</p>
       <nav class="flex gap-8">
-        <Button variant="link" href={withBase('/terms')}>
+        <Button variant="link" href="/terms">
           TERMS OF SERVICE
         </Button>
-        <Button variant="link" href={withBase('/privacy')}>PRIVACY POLICY</Button>
+        <Button variant="link" href="/privacy">PRIVACY POLICY</Button>
       </nav>
     </div>
   </div>

--- a/src/components/HeroBanner.tsx
+++ b/src/components/HeroBanner.tsx
@@ -6,7 +6,6 @@ import { ScrollIndicator } from '@/components/ScrollIndicator';
 import BorderBeam from '@/components/ui/BorderBeam';
 import { SirenIcon } from '@phosphor-icons/react';
 import { AugurLogo } from '@/components/icons';
-import { withBase } from '@/lib/utils';
 
 const ASCII_ART = `██╗ ███████╗     ██████╗  ███████╗ ██████╗   ██████╗   ██████╗  ████████╗ ██╗ ███╗   ██╗  ██████╗
 ██║ ██╔════╝     ██╔══██╗ ██╔════╝ ██╔══██╗ ██╔═══██╗ ██╔═══██╗ ╚══██╔══╝ ██║ ████╗  ██║ ██╔════╝
@@ -57,13 +56,13 @@ const HeroBanner: React.FC = () => {
           <div className="flex flex-col place-items-center text-left w-full max-w-3xl mx-auto mb-3">
             <a
               ref={menuItem1Ref}
-              href={withBase('/mission')}
+              href="/mission"
               className="hero-menu-1 menu-link font-display text-xl sm:text-3xl font-bold text-foreground hover:text-loud-foreground focus:text-loud-foreground block hover:fx-glow focus:fx-glow focus:outline-none uppercase"
             >
               THE NEXT GENERATION OF ORACLES
             </a>
             <a
-              href={withBase('/team')}
+              href="/team"
               className="hero-menu-2 menu-link font-display text-xl sm:text-3xl font-bold text-foreground hover:text-loud-foreground focus:text-loud-foreground block hover:fx-glow focus:fx-glow focus:outline-none uppercase"
             >
               THE MINDS BEHIND THE REBOOT
@@ -75,7 +74,7 @@ const HeroBanner: React.FC = () => {
             <div className="animate-[bob_2s_ease-in-out_infinite]">
               <BorderBeam duration={2.5}>
                 <a
-                  href={withBase('/faq')}
+                  href="/faq"
                   className="font-display bg-foreground/5 tracking-wide flex items-center px-4 py-2 sm:text-xl font-semibold text-loud-foreground uppercase shadow-[0_0_10px_oklch(from_var(--color-foreground)_l_c_h/_0.4)] hover:fx-glow-sm focus:fx-glow-sm focus:outline-none whitespace-nowrap"
                 >
                   <SirenIcon className="w-6 h-6 border-muted-foreground/80 rounded-full p-1 mr-3" />

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -5,7 +5,6 @@ import BlogNavigation from "../components/BlogNavigation.tsx";
 import BlogPostMeta from "../components/BlogPostMeta.astro";
 import PageHeader from "../components/PageHeader.tsx";
 import PageTitle from "../components/PageTitle.astro";
-import { withBase } from "../lib/utils";
 
 interface Post {
   title: string;
@@ -35,7 +34,7 @@ const { title, description, author, publishDate, updatedDate, ogImage, prevPost,
 >
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
     {/* Top Section: Navigation */}
-    <PageHeader client:load backHref={withBase('/')} />
+    <PageHeader client:load backHref="/" />
 
     {/* Middle Section: Scrollable Content */}
     <main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,7 +3,6 @@ import { ClientRouter } from "astro:transitions";
 import "../styles/global.css";
 import PerspectiveGridTunnel from "../components/PerspectiveGridTunnel.tsx";
 import GoogleAnalytics from "../components/GoogleAnalytics.astro";
-import { withBase } from "../lib/utils";
 
 interface Props {
 	title: string;
@@ -82,8 +81,8 @@ const {
 		<meta name="application-name" content="Augur" />
 
 		<!-- Icons and manifest -->
-		<link rel="icon" type="image/svg+xml" href={withBase('/favicon.svg')} />
-		<link rel="apple-touch-icon" href={withBase('/favicon.svg')} />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="apple-touch-icon" href="/favicon.svg" />
 
 		<!-- DNS prefetch for external resources -->
 		<link rel="dns-prefetch" href="//github.com" />

--- a/src/layouts/LearnLayout.astro
+++ b/src/layouts/LearnLayout.astro
@@ -4,7 +4,6 @@ import Footer from "../components/Footer.astro";
 import LearnNavigation from "../components/LearnNavigation.tsx";
 import PageHeader from "../components/PageHeader.tsx";
 import PageTitle from "../components/PageTitle.astro";
-import { withBase } from "../lib/utils";
 
 interface Props {
 	title: string
@@ -35,7 +34,7 @@ const currentPath = Astro.url.pathname
 >
 	<div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
 		{/* Top Section: Navigation */}
-		<PageHeader client:load backHref={withBase('/')} />
+		<PageHeader client:load backHref="/" />
 
 		{/* Middle Section: Scrollable Content */}
 		<main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">

--- a/src/layouts/MigrationGuideLayout.astro
+++ b/src/layouts/MigrationGuideLayout.astro
@@ -3,7 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import Footer from "../components/Footer.astro";
 import LearnNavigation from "../components/LearnNavigation.tsx";
 import PageHeader from "../components/PageHeader.tsx";
-import { withBase } from "../lib/utils";
+
 
 interface Props {
 	title: string;
@@ -33,7 +33,7 @@ const currentPath = Astro.url.pathname;
 	ogType="article"
 >
 	<div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
-		<PageHeader client:load backHref={withBase("/")} />
+		<PageHeader client:load backHref="/" />
 
 		<main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">
 			<div class="max-w-3xl mx-auto">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,31 +5,4 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-/**
- * Utility function to construct URLs with the correct base path
- * Works with Cloudflare (no base), GitHub Pages (with base path), and custom domain (no base)
- */
-export function withBase(path: string): string {
-  let base = import.meta.env.BASE_URL || '/';
-  
-  // Ensure base ends with slash for proper concatenation
-  if (base !== '/' && !base.endsWith('/')) {
-    base = `${base}/`;
-  }
-  
-  // Handle empty path
-  if (!path) return base;
-  
-  // Handle query strings and fragments
-  if (path.startsWith('?') || path.startsWith('#')) {
-    return base === '/' ? path : base.replace(/\/$/, '') + path;
-  }
-  
-  // Handle absolute paths
-  if (path.startsWith('/')) {
-    return base === '/' ? path : base + path.slice(1);
-  }
-  
-  // Handle relative paths
-  return base + path;
-}
+

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,7 +4,6 @@ import Footer from "../components/Footer.astro";
 import PageHeader from "../components/PageHeader.tsx";
 import AsciiText from "../components/AsciiText.tsx";
 import Pointer from "../components/Pointer.tsx";
-import { withBase } from "../lib/utils";
 ---
 
 <Layout title="404: Page Not Found - Augur">
@@ -12,7 +11,7 @@ import { withBase } from "../lib/utils";
     <!-- Main content wrapper that fills viewport -->
     <div class="min-h-screen flex flex-col">
       <!-- Top Section: Navigation -->
-      <PageHeader client:load backHref={withBase('/')} />
+      <PageHeader client:load backHref="/" />
 
       <!-- Middle Section: 404 Content -->
       <main class="flex-1 flex items-center justify-center px-4 md:px-8">
@@ -36,7 +35,7 @@ import { withBase } from "../lib/utils";
           <!-- Navigation Message -->
           <div class="text-center space-y-4">
             <p class="text-sm uppercase text-muted-foreground opacity-80">
-              Return to the homepage by <a href={withBase("/")} class="text-loud-foreground hover:fx-glow-sm transition-all">clicking here</a> <br />
+              Return to the homepage by <a href="/" class="text-loud-foreground hover:fx-glow-sm transition-all">clicking here</a> <br />
               or scroll further down to explore community links.
             </p>
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,7 +6,6 @@ import Footer from '../../components/Footer.astro';
 import PageHeader from '../../components/PageHeader.tsx';
 import PageTitle from '../../components/PageTitle.astro';
 import BlogPostCard from '../../components/BlogPostCard.astro';
-import { withBase } from '../../lib/utils';
 
 // Import featured images from all blog posts
 const images: Record<string, { default: ImageMetadata }> = import.meta.glob(
@@ -38,7 +37,7 @@ const sortedPosts = blogPosts.sort(
 >
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
     {/* Top Section: Navigation */}
-    <PageHeader client:load backHref={withBase('/')} />
+    <PageHeader client:load backHref="/" />
 
     {/* Middle Section: Scrollable Content */}
     <main class="overflow-y-auto px-4 md:px-8 mb-12">

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -6,7 +6,6 @@ import PageTitle from "../components/PageTitle.astro";
 import SectionHeading from "../components/SectionHeading.astro";
 import FaqItem from "../components/FaqItem.astro";
 import MigrationCta from "../components/MigrationCta.tsx";
-import { withBase } from "../lib/utils";
 ---
 
 <Layout
@@ -25,7 +24,7 @@ import { withBase } from "../lib/utils";
 >
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
     <!-- Top Section: Navigation -->
-    <PageHeader client:load backHref={withBase('/')} />
+    <PageHeader client:load backHref="/" />
 
     <!-- Middle Section: Content -->
     <main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">

--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -5,7 +5,6 @@ import Footer from "../components/Footer.astro";
 import PageHeader from "../components/PageHeader.tsx";
 import PageTitle from "../components/PageTitle.astro";
 import SectionHeading from "../components/SectionHeading.astro";
-import { withBase } from "../lib/utils";
 ---
 
 <Layout
@@ -25,7 +24,7 @@ import { withBase } from "../lib/utils";
 >
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
     <!-- Top Section: Navigation -->
-    <PageHeader client:load backHref={withBase('/')} />
+    <PageHeader client:load backHref="/" />
 
     <!-- Middle Section: Scrollable Content -->
     <main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,13 +3,12 @@ import Layout from "../layouts/Layout.astro";
 import Footer from "../components/Footer.astro";
 import PageHeader from "../components/PageHeader.tsx";
 import PageTitle from "../components/PageTitle.astro";
-import { withBase } from "../lib/utils";
 ---
 
 <Layout title="Privacy Policy - Augur">
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
     <!-- Top Section: Navigation -->
-    <PageHeader client:load backHref={withBase('/')} />
+    <PageHeader client:load backHref="/" />
 
     <!-- Middle Section: Scrollable Content -->
     <main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -6,13 +6,12 @@ import PageHeader from "../components/PageHeader.tsx";
 import PageTitle from "../components/PageTitle.astro";
 import SectionHeading from "../components/SectionHeading.astro";
 import { LituusLogo, DarkFloristLogo } from "../components/icons.tsx";
-import { withBase } from "../lib/utils";
 ---
 
 <Layout title="Team - Augur">
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
     <!-- Top Section: Navigation -->
-    <PageHeader client:load backHref={withBase('/')} />
+    <PageHeader client:load backHref="/" />
 
     <!-- Middle Section: Scrollable Content -->
     <main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -3,13 +3,12 @@ import Layout from "../layouts/Layout.astro";
 import Footer from "../components/Footer.astro";
 import PageHeader from "../components/PageHeader.tsx";
 import PageTitle from "../components/PageTitle.astro";
-import { withBase } from "../lib/utils";
 ---
 
 <Layout title="Terms of Service - Augur">
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
     <!-- Top Section: Navigation -->
-    <PageHeader client:load backHref={withBase('/')} />
+    <PageHeader client:load backHref="/" />
 
     <!-- Middle Section: Scrollable Content -->
     <main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">


### PR DESCRIPTION
## What

Removes the `withBase()` utility and replaces all 24 call sites with bare absolute paths.

## Why

`withBase()` was an identity function for this site's deployment config — the site deploys to custom domain `www.augur.net`, CI has no `BASE_PATH` set, so `import.meta.env.BASE_URL` is always `/`. Therefore `withBase('/x') === '/x'` in every scenario (Cloudflare dev, GH Actions CI, local dev).

All call sites used simple absolute paths like `'/faq'`, `'/mission'`, etc., so the utility was always a no-op. Replacing with bare paths removes unnecessary indirection, simplifies imports, and eliminates a source of confusion (half the codebase used `withBase`, the other half used bare paths — now all are bare paths, consistently).

## Changes

- **`src/lib/utils.ts`** — removed `withBase()` function
- **14 files** — removed imports and replaced `withBase('/x')` → `'/x'`:
  - `Layout.astro` (favicon/touch-icon links)
  - `Footer.astro` (logo, FAQ, terms, privacy links)
  - `HeroBanner.tsx` (mission, team, FAQ links)
  - `FeaturedBlogs.astro` (blog post links, View All CTA)
  - `BlogLayout.astro`, `LearnLayout.astro`, `MigrationGuideLayout.astro`
  - `404.astro`, `faq.astro`, `mission.astro`, `team.astro`, `terms.astro`, `privacy.astro`, `blog/index.astro` (all `PageHeader backHref` links)

No functional change. Verified: grep confirms zero remaining `withBase` references.
