### PR TITLE
style: refine blog post card layout

### DIFF
--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from "astro:assets";
 import type { ImageMetadata } from "astro";
+import { cn } from "@/lib/utils";
 
 interface Props {
 	title: string;
@@ -23,23 +24,33 @@ function formatDate(date: Date): string {
 }
 ---
 
-<article class="blog-post-card border border-foreground/20 bg-background/70 hover:border-primary/50 transition-colors flex flex-col md:flex-row gap-0 md:gap-6">
+<article class={cn(
+  "grid transition-colors group",
+  "md:grid-cols-[4fr_5fr_3fr] md:grid-rows-[3fr_1fr_2fr]",
+  "lg:grid-cols-2 lg:grid-rows-1"
+)}>
   {/* Featured Image - OG ratio (1.91:1 = 1200×630) */}
   {featuredImage && (
-    <div class="w-full md:w-64 aspect-191/100">
+    <div class={cn(
+      "border-x border-t border-foreground/20",
+      "md:col-[1/3] md:row-[1/3] md:border-b",
+      "lg:col-auto lg:row-auto lg:border-r-0"
+    )}>
       <Image
         src={featuredImage}
         alt={title}
-        width={384}
-        height={202}
         loading="lazy"
-        class="w-full h-full object-cover"
+        class="w-full h-full object-cover aspect-191/100"
       />
     </div>
   )}
 
   {/* Content */}
-  <a href={`/blog/${slug}`} class="block flex-1">
+  <a href={`/blog/${slug}`} class={cn(
+    "block flex-1 bg-background border border-foreground/20 transition-transform",
+    "md:col-[2/4] md:row-[2/4]",
+    "lg:col-auto lg:row-auto"
+  )}>
     <div class="flex flex-col gap-3 p-6">
       {/* Post Title */}
       <h3 class="text-xl font-display font-bold text-loud-foreground tracking-wider uppercase hover:fx-glow transition-all duration-200">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -44,7 +44,7 @@ const sortedPosts = blogPosts.sort(
 
     {/* Middle Section: Scrollable Content */}
     <main class="overflow-y-auto px-4 md:px-8 mb-12">
-      <div class="max-w-screen-lg mx-auto">
+      <div class="max-w-5xl mx-auto">
         <PageTitle prefix="BLOG" title="THE AUGUR ARC" />
 
         <p class="text-sm tracking-prose text-center mb-12 max-w-2xl mx-auto text-foreground">
@@ -52,7 +52,7 @@ const sortedPosts = blogPosts.sort(
         </p>
 
         {/* Blog Posts Grid */}
-        <div class="grid grid-cols-1 gap-6 max-w-3xl mx-auto">
+        <div class="grid grid-cols-1 gap-y-12 lg:gap-y-8 mx-auto">
           {sortedPosts.map((post) => (
             <BlogPostCard
               title={post.data.title}


### PR DESCRIPTION
## Summary
- Refine blog post cards with a responsive grid layout
- Separate featured image and content into bordered regions
- Widen the blog index layout and adjust card spacing

## Verification
- `node ./node_modules/.bin/astro check`
- `npm run lint`

Note: root-level `bun.lock` remains untracked and is not part of this PR.
