### PR TITLE
Normalize quarterly blog subheadings

### DIFF
--- a/src/content/blog/augurs-decade/index.mdx
+++ b/src/content/blog/augurs-decade/index.mdx
@@ -29,19 +29,19 @@ Across both development tracks, maintaining a unified REP remains a key design g
 
 ## ⚖️ Micah's Fork
 
-**Summary**
+### Summary
 
 The fork is Augur's ultimate security mechanism, designed to resolve disputes by forcing REP holders to collectively choose the honest universe. Micah previously launched a crowdsourcer to raise the 200k REP required to trigger the fork, which filled this quarter and opened the path toward execution.
 
 [Learn more here](/blog/augur-cryptos-first-algorithmic-fork)
 
-**This quarter:**
+### This quarter
 
 - Micah's fork crowdsourcer successfully filled
 - Community-led development of fork and migration tooling progressed
 - Active coordination with centralized exchanges on fork handling
 
-**Next quarter:**
+### Next quarter
 
 - Continued community development and testing of fork tooling
 - Potential progression toward the fork process, subject to community readiness and timing
@@ -52,17 +52,17 @@ The fork reminds us that **REP is not a passive asset**. Participation matters, 
 
 ## 📈 Liquidity & Token Support
 
-**Summary**
+### Summary
 
 This quarter, liquidity efforts focused on preparing for the fork by establishing functional relationships with exchanges that custody REP.
 
-**This quarter:**
+### This quarter
 
 - Engaged exchanges holding REP on their books (17 total)
 - Coordinated on fork and migration handling
 - Maintained on-chain REP liquidity
 
-**Next quarter:**
+### Next quarter
 
 - Continue exchange coordination as tooling matures
 - Launch a tracker with exchange responses on fork participation
@@ -72,17 +72,17 @@ Fork readiness depends on access and coordination. This work supports a smooth m
 
 ## 🌍 Presence & Ecosystem Growth
 
-**Summary**
+### Summary
 
 Q3 focused on measured, high-signal ecosystem engagement, paced intentionally alongside research progress and fork preparation.
 
-**This quarter:**
+### This quarter
 
 - Participated on prediction market panels and X Spaces
 - Attended two major conferences to strengthen Augur relationships
 - Continued targeted engagement
 
-**Next quarter:**
+### Next quarter
 
 - Increase podcast and X Spaces appearances to explain the whitepaper
 - Get loud to ensure REP holders are aware of the fork
@@ -92,13 +92,13 @@ As fork preparation advances, we are focused on matching the scale of what may b
 
 ## 🧪 Research & Development
 
-**Summary**
+### Summary
 
 Q3 was a research-heavy quarter focused on strengthening Augur's oracle design through deeper analysis, external review, and continued work across two complementary development tracks.
 
 Much of the quarter was spent preparing the whitepaper and incorporating feedback from academics, researchers, and independent reviewers.
 
-**This quarter:**
+### This quarter
 
 - Continued parallel R&D across B2C and B2B oracle designs
 - Integrated extensive external feedback into the whitepaper
@@ -106,7 +106,7 @@ Much of the quarter was spent preparing the whitepaper and incorporating feedbac
 
 A key focus remains unification. While both designs are progressing, maintaining a single REP token is an open problem. Solving it would allow the community to benefit from adoption across multiple usecases without fragmentation, but doing so safely requires careful tradeoffs and further research.
 
-**Next quarter:**
+### Next quarter
 
 - Release the whitepaper for public review
 - Publish a post explaining the two oracle designs and their goals

--- a/src/content/blog/augurs-revival/index.mdx
+++ b/src/content/blog/augurs-revival/index.mdx
@@ -25,16 +25,16 @@ We’re proud to say we’ve made significant strides across all of these areas,
 
 ## 📈 Liquidity & Token Support
 
-**Summary:**
+### Summary
 
 The Foundation doubled its REP holdings and deployed capital to kickstart on-chain liquidity. We’re on track to expand this, and next quarter, we’ll begin the important work of relisting REP on centralized exchanges.
 
-**This quarter:**
+### This quarter
 
 - Doubled the Foundation’s REP holdings: 250k → 550k REP
 - Seeded a $100k Uniswap v3 pool to support DEX liquidity
 
-**Next quarter:**
+### Next quarter
 
 - Continue strengthening REP’s on-chain liquidity
 - Begin outreach to centralized exchanges
@@ -43,16 +43,16 @@ REP is not just a token — it’s Augur’s security backstop. A liquid market 
 
 ## 🌍 Presence & Ecosystem Growth
 
-**Summary:**
+### Summary
 
 This quarter, we’ve reintroduced Augur to the ecosystem, rekindling old relationships and building new ones. The excitement surrounding Augur’s return has been reassuring — there’s a real hunger for decentralized, trustless systems. We’ll build on this momentum in the coming months.
 
-**This quarter:**
+### This quarter
 
 Attended 3 major crypto conferences to represent Augur
 Built strong relationships with key opinion leaders (KOLs) and ecosystem players who are excited to support the relaunch
 
-**Next quarter:**
+### Next quarter
 
 Continue attending events and growing our ecosystem presence
 Increase our reach and share our vision with the world: podcasts, X Spaces, community calls, AMAs — wherever we can engage and inspire
@@ -60,18 +60,18 @@ People remember what made Augur special, and they’re excited to see it evolve.
 
 ## 🧪 Research & Development
 
-**Summary:**
+### Summary
 
 This quarter started with solid momentum — The Dark Florists were making great progress with AugurCP. However, a critical flaw was discovered in the v2 game theory, which shifted our focus back to deep research. Both teams have been working closely to rethink the oracle from first principles, pushing the boundaries of what’s possible.
 
-**This quarter:**
+### This quarter
 
 - AugurCP development began with strong progress
 - Paused after discovering a key game-theoretic issue in v2
 - Entered full research mode, with Lituus Labs and Dark Florists working together to propose new oracle models
 - 298 [GitHub commits](https://github.com/AugurProject/Augur-Constant-Product-Market), [15+ design drafts](https://github.com/AugurProject/Research-2025), and over 10,000 messages exchanged in Augur’s Discord research channels
 
-**Next quarter:**
+### Next quarter
 
 - Continue refining and testing competing oracle models
 - Publish our research for public review and invite feedback from the community

--- a/src/content/blog/augurs-rising/index.mdx
+++ b/src/content/blog/augurs-rising/index.mdx
@@ -36,17 +36,17 @@ Momentum is building on every front, Augur is waking up.
 
 ## 📈 Liquidity & Token Support
 
-**Summary**
+### Summary
 
 REP continues to be strengthened as the backbone of Augur's oracle. We expanded the Foundation's holdings this quarter, laying the groundwork for long-term liquidity support and oracle security. CEX relistings remain a priority, but are paused until the fork path is clear.
 
-**This quarter**
+### This quarter
 
 - Expanded buyback up to 1M REP total
 - Maintained Uniswap liquidity
 - Explored treasury staking options (including Uniswap v2) and decided on stETH
 
-**Next quarter**
+### Next quarter
 
 - If the crowdsourcer does not fill, we will plan towards CEX engagement in Q4
 
@@ -54,17 +54,17 @@ REP must remain liquid and widely accessible, forming the foundation of Augur's 
 
 ## 🌍 Presence & Ecosystem Growth
 
-**Summary**
+### Summary
 
 We've been working hard to expand Augur's presence, both digitally and in-person. From launching our new website to attending conferences and engaging on social channels, Augur is being reintroduced to a new generation of builders and users.
 
-**This quarter**
+### This quarter
 
 - Launched the new [Augur website](https://www.augur.net)
 - Participated in multiple X Spaces
 - Attended multiple conferences to get the word out and build partnerships
 
-**Next quarter**
+### Next quarter
 
 - Scale up community calls, podcasts, and AMAs
 - Accelerate our presence on X and explore other channels to raise awareness
@@ -74,11 +74,11 @@ Next quarter will mark a major push in growth, PR, and marketing to set the stag
 
 ## 🧪 Research & Development
 
-**Summary**
+### Summary
 
 Our research efforts continue to advance along two streams: Lituus Labs is moving closer to development, while the Dark Florists remain in deep research. We'll dive into these tracks in a dedicated post soon, but both aim to capture B2C and B2B opportunities, unified under Augur's generalized vision and the REP token.
 
-**This quarter**
+### This quarter
 
 - Continued parallel R&D with Lituus Labs and Dark Florists
 - Dark Florists pivoted to an exciting and unique new design
@@ -86,7 +86,7 @@ Our research efforts continue to advance along two streams: Lituus Labs is movin
 - Drafted and reviewing core sections of the Lituus whitepaper
 - 219 [GitHub commits](https://github.com/AugurProject), multiple new [design drafts](https://github.com/AugurProject/oracle-research), and 13,000+ messages in Discord research channels
 
-**Next quarter**
+### Next quarter
 
 - Release the first version of the Lituus whitepaper for community review
 - Continue toward a merged architecture

--- a/src/content/blog/q1-2026-progress-report/index.mdx
+++ b/src/content/blog/q1-2026-progress-report/index.mdx
@@ -12,7 +12,7 @@ tags: ["augur", "fork", "migration", "lituus", "quarterly"]
 
 ## 🔥 Q1 Fiscal Summary
 
-**Summary**
+### Summary
 
 In the last update, Micah's fork was still ahead of us. Augur was preparing to enter its first live algorithmic fork: disputes would escalate through the onchain dispute process, the system would split into parallel universes if disagreement persisted, and holders would need to migrate to the universe they believed reflected reality.
 
@@ -31,7 +31,7 @@ The fork is the most urgent work in front of us, but it is not the only importan
 
 ## ⚖️ The Fork & REP Migration
 
-**Summary**
+### Summary
 
 During a fork, holders choose the universe they believe reflects reality by migrating REP into that universe, moving economic weight toward the truthful outcome. REP is not a passive asset: it secures Augur's oracle, and that role requires holders to participate when the system reaches this stage.
 
@@ -39,19 +39,19 @@ REP holders must migrate before **August 1, 2026**.
 
 Tokens left in the old universe, or migrated into the wrong universe, may lose economic value. As the deadline gets closer, the public message has become simple: if you hold REP, migrate before the window closes.
 
-**This quarter**
+### This quarter
 
 We published the [migration guide](https://www.augur.net/learn/fork/migration/) and [migration site](https://6.augurfork.eth.limo/). [ForkWatch](https://v3.augur.net/) also went live as a public support page for the migration window, with fork status, migration progress, exchange-support list, and a tool to check whether an address holds REPv1 or REPv2.
 
 For REP held on an exchange, the important question is how that custodian will support migration. Exchange handling can involve exchange-side migration, a user action through the exchange interface, withdrawals, or no support. The Foundation is working with exchanges to make direct or indirect migration support available where possible, but holders should not assume support until it is confirmed. If support is unclear, holders should consider withdrawing REP to a wallet they control and migrating through the official migration site.
 
-**Next quarter**
+### Next quarter
 
 After the migration window closes, we will have a clearer picture of how much REP migrated, how holders and exchanges handled the window, and what the active post-fork REP set looks like.
 
 ## 🧪 Augur & ChainSafe
 
-**Summary**
+### Summary
 
 The foundation partnered with ChainSafe to build Augur Lituus, using the whitepaper as the technical foundation. We are working closely with them to turn that architecture into protocol software, with their team focused on implementation while our team keeps the work consistent with the outlined design.
 
@@ -61,25 +61,25 @@ The new design builds on Augur's fork-based oracle model. REP still sits at the 
 
 Augur's development work continues across two parallel streams: Augur Lituus, focused on protocol and oracle infrastructure, and Dark Florists' oracle and prediction market product on the user-facing side.
 
-**This quarter**
+### This quarter
 
 Public development has started in the [Lituus-CS](https://github.com/AugurProject/Lituus-CS) repository.
 
 Both development streams are fully open source, so progress can be followed directly as the Augur Lituus implementation and Dark Florists product work progress.
 
-**Next quarter**
+### Next quarter
 
 Next quarter, the focus is to make the work easier to follow: continued implementation progress in the repository, and a more accessible written explanation for readers who want to understand Augur Lituus design without reading the full technical paper.
 
 ## 📈 Active REP & Oracle Security
 
-**Summary**
+### Summary
 
 Migration also clarifies Augur's active security set.
 
 Augur's oracle security depends on active REP participation. When disputes reach the fork stage, holders need to show up and migrate into the universe they believe reflects reality.
 
-**This quarter**
+### This quarter
 
 During the fork, active REP moves into the universe that holders believe should carry Augur forward. REP that does not migrate stays behind.
 
@@ -89,17 +89,17 @@ Migration makes the post-fork REP set explicit. REP that moves into the active u
 
 REP is not a passive investment.
 
-**Next quarter**
+### Next quarter
 
 After the window closes, the post-fork REP supply should be easier to reason about because the active security set will be based on the REP that migrated.
 
 ## 🌍 Fork Awareness & Exchanges
 
-**Summary**
+### Summary
 
 A lot of the work this quarter was simple, necessary, and easy to underestimate: do our best to reach REP holders, make it clear that the fork is live, and give them enough practical information to understand what they need to do.
 
-**This quarter**
+### This quarter
 
 At Consensus in Miami, the Lituus Foundation team spoke with multiple exchanges about migration support for REP held in custody. The conversations covered exchange-side migration, possible user-facing migration flows, and the technical or operational requirements each exchange needs before confirming a path.
 
@@ -107,13 +107,13 @@ We also published a series of blog posts on the [Augur website](https://augur.ne
 
 We are also working closely with a professional PR firm to help make sure the fork message reaches REP holders while there is still time to act. The goal is straightforward: get clear migration information in front of the people who need it, reduce confusion around the deadline, and make official links easier to find. We are treating fork awareness as a top priority and making a full push across every channel available to us so REP holders see the fork, understand the deadline, and migrate in time.
 
-**Next quarter**
+### Next quarter
 
 Until August 1, outreach remains focused on migration. We will keep pushing reminders, exchange updates, and holder guidance while holders still need clear information and time to act.
 
 ## 🔮 Looking Ahead
 
-**Summary**
+### Summary
 
 The next month is mostly about the fork.
 
@@ -121,7 +121,7 @@ That means being clear and repetitive where it helps: keep migration reminders v
 
 After the migration window closes, we will publish a follow-up update with final migration numbers, exchange handling, the state of REP after the fork, and the next development milestones.
 
-**Next quarter**
+### Next quarter
 
 The next update should have a clearer picture of where Augur stands after the fork: how much REP migrated, how exchanges handled the migration, and how Augur's development work is progressing in public. For now, the priority remains the same until the window closes: migrate REP, use official links, and do not wait until the final days.
 


### PR DESCRIPTION
## Summary
- Promote standalone quarterly blog labels like Summary, This quarter, and Next quarter from bold paragraphs to h3 headings
- Keep list introducers, signatures, and inline bold callouts as bold text
- Reuse the existing heading icon pipeline for consistent subsection styling

## Verification
- npm run typecheck && npm run lint && npm run build