### PR TITLE
Update drifted documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ Astro 5.10+ static site with React 19 islands. Deployed to GitHub Pages at `www.
 ## Constraints
 
 - **Dual tsconfig** — `tsconfig.app.json` (frontend) and `tsconfig.scripts.json` (scripts). Do not merge.
+- **File naming** — use lowercase kebab-case filenames; keep component symbols PascalCase inside files.
+- **Component cleanup** — audit imports and content usages before moving or deleting components; remove only confirmed-unused modules.
 - **No auto-commit** unless instructed.
 - `.worktrees/` (gitignored) for git worktrees
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ scripts/
 └── probe-fork-state.ts
 
 public/
-├── cache/event-cache.json
-└── data/fork-risk.json
+├── cache/event-cache.json  # Generated and gitignored
+└── data/fork-risk.json     # Generated and gitignored
 
 docs/
 ├── INDEX.md

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -27,7 +27,9 @@ docs/
 ## Writing conventions
 
 - **Filenames:** lowercase, hyphenated. Must match the wikilink reference. Exception: `INDEX.md` is capitalized as the docs entry point.
-- **Frontmatter:** light YAML — `title` (required), `tags` (list, optional). Placed at the top of every doc.
+- **Frontmatter:** light YAML — `title` (required), `tags` (list, optional). Placed at the top of every knowledge page.
+
+  `INDEX.md` and `SCHEMA.md` are operating instructions for the documentation block, not knowledge pages. They intentionally do not use frontmatter.
 
   ```yaml
   ---

--- a/docs/blog-feature.md
+++ b/docs/blog-feature.md
@@ -5,7 +5,7 @@ tags: [blog, feature, mdx, content]
 
 # Blog Feature Documentation
 
-The blog is built on Astro's content collections, allowing you to write posts as Markdown/MDX files with YAML frontmatter. Posts are automatically routed to `/blog/[slug]` with featured images, social sharing, and RSS feed support.
+The blog is built on Astro's content collections, allowing you to write posts as Markdown/MDX files with YAML frontmatter. Posts are automatically routed to `/blog/[slug]` with featured images, social-preview metadata, and RSS feed support.
 
 ---
 
@@ -92,7 +92,7 @@ Create a featured image for your post:
 
 **Image Requirements:**
 - **Size**: 1200 × 630 pixels (1.91:1 aspect ratio - standard OG image size)
-- **Format**: WebP (preferred), PNG, or JPG
+- **Format**: WebP, named exactly `featured-image.webp` so the route glob can import it
 - **File size**: Less than 1MB recommended
 
 **Save the image:**
@@ -123,7 +123,7 @@ Use kebab-case for directory names:
 - ✗ `MyPostTitle/` or `my post title/`
 
 The directory name becomes the URL slug:
-- `generalizing-augur/index.mdx` → `/blog/generalizing-augur`
+- `generalized-augur/index.mdx` → `/blog/generalized-augur`
 
 ### Post Metadata Display
 
@@ -133,7 +133,7 @@ Posts automatically display:
 - **Publish Date**: From `publishDate` frontmatter
 - **Updated Date**: From `updatedDate` (if present)
 - **Featured Image**: On blog listing cards (desktop: left sidebar, mobile: top)
-- **Social Sharing**: Buttons to share on Twitter, LinkedIn, and via email
+- **Social Preview Metadata**: Open Graph and Twitter card metadata derived from the post
 - **Navigation**: Links to next/previous posts
 
 **Note:** Tags are included in frontmatter for RSS categorization but are not displayed on the page.
@@ -210,7 +210,7 @@ src/content/blog/technical-deep-dive/
 └── timeline.webp
 ```
 
-### Social Sharing
+### Social Previews
 
 When you share a blog post on social media (Twitter, LinkedIn, Facebook), the platform automatically:
 1. Pulls the post title from the page
@@ -220,10 +220,7 @@ When you share a blog post on social media (Twitter, LinkedIn, Facebook), the pl
 
 **No extra steps needed**: Your `featured-image.webp` in the post directory is automatically optimized for Open Graph (1200×630, WebP format) at build time and used for social sharing previews.
 
-Each blog post has three share buttons:
-- **Twitter**: Opens Twitter with pre-filled text
-- **LinkedIn**: Opens LinkedIn share dialog
-- **Email**: Opens email composer with post link and description
+The site does not render dedicated share buttons. Sharing is handled by the browser or destination platform using the page metadata.
 
 ### RSS Feed
 
@@ -244,7 +241,7 @@ The RSS feed includes:
 The blog feature provides a listing page (`/blog`) that displays blog posts with featured images and metadata. Blog posts are stored as Markdown/MDX files with co-located assets.
 
 **What was built:**
-- **Featured Images on Listing** - Blog post cards on `/blog` display featured images responsively (mobile: full-width top, desktop: 384×202px left sidebar)
+- **Featured Images on Listing** - Blog post cards on `/blog` display featured images in a responsive grid
 - **Tags Removal** - Tags were removed from blog listing cards to simplify the display
 - **Per-Directory Structure** - Blog posts reorganized from flat files to directories with co-located assets
 
@@ -254,7 +251,7 @@ The blog feature provides a listing page (`/blog`) that displays blog posts with
 src/
 ├── content/
 │   └── blog/
-│       ├── generalizing-augur/
+│       ├── generalized-augur/
 │       │   ├── index.mdx
 │       │   └── featured-image.webp
 │       └── [new-post-name]/
@@ -270,8 +267,8 @@ src/
 ├── pages/
 │   └── blog/
 │       ├── index.astro (blog listing)
-│       ├── [...slug].astro (individual post)
-│       └── rss.xml.ts (RSS feed)
+│       └── [...slug].astro (individual post)
+└── rss.xml.ts (RSS feed)
 ```
 
 ### Design Decisions
@@ -298,24 +295,22 @@ src/
 
 #### 3. Responsive Layout with Tailwind
 
-**Decision:** Use flexbox with breakpoint-driven direction change
+**Decision:** Use a responsive CSS grid for overlapping card regions at medium widths and a two-column layout at large widths
 
 ```astro
-<article class="flex flex-col md:flex-row gap-0 md:gap-6">
-  {/* Image: full-width on mobile, 384px sidebar on desktop */}
+<article class="grid md:grid-cols-[4fr_5fr_3fr] lg:grid-cols-2">
   {featuredImage && (
-    <div class="w-full md:w-64 aspect-191/100">
-      <Image src={featuredImage} alt={title} width={384} height={202} />
+    <div class="md:col-[1/3] lg:col-auto">
+      <Image src={featuredImage} alt={title} class="aspect-191/100" />
     </div>
   )}
-  {/* Content: stack vertically */}
-  <div>Title, metadata, description</div>
+  <a class="md:col-[2/4] lg:col-auto">Title, metadata, description</a>
 </article>
 ```
 
 **Why:**
 - Mobile-first approach: content stacks naturally on small screens
-- Responsive without media query complexity
+- Grid regions create the overlapping card treatment at medium widths
 - Aspect ratio preserved for consistent visual appearance
 
 #### 4. Astro Native Image Optimization
@@ -362,7 +357,7 @@ import { getImage } from 'astro:assets';
 
 // Generate OG image from featured image at build time
 const ogImage = featuredImage
-  ? (await getImage({ src: featuredImage }, { width: 1200, height: 630, format: 'webp' })).src
+  ? (await getImage({ src: featuredImage, width: 1200, height: 630, format: 'webp' })).src
   : undefined;
 ```
 
@@ -464,9 +459,9 @@ Posts are pre-rendered into static HTML at build time. RSS feed is generated in 
 
 #### Modifying Featured Image Dimensions
 
-Featured images render at 384×202px. To change dimensions:
-1. Update `width` and `height` props in `BlogPostCard.astro`
-2. Update `aspect-191/100` Tailwind class to match new ratio (191:100 = 384:202)
+Featured images use a 191:100 display ratio. To change it:
+1. Update the `aspect-191/100` class in `src/features/blog/post-card.astro`
+2. Review the responsive grid treatment at mobile, medium, and large breakpoints
 3. Rebuild to regenerate optimized images
 
 #### Image Optimization

--- a/docs/faq-feature.md
+++ b/docs/faq-feature.md
@@ -53,15 +53,15 @@ Collapsible Q&A styled to match the terminal aesthetic via `.faq-item` and `.faq
 - **Answer content:** Indented, `font-prose` (IBM Plex Mono) font family, `text-foreground`, `text-transform: none` (no uppercase override)
 - **Browser markers:** WebKit and standard `::marker` hidden with `display: none`
 
-## Landing Page Integration
+## Site Integration
 
-The FAQ page is linked from two places on the landing page:
+The FAQ is linked from two site-level entry points:
 
-1. **`MigrationCta.tsx`** — a red-bordered CTA block that links to `/learn/fork/migration/` (the migration guide). This is rendered in the FAQ page itself as an inline call-to-action.
+1. **`src/features/home/hero-banner.tsx`** — direct `/faq` link in the landing-page menu.
 
 2. **`src/components/shell/footer.astro`** — FAQ link in the `>_ KB` section.
 
-The hero no longer contains a direct FAQ link. The original urgent hero item (`THE FORK IS HERE! OWN REP? ACT NOW.`) was removed when the hero was refactored to CSS-driven animation. The migration guide in `learn/fork/migration/` now serves as the primary entry point for fork/migration content.
+The FAQ page also renders `src/features/learn/migration-cta.tsx`, a red-bordered inline CTA linking to `/learn/fork/migration/`.
 
 ## Footer Integration
 

--- a/docs/fork-monitoring-pipeline.md
+++ b/docs/fork-monitoring-pipeline.md
@@ -41,7 +41,7 @@ risk-monitor          →  build              →  deploy
 1. Shallow checkout (`fetch-depth: 1`)
 2. Restore event cache from `actions/cache`
 3. Run `scripts/calculate-fork-risk.ts`
-4. Cache auto-saves after the step
+4. On a cache miss, save the resulting cache under `event-cache-v1`
 5. Upload `fork-risk.json` as artifact (`fork-risk-data`)
 
 ### build (always runs, needs: risk-monitor)
@@ -89,15 +89,15 @@ For first-ever deploys, the site doesn't exist until `risk-monitor` succeeds at 
     key: event-cache-v1
 ```
 
-**Static key**: always overwrites the same entry. No proliferation of cache entries.
+**Current limitation:** GitHub Actions cache entries are immutable. Once `event-cache-v1` exists for a ref, later exact-key hits restore that snapshot but do not replace it with the file updated by the script. Repository cache metadata confirms that the `main` cache was created on April 22, 2026 and has only been accessed since. The workflow remains functional, but it does not persist incremental cache updates across runs as intended.
 
 ### Why not `hashFiles`
 
-The previous workflow used `event-cache-${{ runner.os }}-${{ hashFiles('public/cache/event-cache.json') }}`. Since the script updates tracked markets every run, the file hash changes every run, creating a new cache entry each time. The repo accumulated 148+ entries. A static key keeps it to one.
+The previous workflow used `event-cache-${{ runner.os }}-${{ hashFiles('public/cache/event-cache.json') }}`. Since the script updates tracked markets every run, the file hash changed every run and created a new cache entry each time. The static key stopped that proliferation, but it also stopped updated state from being saved. A future workflow fix should use unique save keys with a stable restore prefix, or explicitly replace the existing cache.
 
 ### Cold start (cache evicted)
 
-When the cache is missing, the script performs a 30-day event scan (~7 minutes, ~835 RPC calls). The seed file ensures no markets are missed. The cache is warm for the next run.
+When the cache is missing, the script performs a 30-day event scan (~7 minutes, ~835 RPC calls). The seed file supplies the known-market baseline. With the current static key, the first successful result becomes the immutable snapshot restored by later runs.
 
 ---
 
@@ -122,9 +122,9 @@ Top-level group for the entire workflow. Prevents:
 |----------|--------|
 | RPC endpoint down | Script auto-falls back to next endpoint |
 | All RPC endpoints fail | Script fails → pipeline stops → retry next hour |
-| Cache missing | 30-day scan + seed file, warm cache for next run |
+| Cache missing | 30-day scan + seed file; successful job creates the static cache snapshot |
 | Artifact missing in build | Build fails → no deploy → site stays on last good version |
-| Workflow failure | Cache unchanged from last successful save, retry next hour |
+| Workflow failure | No deploy; retry on the next scheduled run |
 
 ---
 
@@ -134,7 +134,7 @@ Top-level group for the entire workflow. Prevents:
 |------|-------|------|
 | Incremental (warm cache) | ~175 | ~30 seconds |
 | Cold start (cache evicted) | ~835 | ~7 minutes |
-| Daily (24 incremental runs) | ~670 | Well within free tier |
+| Daily (24 incremental runs) | ~4,200 at ~175 calls/run | Estimate; actual usage varies with block range and tracked markets |
 
 ---
 

--- a/docs/public-data-endpoints.md
+++ b/docs/public-data-endpoints.md
@@ -7,16 +7,9 @@ tags: [data, api, external-consumers, fork-risk]
 
 Augur.net serves structured JSON at stable URLs under `/data/` for external consumers: exchanges, dashboards, fork trackers, community explorers, and integrator tools.
 
-## Convention
+## Compatibility
 
-Every endpoint carries:
-
-| Field | Type | Description |
-|---|---|---|
-| `generatedAt` | `string` (ISO 8601) | When the data was last computed. Poll this to detect staleness. |
-| `schemaVersion` | `string` | Semantic version of the response shape. Increments on breaking changes. |
-
-Adding a field is safe. Renaming or removing a top-level field is a breaking change — coordinate with known consumers.
+The current endpoint does not expose an explicit schema version. Treat renaming, removing, or changing the type of an existing field as a breaking change and coordinate it with known consumers. Adding an optional field is backward-compatible.
 
 ## Endpoints
 
@@ -34,17 +27,16 @@ Pipeline: scripts/calculate-fork-risk.ts
 
 | Field | Type | Description |
 |---|---|---|
-| `generatedAt` | `string` (ISO 8601) | Last pipeline run timestamp |
-| `schemaVersion` | `string` | Response shape version |
-| `blockNumber` | `number` | Ethereum block at time of calculation |
+| `lastRiskChange` | `string` (ISO 8601) | Timestamp of the latest calculation. Poll this to detect staleness. |
+| `blockNumber` | `number`, optional | Ethereum block at time of calculation; omitted from error results |
 | `riskLevel` | `enum` | `none` \| `low` \| `moderate` \| `high` \| `critical` \| `unknown` |
 | `riskPercentage` | `number \| null` | Round progress as percentage (0–100). `null` when projection unavailable. |
 | `metrics` | `object` | Dispute and escalation metrics (below) |
-| `rpcInfo` | `object` | RPC endpoint used, latency, fallback count |
+| `rpcInfo` | `object`, optional | RPC endpoint used, latency, fallback count |
 | `calculation` | `object` | `forkThreshold` — REP threshold that triggers fork |
-| `cacheValidation` | `object` | Cache health: `isHealthy: boolean`, optional `discrepancy` |
-| `forkActive` | `object \| null` | Present only when fork is live (below) |
-| `error` | `string \| null` | Error message if pipeline failed |
+| `cacheValidation` | `object`, optional | Cache health: `isHealthy: boolean`, optional `discrepancy` |
+| `forkActive` | `object`, optional | Present only when a fork is live (below) |
+| `error` | `string`, optional | Error message if the pipeline failed |
 
 #### `metrics`
 
@@ -60,7 +52,7 @@ Pipeline: scripts/calculate-fork-risk.ts
 
 #### `forkActive`
 
-Present and non-null only when a fork is live. Absent (`null` or missing) otherwise.
+Present only when a fork is live. Omitted otherwise.
 
 | Field | Type | Description |
 |---|---|---|


### PR DESCRIPTION
## What changed

- clarify that docs/INDEX.md and docs/SCHEMA.md are operating instructions that intentionally omit frontmatter
- align blog, FAQ, public-data, and monitoring documentation with the current implementation
- mark generated public artifacts in the repository tree
- capture the established filename and component-cleanup conventions in AGENTS.md

## Why

Several documentation examples and behavioral descriptions still reflected earlier component paths, layouts, endpoint fields, and cache assumptions. This update makes the written guidance match the code and observed GitHub Actions cache behavior.

## Impact

Contributor guidance and external endpoint documentation are more accurate. There are no application or workflow code changes.

## Validation

- npm run typecheck
- npm run lint
- npm run build
- git diff --check