### PR TITLE
Add lifecycle-aware post-fork landing page states

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,6 +21,7 @@ Start here to find the right doc. Read deeper only when the task calls for it.
 | Doc | When to Read |
 |---|---|
 | [Technical Architecture](technical-architecture.md) | React/TypeScript component hierarchy, state management (Context API), UI patterns, visual rendering |
+| [Post-Fork Landing Page Implementation Plan](post-fork-landing-page-implementation-plan.md) | Implementation status and rollout plan for the migration CTA/countdown, verified Fork Record, and lifecycle data contract |
 | [Public Data Endpoints](public-data-endpoints.md) | Structured JSON endpoints at /data/*.json for external consumers — schemas, conventions, adding new endpoints |
 | [FAQ Feature](faq-feature.md) | FAQ page design, route, collapsible Q&A, landing page/footer integration |
 | [Blog Feature](blog-feature.md) | Blog frontmatter schema, MDX integration, RSS feed, Learn section |

--- a/docs/fork-monitoring-pipeline.md
+++ b/docs/fork-monitoring-pipeline.md
@@ -40,7 +40,7 @@ risk-monitor          →  build              →  deploy
 
 1. Shallow checkout (`fetch-depth: 1`)
 2. Restore event cache from `actions/cache`
-3. Run `scripts/calculate-fork-risk.ts`
+3. Run `scripts/calculate-fork-risk.ts` (including the post-deadline fork-record preservation path)
 4. On a cache miss, save the resulting cache under `event-cache-v1`
 5. Upload `fork-risk.json` as artifact (`fork-risk-data`)
 
@@ -122,6 +122,7 @@ Top-level group for the entire workflow. Prevents:
 |----------|--------|
 | RPC endpoint down | Script auto-falls back to next endpoint |
 | All RPC endpoints fail | Script fails → pipeline stops → retry next hour |
+| Parent universe reports `isForking()` false after the deadline | The calculation path re-reads fork metadata and preserves the historical record; if metadata cannot be verified, it emits an unavailable result instead of ordinary risk data |
 | Cache missing | 30-day scan + seed file; successful job creates the static cache snapshot |
 | Artifact missing in build | Build fails → no deploy → site stays on last good version |
 | Workflow failure | No deploy; retry on the next scheduled run |

--- a/docs/fork-monitoring-pipeline.md
+++ b/docs/fork-monitoring-pipeline.md
@@ -122,7 +122,8 @@ Top-level group for the entire workflow. Prevents:
 |----------|--------|
 | RPC endpoint down | Script auto-falls back to next endpoint |
 | All RPC endpoints fail | Script fails → pipeline stops → retry next hour |
-| Parent universe reports `isForking()` false after the deadline | The calculation path re-reads fork metadata and preserves the historical record; if metadata cannot be verified, it emits an unavailable result instead of ordinary risk data |
+| Parent universe reports `isForking()` false after the deadline | The calculation path re-reads fork metadata and preserves the historical record |
+| Lifecycle metadata read fails | The script retries the RPC endpoints; if none can verify lifecycle state, the job fails and no deploy occurs, preserving the last verified site |
 | Cache missing | 30-day scan + seed file; successful job creates the static cache snapshot |
 | Artifact missing in build | Build fails → no deploy → site stays on last good version |
 | Workflow failure | No deploy; retry on the next scheduled run |

--- a/docs/migration-guide-feature.md
+++ b/docs/migration-guide-feature.md
@@ -5,7 +5,7 @@ tags: [migration, feature, learn, fork]
 
 # Migration Guide Feature
 
-> The Moon Fork migration guide: a step-by-step walkthrough for REP holders who must migrate before the deadline.
+> The Moon Fork migration guide: a step-by-step walkthrough for REP holders while the migration window is open, preserved as historical reference after closure.
 
 ## Overview
 
@@ -41,7 +41,7 @@ The migration guide lives at `/learn/fork/migration/` and uses a dedicated **Mig
 
 A dedicated layout distinct from [[technical-architecture]]'s standard LearnLayout:
 
-- **Header**: Red-bordered alert box with `CRITICAL · MIGRATION IMMINENT` eyebrow and deadline display (default: "AUGUST 1, 2026")
+- **Header**: Red-bordered alert box with `CRITICAL · MIGRATION IMMINENT` while migration is open; after closure it becomes a state-aware Fork Record or verification-pending header with the recorded deadline.
 - **Navigation**: Uses the same `LearnNavigation.tsx` sidebar with migration guide as the first/critical topic
 - **Prose**: Same typographic treatment as LearnLayout articles
 

--- a/docs/post-fork-landing-page-implementation-plan.md
+++ b/docs/post-fork-landing-page-implementation-plan.md
@@ -1,0 +1,559 @@
+---
+title: Post-Fork Landing Page Implementation Plan
+tags: [homepage, fork, post-fork, implementation, github-actions]
+---
+
+# Post-Fork Landing Page Implementation Plan
+
+## Status
+
+**Implementation complete locally; post-deadline observation pending.** This document defines the change from the current fork-migration hero to a durable post-fork record. Protocol signals are verified, the versioned fork JSON contract and lifecycle derivation are implemented, the on-chain generator emits the winner, the data job preserves the record when `isForking()` flips false at closure, and the local UI now covers open, resolved-open, closed-resolved, and closed-unverified states. Monitoring continues after closure; reducing its cadence is a separate operational follow-up.
+
+## Local Review Demo
+
+The first visual slice is available locally while the full post-fork transition remains phased:
+
+1. Start the site with `npm run dev`.
+2. [Click “DEV: F2 for demo”](http://localhost:4321/) in the upper-left corner, or press `F2`.
+3. Select an **Active Fork** scenario to review the original live/main CTA while the winner is unknown.
+4. Select **Winner Known — Migration Still Open** to review the closing-window CTA while migration remains actionable.
+5. Select **Winner Known — Closing (~1 Day)** to review the same resolved state near the deadline.
+6. Select **Migration Closed — Fork Record** to review the historical record and resolution dialog.
+7. Select **Migration Closed — Winner Pending** to review the safe post-deadline fallback.
+8. Select **Return to Fork JSON Data** to restore the local fork JSON data.
+
+The demo controls are development-only and are not rendered in production builds. They exercise the same lifecycle derivation used by the CTA and lower hero, including the rule that a known winner does not reveal the Fork Record before the deadline.
+
+The local CTA copy is tied to the lifecycle signal: an unknown winner keeps the original live/main copy, while an established winner uses the closing-window copy for as long as migration remains open.
+
+## Protocol Verification Snapshot
+
+The read-only probe confirmed the Phase 0 contract semantics against Ethereum mainnet at block `25,662,284`:
+
+- Forking universe: `0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA`.
+- `isForking()` is `true`.
+- `getForkEndTime()` is `2026-08-03T01:00:59Z`, the current migration deadline exposed by the contract.
+- `getWinningChildUniverse()` returns `0x281171519Fb41540528398d8ED3EA257f0F32A9f` before the deadline.
+- That child matches outcome index `1` (`Yes`) and its migrated REP supply exceeds the fork reputation goal.
+
+This confirms the transitional state used by the local demo: a winner can be established while migration remains open. The probe result is an acceptance fixture, not a permanent claim about future chain state; generated data must continue to read these values from the contract.
+
+## Confirmed Product Decisions
+
+- After the migration deadline, the landing page presents the Fork Record while monitoring continues.
+- Revisit monitoring cadence after closure; a future protocol change or new oracle work can justify a later schedule change.
+- `VIEW RESOLUTION` opens a dialog.
+- Etherscan is the initial verification destination.
+- The Fork Record remains in the hero temporarily; its eventual move to a historical section can be decided later.
+- Migration CTAs link to the full guide at `/learn/fork/migration/`.
+
+## Goal
+
+Turn the lower landing-page hero from an action-oriented migration warning into a state-aware account of the fork:
+
+- While migration is open, preserve the urgent REP migration action, countdown, and progress.
+- If a winning child universe is known before the deadline, switch only the CTA to the closing-window copy; keep the existing countdown and migration progress presentation.
+- After migration closes, remove the action CTA and replace the countdown with a factual, inspectable Fork Record.
+- Ground every canonical-universe claim in the fork JSON data generated from on-chain state.
+- Revisit the monitoring cadence separately after the historical record is stable; this landing-page change does not retire the fork monitor.
+
+The core post-fork message remains:
+
+> The protocol reached consensus. A canonical universe emerged. The reboot continues.
+
+The page should present that as provenance, not as a security score, victory claim, or request for trust.
+
+## Non-Goals
+
+- Redesigning the entire homepage, navigation, featured posts, mission page, FAQ, or migration guide in the first release.
+- Removing the migration experience before the migration window closes.
+- Inventing a numerical confidence or security score.
+- Treating a client-side countdown reaching zero as proof that a winner exists.
+- Renaming the public `/data/fork-risk.json` endpoint during the transition.
+- Deleting scripts, components, cache files, or workflow jobs before their consumers and fallback value are audited.
+
+## Current-State Audit
+
+### User interface
+
+The hero now renders two coordinated elements that are semantically one experience:
+
+1. **State-aware CTA** in `src/features/fork-monitor/fork-action.tsx`: “THE FORK IS HERE! OWN REP? ACT NOW.” or the closing-window copy.
+2. **Lifecycle monitor** in `src/features/fork-monitor/display.tsx`.
+
+The CTA and monitor now share `ForkExperience` and derive the state from the fork record. The monitor previously chose the active-fork card when:
+
+```ts
+rawData.metrics.disputeDetails[0]?.marketId === "FORKING"
+```
+
+This sentinel remains in the compatibility fields, but it is no longer the UI lifecycle contract. The browser derives the presentation from the versioned fork record and current time, so the CTA disappears at the verified deadline and the lower hero cannot render a zeroed migration countdown as a post-fork record.
+
+### Fork JSON data
+
+`public/data/fork-risk.json` currently contains:
+
+- pre-fork risk metrics;
+- an artificial `FORKING` dispute record;
+- `forkActive.forkEndTime`;
+- the forking market;
+- the reputation goal;
+- parent-universe REP supply;
+- outcome labels, child universes, migrated REP totals, and the contract-reported winner.
+
+Schema version 2 now adds the explicit fork record, winner, outcome mapping, generation timestamp, and observed block while preserving the existing fields and `forkActive` shape.
+
+### Script and protocol access
+
+`scripts/calculate-fork-risk.ts` checks `universe.isForking()`. When true, it emits a maximum-risk result and active-fork details, including `getWinningChildUniverse()`, child REP token addresses, and the normalized fork record. The generated result is validated before it is written.
+
+`scripts/probe-fork-state.ts` already includes `getWinningChildUniverse()` and can walk from a parent universe into the winning child. It is diagnostic-only and does not write the fork JSON data.
+
+### GitHub Actions
+
+`.github/workflows/build-and-deploy.yml` currently runs hourly and on push, pull request, and manual dispatch:
+
+```text
+risk-monitor → build → deploy
+```
+
+Every hourly run recalculates the fork JSON data, rebuilds the entire site, and deploys the result on `main`. The landing-page change does not alter that workflow; a later cadence adjustment belongs to a separate CI change.
+
+The existing event cache uses an immutable exact key (`event-cache-v1`), so its updated contents are not persisted across warm runs as intended. That issue is relevant only while dispute discovery remains active.
+
+### Migration warning content
+
+The hero is not the only place that presents migration as an active emergency. These surfaces now derive their active/closed treatment from the same build-time fork JSON lifecycle:
+
+- `src/pages/faq.astro`: urgent intro, red migration CTA, “Open now” timeline copy, deadline instructions, and current ForkWatch wording.
+- `src/features/learn/migration-cta.tsx`: active critical CTA remains available while migration is open.
+- `src/content/learn/fork/index.mdx`: critical migration banner becomes a closed-window record notice.
+- `src/content/learn/fork/what-to-do.mdx`: risk guidance is explicitly framed as historical after the migration window closes.
+- `src/layouts/MigrationGuideLayout.astro` and `src/content/learn/fork/migration.mdx`: deadline alert, navigation marker, description, and closed-window framing are state-aware.
+- `src/layouts/LearnLayout.astro` and `src/features/learn/navigation.tsx`: the migration guide's `ACT NOW` treatment is removed after closure through the `critical` state.
+- `src/pages/mission.astro`: current-tense migration-window timeline copy becomes a historical milestone.
+- `src/lib/fork-data.ts`: build-time state reader used by Astro pages and layouts.
+
+Historical blog posts should remain available as historical material. They should not be rewritten as if they describe the current state, but can receive an archive/date treatment if the release review finds the context unclear.
+
+## Lifecycle Contract
+
+The user experience must distinguish resolution from the migration deadline. The fork can resolve early when one child receives more than the reputation goal, while REP migration remains available for the full migration window.
+
+### Required states
+
+| State | Winner known | Migration deadline passed | Hero CTA | Lower hero |
+|---|---:|---:|---|---|
+| `monitoring` | No | No fork | None or existing monitor treatment | Pre-fork risk monitor |
+| `migration-open` | No | No | `THE FORK IS HERE! OWN REP? ACT NOW.` | Countdown and migration progress |
+| `migration-open-resolved` | Yes | No | `MIGRATION WINDOW CLOSING, ACT NOW!` | Existing countdown and migration progress |
+| `migration-closed-resolved` | Yes | Yes | No migration CTA | Fork Record |
+| `migration-closed-unverified` | No/unknown | Yes | No migration CTA | Resolution pending verification |
+| `data-unavailable` | Unknown | Unknown | No consequential CTA | Honest unavailable/stale state |
+
+### Authoritative inputs
+
+- **Winner known:** a non-zero `getWinningChildUniverse()` result from the parent universe contract, matched to an emitted outcome. An outcome exceeding the reputation goal is supporting evidence.
+- **Migration open:** current time is earlier than the verified migration deadline represented by the existing `forkEndTime` field. Phase 0 confirmed that this contract value is the active migration deadline for the deployed Augur implementation.
+- **Migration closed:** current time is at or after that deadline.
+- **Canonical universe:** the exact winning child universe returned by the contract, matched to the corresponding outcome record.
+
+### Time handling
+
+The generated lifecycle field is a snapshot, but the browser remains open while time passes. The UI therefore derives presentation from both the fork JSON data and current time:
+
+```text
+winner signal from fork JSON data
+        +
+fork deadline from fork JSON data
+        +
+current browser time
+        ↓
+derived hero state
+```
+
+The browser may hide the migration CTA once a verified deadline passes, even if the fork JSON data is stale. It must not declare a canonical universe unless the fork JSON data contains the authoritative winner signal.
+
+## Proposed Fork JSON Data Contract
+
+Keep `/data/fork-risk.json` during the migration to avoid breaking the UI or external consumers. Make the change additive and versioned.
+
+Illustrative shape:
+
+```json
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-02T00:00:00.000Z",
+  "fork": {
+    "status": "migration-open-resolved",
+    "parentUniverse": "0x...",
+    "forkingMarket": "0x...",
+    "migrationDeadline": 1785718859,
+    "reputationGoal": 5497186.88,
+    "winningChildUniverse": "0x...",
+    "outcomes": [
+      {
+        "index": 1,
+        "label": "Yes",
+        "childUniverse": "0x...",
+        "reputationToken": "0x...",
+        "migratedRep": 6454838.02,
+        "isWinner": true
+      }
+    ]
+  },
+  "metrics": {}
+}
+```
+
+Final field names should follow what the contract actually exposes. During the compatibility period, preserve `forkActive` and the existing risk fields while the new `fork` object is introduced. The UI should prefer schema version 2 and retain a tested adapter for the current shape until the transition deploy is stable.
+
+### Runtime validation
+
+Before writing the fork JSON data, the calculation script should reject internally inconsistent states, including:
+
+- `status` claims resolution but `winningChildUniverse` is zero or absent;
+- a winning child does not match any emitted outcome;
+- migration deadline is missing during an active or resolved fork;
+- duplicate child universe addresses;
+- negative or non-finite REP values;
+- malformed Ethereum addresses;
+- generated timestamp or observed block is missing.
+
+A validation failure should fail the data job. The existing deployed site then remains on its last good fork JSON data rather than publishing a false canonical claim.
+
+## Proposed User Experience
+
+### Migration open, winner not yet known
+
+Preserve the current experience, with copy and layout refinement only if needed:
+
+```text
+THE FORK IS HERE! OWN REP? ACT NOW.
+
+FORK ACTIVE, MIGRATING
+01 DAYS 08 HRS 28 MIN 55 SEC
+58.7% REP MIGRATED
+```
+
+### Migration open, winner known
+
+Migration remains actionable. The winner signal changes only the CTA copy; the lower hero stays on the existing migration countdown and progress presentation. Do not show the Fork Record, canonical-universe declaration, or `VIEW RESOLUTION` before the migration window closes:
+
+```text
+MIGRATION WINDOW CLOSING, ACT NOW!
+
+FORK ACTIVE, MIGRATING
+01 DAYS 08 HRS 28 MIN 55 SEC
+58.7% REP MIGRATED
+```
+
+This is the transitional state demonstrated locally. The historical record begins only after the verified migration deadline passes.
+
+### Migration closed, winner known
+
+Remove the urgent CTA and countdown. The lower hero becomes the historical record:
+
+```text
+THE FORK RECORD
+
+A canonical universe emerged.
+The reboot continues.
+
+CANONICAL UNIVERSE
+0x2811...A9f
+
+[ VIEW RESOLUTION ]
+```
+
+`VIEW RESOLUTION` is disclosure, not a required action. It opens an accessible dialog using the project’s existing dialog primitives. The first version should contain:
+
+```text
+Legacy Universe
+      ↓
+Fork Triggered
+      ↓
+REP Migration
+      ↓
+Canonical Universe
+      ↓
+Reboot Continues
+```
+
+Each step presents factual fields only: addresses, block or timestamp where available, outcome, migration totals, and external verification links. Editorial claims should remain outside the data layer.
+
+### Migration closed, winner unverified
+
+Do not retain a zeroed countdown and do not guess the winner:
+
+```text
+MIGRATION WINDOW CLOSED
+
+Resolution pending verification.
+Last checked: ...
+```
+
+This is the safe state for RPC failure, a stale fork JSON file, or an unexpected contract transition.
+
+## Component Architecture
+
+The CTA and monitor need one data owner so they cannot disagree.
+
+```text
+HeroBanner
+└── ForkExperienceProvider
+    ├── HeroForkAction
+    ├── ForkExperienceDisplay
+    │   ├── ActiveMigrationCard
+    │   ├── ForkRecord
+    │   └── ForkDataUnavailable
+    └── ForkControls (development only)
+```
+
+Recommended implementation details:
+
+- Move `ForkDataProvider` and `ForkMockProvider` high enough to serve both the CTA and lower display.
+- Extract lifecycle derivation into a pure function such as `derive-fork-lifecycle.ts`.
+- Keep time-dependent rendering in one hook so the CTA and countdown transition together.
+- Keep `active-card.tsx` during migration; do not overload it with post-fork presentation.
+- Add `post-fork-record.tsx` for the historical state and its resolution dialog.
+- Keep the existing error boundary around the complete fork experience.
+- Preserve development-only F2 controls and add explicit lifecycle scenarios.
+
+## Expected File Changes
+
+| File | Change |
+|---|---|
+| `src/features/home/hero-banner.tsx` | Remove the unconditional migration CTA; render state-aware action and display under one provider |
+| `src/features/fork-monitor/monitor.tsx` | Evolve into the shared fork-experience boundary or deprecate after its provider responsibilities move |
+| `src/features/fork-monitor/clock.tsx` | Provide one ticking timestamp so CTA, countdown, and closed-state transition together |
+| `src/features/fork-monitor/display.tsx` | Switch on the derived lifecycle instead of the `FORKING` sentinel |
+| `src/features/fork-monitor/active-card.tsx` | Preserve active migration behavior; accept normalized lifecycle data |
+| `src/features/fork-monitor/fork-action.tsx` | State-aware migration CTA that preserves the original copy until a winner is known, then uses the closing copy while migration remains open |
+| `src/features/fork-monitor/derive-fork-lifecycle.ts` | New pure lifecycle derivation and safety rules |
+| `src/features/fork-monitor/validate-fork-data.ts` | Validate versioned data before it reaches the UI or build-time content |
+| `src/features/fork-monitor/data-provider.tsx` | Parse versioned fork JSON data and expose normalized state |
+| `src/features/fork-monitor/types.ts` | Add schema version, fork resolution fields, and normalized lifecycle types |
+| `src/features/fork-monitor/demo-data.ts` | Add open-unresolved, open-resolved, closed-resolved, and closed-unverified fixtures |
+| `src/features/fork-monitor/controls.tsx` | Make the local demo trigger clickable, expose the closing-window scenario, and rename “Return to Live Data” to “Return to Fork JSON Data” |
+| `src/features/fork-monitor/post-fork-record.tsx` | Render the closed Fork Record, resolution dialog, and unverified fallback |
+| `src/pages/faq.astro` | Replace or state-gate active migration warnings after the deadline while retaining useful fork mechanics and safety information |
+| `src/features/learn/migration-cta.tsx` | Preserve the shared critical CTA for the open-migration state |
+| `src/content/learn/fork/index.mdx` | Update the fork explainer’s time-bound migration banner |
+| `src/content/learn/fork/what-to-do.mdx` | State-gate active fork-risk guidance and label it historical after closure |
+| `src/layouts/MigrationGuideLayout.astro` | Replace the post-deadline critical alert and migration navigation treatment |
+| `src/content/learn/fork/migration.mdx` | Preserve the guide as historical/reference material and update its closed-window framing |
+| `src/layouts/LearnLayout.astro` | Remove or state-gate the critical migration navigation marker |
+| `src/features/learn/navigation.tsx` | Remove or state-gate the `ACT NOW` label after closure |
+| `src/pages/mission.astro` | Convert current-tense migration timeline copy into a historical milestone |
+| `src/lib/fork-data.ts` | Read the generated fork JSON during static builds for state-gated content |
+| `src/styles/global.css` | Coordinate CTA/record spacing, entrance animation, responsive layout, and reduced motion |
+| `scripts/calculate-fork-risk.ts` | Read winner and parent/child data, emit schema v2, validate before writing |
+| `scripts/probe-fork-state.ts` | Confirm and retain diagnostic coverage for the exact resolution signals |
+| `public/data/fork-risk.json` | Generated fixture/snapshot updated to the compatible schema |
+| `package.json` | Add targeted lifecycle/data tests if needed; retain dual-tsconfig commands |
+| `scripts/fork-lifecycle.test.ts` | Exercise lifecycle boundaries and malformed winner data |
+| `docs/public-data-endpoints.md` | Document the additive schema and compatibility window |
+| `docs/technical-architecture.md` | Update the homepage component hierarchy and state ownership |
+
+## Delivery Phases
+
+Estimates are implementation effort, not calendar commitments. Review and protocol verification can extend elapsed time.
+
+### Phase 0 — Verify protocol signals and lifecycle semantics — COMPLETE FOR CURRENT SNAPSHOT
+
+**Estimate:** 0.5–1 day
+
+**Work:**
+
+- Run the diagnostic probe against the parent universe and forking market.
+- Confirm the behavior of `isForking()`, `getForkEndTime()`, and `getWinningChildUniverse()` before and after early resolution.
+- Confirm whether `forkEndTime` is the full REP migration deadline in this deployed contract.
+- Match the winning child address to the correct outcome and REP token.
+- Record the exact block and timestamp used for acceptance fixtures.
+- Resolve terminology: “winning universe” is protocol language; “canonical universe” is presentation language.
+
+**Gate:** Satisfied for the current contract snapshot. The generated data must continue to re-read these values on each run.
+
+### Phase 1 — Data contract and lifecycle foundation — COMPLETE LOCALLY
+
+**Estimate:** 1–1.5 days
+
+**Work:**
+
+- Add schema version 2 fields additively.
+- Extract lifecycle derivation into a pure, testable function.
+- Implement backward compatibility for the current fork JSON shape.
+- Add deterministic fixtures for every lifecycle state.
+- Add runtime validation to the data generation path.
+- Add tests for deadline boundaries, winner absence, stale data, and malformed records.
+
+**Gate:** Lifecycle tests pass without rendering UI, including one second before, exactly at, and one second after the migration deadline.
+
+### Phase 2 — Local visual implementation — COMPLETE LOCALLY
+
+**Estimate:** 1.5–2.5 days plus visual review
+
+**Work:**
+
+- Bring the CTA and monitor under one provider and lifecycle state.
+- Preserve the current active migration card.
+- Add the open-resolved transitional presentation.
+- Build the closed-resolved Fork Record and resolution dialog.
+- Add the closed-unverified fallback.
+- Extend F2 controls for side-by-side local review.
+- Test desktop, tablet, and mobile layouts plus reduced motion.
+
+**Gate:** Every lifecycle can be selected locally without editing source or the fork JSON file, and the CTA never contradicts the lower panel.
+
+### Phase 3 — Script integration with on-chain state — COMPLETE LOCALLY
+
+**Estimate:** 1–2 days
+
+**Work:**
+
+- Move the verified winner-reading logic from the probe into the calculation path.
+- Emit parent universe, winning child, outcome mapping, observed block, and generated timestamp.
+- Preserve RPC fallback behavior.
+- Fail safely on contradictory or incomplete resolution data.
+- Run the script locally and compare output with the Phase 0 acceptance fixture.
+
+**Gate:** Two independent reads against the same finalized block produce equivalent lifecycle and winner data.
+
+### Phase 4 — Fork data handoff — COMPLETE LOCALLY; CI FOLLOW-UP SEPARATE
+
+**Estimate:** 0.5–1 day
+
+**Work:**
+
+- Preserve the fork record if the parent universe stops reporting `isForking()` immediately after the migration deadline.
+- Keep the existing CI schedule and artifact flow unchanged in this landing-page PR.
+- Handle monitoring cadence and event-cache persistence in the separate CI workstream.
+
+**Gate:** The generated data preserves the fork record after closure, and the existing build continues to receive the JSON artifact.
+
+### Phase 5 — Content, accessibility, and release verification — COMPLETE LOCALLY; RELEASE GATE PENDING
+
+**Estimate:** 0.5–1 day
+
+**Work:**
+
+- Finalize hero and Fork Record copy.
+- Review every active migration warning and convert closed-window content to historical or post-fork guidance.
+- Validate canonical addresses, labels, links, timestamps, and migrated REP totals.
+- Verify keyboard navigation, focus return, dialog labeling, contrast, reduced motion, and screen-reader names.
+- Run `npm run typecheck`, `npm run typecheck:scripts`, `npm run lint`, lifecycle/data tests, and `npm run build`.
+- Render all lifecycle states locally and capture screenshots for review.
+
+**Gate:** Product, data, responsive, and accessibility success criteria are all met.
+
+### Phase 6 — Post-fork monitoring follow-up
+
+**Earliest timing:** after the migration deadline, authoritative winner verification, and a stable post-close deployment. A 24–48 hour observation buffer is recommended.
+
+**Estimate:** 0.5–1.5 days, depending on the ongoing-monitor decision
+
+- Revisit the monitoring cadence and cache persistence separately.
+- Decide whether monitoring should follow the winning universe or remain a historical fork-state monitor.
+- Preserve the Fork Record as part of the public state surface.
+
+**Gate:** The follow-up has an explicit cadence, stale-data policy, and ownership decision before any schedule or cache changes are made.
+
+## CI and Rollout Strategy
+
+### Before migration closes
+
+- Keep hourly calculation, build, and deployment.
+- Publish additive fork JSON fields.
+- Deploy UI compatibility before relying on the new fields.
+- Keep migration CTA and countdown available whenever the deadline is still open.
+
+### At the deadline
+
+- The browser removes the migration CTA based on the verified deadline.
+- The UI shows the Fork Record only if the winner is present and valid in the fork JSON data.
+- Otherwise it shows “Resolution pending verification.”
+- The next successful hourly run confirms the post-close state and republishes the site.
+
+### After the deadline
+
+- Keep monitoring while the post-close state is observed.
+- Keep the Fork Record as the historical presentation.
+- Decide the lower-frequency schedule in the separate CI follow-up.
+
+### Rollback
+
+- UI rollback: select the compatibility adapter and render the existing active card from the current fork JSON shape.
+- Data rollback: schema v2 is additive, so older UI continues reading existing fields.
+- CI rollback: preserve the existing artifact/build/deploy chain; schedule and cache changes are outside this PR.
+- Content rollback: if canonical verification becomes questionable, force the closed-unverified presentation without restoring a migration CTA after the deadline.
+
+## Test Matrix
+
+| Scenario | Expected result |
+|---|---|
+| No `fork` and no `forkActive` | Existing pre-fork monitor or safe unavailable state |
+| Migration open, no winner | Migration CTA, countdown, progress |
+| Migration open, winner known | Closing CTA with the existing countdown and migration progress; no Fork Record or resolution disclosure |
+| One second before deadline | Migration CTA present |
+| Exactly at deadline | Migration CTA removed |
+| After deadline, winner known | Fork Record shown |
+| After deadline, winner absent | Resolution pending verification |
+| Winner does not match an outcome | Data validation fails; no deploy |
+| Fork JSON fetch fails | Honest unavailable state; no false canonical claim |
+| Fork JSON is stale across deadline | CTA closes by deadline; canonical claim still requires winner data |
+| Reduced motion | No entrance, pulse, bob, or countdown motion required to understand state |
+| Mobile viewport | Record and dialog remain readable without horizontal overflow |
+
+## Success Criteria
+
+### Product and messaging
+
+- The page answers what happened, where the protocol is now, and how the result can be verified.
+- No migration action is shown after the verified deadline.
+- A migration action remains visible while migration is still possible, even if a winner has already been established.
+- The Fork Record and resolution dialog never appear before the verified migration deadline.
+- “Canonical universe” is never asserted from migration percentages alone.
+- The post-fork experience reads as a record, not a status dashboard or victory announcement.
+
+### Data integrity
+
+- Winner, child universe, outcome, deadline, and totals trace to the fork JSON data.
+- The fork JSON data identifies its schema version, generation time, and observed block.
+- Contradictory resolution data is rejected before it reaches the UI or build-time content.
+- The UI has an explicit unverified fallback and never guesses.
+
+### User interface
+
+- CTA and lower hero always represent the same lifecycle state.
+- All lifecycle states are available through local F2 demo controls.
+- The Fork Record works at supported viewport sizes and with reduced motion.
+- Resolution disclosure is keyboard accessible and returns focus correctly.
+- The hero remains coherent when no CTA is rendered.
+
+### Engineering and CI
+
+- `npm run typecheck`, `npm run typecheck:scripts`, `npm run lint`, targeted tests, and `npm run build` pass.
+- Pull requests validate both current and versioned fork JSON fixtures.
+- A failed fork-state read cannot deploy a fabricated or incomplete record.
+- The deployment can be rolled back without changing the public data URL.
+
+### Monitoring follow-up
+
+- Monitoring cadence changes only after a defined post-close observation period.
+- Any schedule or cache change is handled as a separate operational PR.
+- The public endpoint remains compatible while the Fork Record is presented.
+
+## Remaining Decisions and Revisit Points
+
+- Decide whether the canonical universe address appears in the collapsed record or only inside the resolution dialog.
+- Define what future protocol change or oracle release triggers the documented reactivation review.
+- Revisit whether the resolved record should remain in the hero or move into a dedicated historical section later.
+
+## Documentation Updates on Completion
+
+- Update [[technical-architecture]] for shared fork-state ownership and the new component hierarchy.
+- Update [[public-data-endpoints]] for schema version 2 and compatibility guarantees.
+- Update [[fork-monitoring-pipeline]] separately when the monitoring cadence or cache strategy changes.
+- Update [[fork-monitoring-methodology]] if monitoring follows the winning universe.
+- Update [[fork-mechanics]] only if implementation verification reveals that the current deadline or early-resolution wording is inaccurate.

--- a/docs/public-data-endpoints.md
+++ b/docs/public-data-endpoints.md
@@ -9,17 +9,20 @@ Augur.net serves structured JSON at stable URLs under `/data/` for external cons
 
 ## Compatibility
 
-The current endpoint does not expose an explicit schema version. Treat renaming, removing, or changing the type of an existing field as a breaking change and coordinate it with known consumers. Adding an optional field is backward-compatible.
+The endpoint now emits additive schema version 2 fields. Treat renaming, removing, or changing the type of an existing field as a breaking change and coordinate it with known consumers. Older consumers can continue reading the existing risk and `forkActive` fields.
 
 ## Endpoints
 
 ### `/data/fork-risk.json`
 
-Live fork status from on-chain Augur contracts. Updated hourly by CI.
+Fork status from on-chain Augur contracts. Updated by the fork-monitoring
+workflow while monitoring is active. The lifecycle record remains available
+after the migration deadline; monitoring cadence is a separate operational
+decision.
 
 ```
 GET /data/fork-risk.json
-Refresh: every hour (GitHub Actions cron: 0 * * * *)
+Refresh: currently hourly (GitHub Actions cron: `0 * * * *`); cadence changes are handled by the monitoring workflow
 Pipeline: scripts/calculate-fork-risk.ts
 ```
 
@@ -28,6 +31,8 @@ Pipeline: scripts/calculate-fork-risk.ts
 | Field | Type | Description |
 |---|---|---|
 | `lastRiskChange` | `string` (ISO 8601) | Timestamp of the latest calculation. Poll this to detect staleness. |
+| `schemaVersion` | `number`, optional | Versioned data contract; current generated records use `2`. |
+| `generatedAt` | `string` (ISO 8601), optional | Timestamp used to derive the emitted lifecycle status. |
 | `blockNumber` | `number`, optional | Ethereum block at time of calculation; omitted from error results |
 | `riskLevel` | `enum` | `none` \| `low` \| `moderate` \| `high` \| `critical` \| `unknown` |
 | `riskPercentage` | `number \| null` | Round progress as percentage (0–100). `null` when projection unavailable. |
@@ -35,7 +40,8 @@ Pipeline: scripts/calculate-fork-risk.ts
 | `rpcInfo` | `object`, optional | RPC endpoint used, latency, fallback count |
 | `calculation` | `object` | `forkThreshold` — REP threshold that triggers fork |
 | `cacheValidation` | `object`, optional | Cache health: `isHealthy: boolean`, optional `discrepancy` |
-| `forkActive` | `object`, optional | Present only when a fork is live (below) |
+| `fork` | `object \| null`, optional | Normalized fork lifecycle record (schema v2, below) |
+| `forkActive` | `object`, optional | Backward-compatible active-fork fields or preserved compatibility snapshot (below) |
 | `error` | `string`, optional | Error message if the pipeline failed |
 
 #### `metrics`
@@ -52,7 +58,8 @@ Pipeline: scripts/calculate-fork-risk.ts
 
 #### `forkActive`
 
-Present only when a fork is live. Omitted otherwise.
+Present for an active fork and may be retained in the finalized record for
+older consumers. New consumers should use `fork` as the lifecycle source.
 
 | Field | Type | Description |
 |---|---|---|
@@ -70,6 +77,23 @@ Present only when a fork is live. Omitted otherwise.
 | `label` | `string` | Human-readable outcome label |
 | `childUniverse` | `string \| null` | Child universe address, or `null` if none created |
 | `migratedRep` | `number` | REP migrated to this outcome so far |
+
+#### `fork` (schema v2)
+
+The normalized record is the source for lifecycle presentation. `status` can be `migration-open`, `migration-open-resolved`, `migration-closed-resolved`, or `migration-closed-unverified`; non-fork records use `fork: null`.
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `enum` | Lifecycle status emitted at generation time |
+| `parentUniverse` | `string \| null` | Parent/forking universe address |
+| `forkingMarket` | `string` | Market that triggered the fork |
+| `migrationDeadline` | `number` | Unix timestamp at which migration closes |
+| `reputationGoal` | `number` | REP needed for early resolution |
+| `winningChildUniverse` | `string \| null` | Contract-reported winner, when known |
+| `outcomes` | `array` | Outcome records, including child universe, REP token, and migrated REP |
+| `observedBlock` | `number`, optional | Ethereum block used for the record |
+
+The browser derives the current display state from `fork.winningChildUniverse`, `fork.migrationDeadline`, and current time. A winner known before the deadline does not make the endpoint post-fork; it remains `migration-open-resolved` until the deadline.
 
 **Risk level thresholds**: `none` (0%), `low` (1–24%), `moderate` (25–49%), `high` (50–74%), `critical` (75–100%). When `forkActive` is present, `riskLevel` is always `critical` and `roundProgress` is `100`.
 

--- a/docs/technical-architecture.md
+++ b/docs/technical-architecture.md
@@ -26,11 +26,16 @@ Layout.astro (Base HTML shell — toggles html.boot class for CSS-driven intro)
 │   ├── index.astro (Homepage)
 │   │   ├── features/home/intro.tsx (client:load — CRT boot overlay, removes html.boot on complete)
 │   │   ├── features/home/hero-banner.tsx (client:load — CSS-animated entrance)
-│   │   │   └── features/fork-monitor/monitor.tsx (client:load — Fork Gauge island)
-│   │   │       ├── data-provider.tsx (data fetching)
+│   │   │   └── features/fork-monitor/monitor.tsx (client:load — shared Fork Experience island)
+│   │   │       ├── data-provider.tsx (data fetching and validation)
+│   │   │       ├── clock.tsx (shared deadline clock for synchronized transitions)
+│   │   │       ├── derive-fork-lifecycle.ts (winner/deadline state derivation)
+│   │   │       ├── validate-fork-data.ts (runtime JSON validation)
 │   │   │       ├── gauge.tsx (SVG visualization)
 │   │   │       ├── stats.tsx (progressive disclosure)
-│   │   │       ├── display.tsx (layout)
+│   │   │       ├── display.tsx (lifecycle layout)
+│   │   │       ├── fork-action.tsx (state-aware migration CTA)
+│   │   │       ├── post-fork-record.tsx (closed record and resolution dialog)
 │   │   │       ├── details-card.tsx (expanded metrics + ascii-art)
 │   │   │       └── controls.tsx (demo mode, F2 toggle)
 │   │   └── features/home/featured-posts.astro → post-card.astro
@@ -59,15 +64,20 @@ When `.boot` is present, the CRT overlay (`#crt-overlay`) is shown and all hero 
 ### React Context (Island-scoped)
 - `features/fork-monitor/data-provider.tsx` — provides fork risk data to the gauge island
 - `features/fork-monitor/mock-provider.tsx` — demo mode data override
+- `features/fork-monitor/clock.tsx` — provides one ticking timestamp so the CTA, countdown, and post-fork record transition together
 
 ### Data Flow
 
-`ForkDataProvider` fetches `/data/fork-risk.json` for the gauge island and refreshes it on an interval. `ForkMockProvider` wraps the same island for development-only demo scenarios.
+`ForkDataProvider` fetches `/data/fork-risk.json`, validates schema-compatible data, and refreshes it on an interval. `ForkMockProvider` wraps the same island for development-only demo scenarios. `ForkExperience` places both the hero CTA and lower display under one provider so they cannot disagree about whether migration is still actionable.
+
+The browser derives one of the lifecycle states `monitoring`, `migration-open`, `migration-open-resolved`, `migration-closed-resolved`, `migration-closed-unverified`, or `data-unavailable`. A known winner changes only the CTA while migration remains open. The shared fork clock re-evaluates the CTA and lower display at the same deadline, so the active countdown cannot remain visible at zero. The Fork Record and dialog are available only after the verified deadline.
 
 The monitor's calculation and CI data pipeline are intentionally documented outside this architecture page:
 
 - [[fork-monitoring-methodology]] — calculation method and risk signal
 - [[fork-monitoring-pipeline]] — GitHub Actions pipeline and artifact flow
+
+Astro content pages use `src/lib/fork-data.ts` during the build to state-gate urgent migration warnings and the `ACT NOW` navigation treatment from the same generated JSON lifecycle.
 
 ## Content Collections
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"build:fork-data": "node --experimental-strip-types scripts/calculate-fork-risk.ts",
 		"lint:blog": "node --experimental-strip-types scripts/blog-lint/index.ts",
 		"test:blog-lint": "node --experimental-strip-types --test scripts/blog-lint/*.test.ts",
+		"test:fork-lifecycle": "node --experimental-strip-types --test scripts/fork-lifecycle.test.ts",
 		"typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
 		"preview": "astro build && wrangler dev",
 		"astro": "astro",

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -219,6 +219,26 @@ async function retryContractCall<T>(
 	throw new Error(`Unexpected retry flow for ${methodName}`);
 }
 
+export interface ForkLifecycleSignals {
+	isForking: boolean;
+	forkEndTime: number | null;
+}
+
+export const readForkLifecycleSignals = async (readers: {
+	isForking: () => Promise<boolean>;
+	getForkEndTime: () => Promise<bigint | number | string>;
+}): Promise<ForkLifecycleSignals> => {
+	const isForking = await readers.isForking();
+	if (isForking) return { isForking: true, forkEndTime: null };
+
+	const forkEndTime = Number(await readers.getForkEndTime());
+	if (!Number.isFinite(forkEndTime) || forkEndTime < 0) {
+		throw new Error("Fork end time is invalid.");
+	}
+
+	return { isForking: false, forkEndTime };
+};
+
 async function loadContracts(
 	provider: ethers.JsonRpcProvider,
 ): Promise<Record<string, ethers.Contract>> {
@@ -333,19 +353,21 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 				);
 			}
 
-			// Check if universe is already forking with retry logic
-			let isForking = false;
-			try {
-				isForking = await retryContractCall(
-					() => contracts.universe.isForking(),
-					"universe.isForking()",
-				);
-			} catch {
-				console.warn(
-					"⚠️ Failed to check forking status, continuing with dispute calculation",
-				);
-				// Continue with graceful degradation
-			}
+			// Lifecycle reads are required evidence. If either read fails, allow the
+			// RPC fallback wrapper to try another endpoint instead of guessing.
+			const lifecycle = await readForkLifecycleSignals({
+				isForking: () =>
+					retryContractCall(
+						() => contracts.universe.isForking(),
+						"universe.isForking()",
+					),
+				getForkEndTime: () =>
+					retryContractCall(
+						() => contracts.universe.getForkEndTime(),
+						"universe.getForkEndTime()",
+					),
+			});
+			const { isForking, forkEndTime: recordedForkEndTime } = lifecycle;
 
 			if (isForking) {
 				console.log("⚠️ UNIVERSE IS FORKING! Setting maximum risk level");
@@ -361,22 +383,9 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 			// immediately after the migration deadline. Preserve the historical fork
 			// record in that case instead of falling back to an unrelated pre-fork
 			// risk calculation.
-			let recordedForkEndTime = 0;
-			try {
-				recordedForkEndTime = Number(
-					await retryContractCall(
-						() => contracts.universe.getForkEndTime(),
-						"universe.getForkEndTime() after fork closure",
-						1,
-					),
-				);
-			} catch {
-				// A non-forking universe may not expose fork metadata; continue with
-				// ordinary dispute monitoring in that case.
-			}
 
 			if (
-				Number.isFinite(recordedForkEndTime) &&
+				recordedForkEndTime !== null &&
 				recordedForkEndTime > 0 &&
 				Math.floor(Date.now() / 1000) >= recordedForkEndTime
 			) {
@@ -388,7 +397,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 					contracts.universe,
 				);
 				if (!closedFork) {
-					return getErrorResult(
+					throw new Error(
 						"Fork metadata could not be verified after the migration deadline.",
 					);
 				}

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -14,6 +14,12 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { ethers } from "ethers";
+import { deriveForkLifecycle } from "../src/features/fork-monitor/derive-fork-lifecycle.ts";
+import type {
+	ForkOutcome,
+	ForkRecordData,
+} from "../src/features/fork-monitor/types.ts";
+import { validateForkRiskData } from "../src/features/fork-monitor/validate-fork-data.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -52,6 +58,8 @@ interface Calculation {
 type RiskLevel = "none" | "low" | "moderate" | "high" | "critical" | "unknown";
 
 interface ForkRiskData {
+	schemaVersion?: number;
+	generatedAt?: string;
 	lastRiskChange: string;
 	blockNumber?: number;
 	riskLevel: RiskLevel;
@@ -64,17 +72,14 @@ interface ForkRiskData {
 		isHealthy: boolean;
 		discrepancy?: string;
 	};
+	fork?: ForkRecordData | null;
 	forkActive?: {
 		forkingMarket: string;
 		forkEndTime: number;
+		winningChildUniverse?: string | null;
 		forkReputationGoal: number;
 		universeRepSupply: number;
-		outcomes: Array<{
-			index: number;
-			label: string;
-			childUniverse: string | null;
-			migratedRep: number;
-		}>;
+		outcomes: ForkOutcome[];
 	};
 }
 
@@ -352,6 +357,50 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 				);
 			}
 
+			// Some deployed universe implementations stop reporting `isForking()`
+			// immediately after the migration deadline. Preserve the historical fork
+			// record in that case instead of falling back to an unrelated pre-fork
+			// risk calculation.
+			let recordedForkEndTime = 0;
+			try {
+				recordedForkEndTime = Number(
+					await retryContractCall(
+						() => contracts.universe.getForkEndTime(),
+						"universe.getForkEndTime() after fork closure",
+						1,
+					),
+				);
+			} catch {
+				// A non-forking universe may not expose fork metadata; continue with
+				// ordinary dispute monitoring in that case.
+			}
+
+			if (
+				Number.isFinite(recordedForkEndTime) &&
+				recordedForkEndTime > 0 &&
+				Math.floor(Date.now() / 1000) >= recordedForkEndTime
+			) {
+				console.log(
+					"⚠️ Migration deadline has passed; preserving the fork record snapshot",
+				);
+				const closedFork = await fetchForkActiveDetails(
+					connection.provider,
+					contracts.universe,
+				);
+				if (!closedFork) {
+					return getErrorResult(
+						"Fork metadata could not be verified after the migration deadline.",
+					);
+				}
+				return await getForkingResult(
+					blockNumber,
+					connection,
+					forkThresholdRep,
+					contracts.universe,
+					closedFork,
+				);
+			}
+
 			// Calculate key metrics
 			// Read dispute round duration from chain (for ETA calculation)
 			let disputeRoundDurationSeconds = 7 * 24 * 60 * 60; // fallback: 7 days
@@ -415,8 +464,11 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 			const riskPercentage = roundProgress;
 
 			// Prepare results
+			const generatedAt = new Date().toISOString();
 			const results: ForkRiskData = {
-				lastRiskChange: new Date().toISOString(),
+				schemaVersion: 2,
+				generatedAt,
+				lastRiskChange: generatedAt,
 				blockNumber,
 				riskLevel,
 				riskPercentage:
@@ -442,7 +494,14 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 					forkThreshold: forkThresholdRep,
 				},
 				cacheValidation,
+				fork: null,
 			};
+			const validation = validateForkRiskData(results);
+			if (!validation.valid) {
+				throw new Error(
+					`Generated fork data failed validation:\n${validation.errors.join("\n")}`,
+				);
+			}
 
 			console.log("Calculation completed successfully");
 			console.log(`Risk Level: ${riskLevel}`);
@@ -1246,6 +1305,7 @@ const FORK_ACTIVE_UNIVERSE_ABI = [
 	"function getForkingMarket() view returns (address)",
 	"function getForkEndTime() view returns (uint256)",
 	"function getForkReputationGoal() view returns (uint256)",
+	"function getWinningChildUniverse() view returns (address)",
 	"function getReputationToken() view returns (address)",
 	"function getChildUniverse(bytes32 parentPayoutDistributionHash) view returns (address)",
 ];
@@ -1293,6 +1353,14 @@ async function fetchForkActiveDetails(
 				u.getForkReputationGoal(),
 				u.getReputationToken(),
 			]);
+		const winningChildUniverseRaw = await u
+			.getWinningChildUniverse()
+			.catch(() => ethers.ZeroAddress);
+		const winningChildUniverse =
+			String(winningChildUniverseRaw).toLowerCase() ===
+			ethers.ZeroAddress.toLowerCase()
+				? null
+				: String(winningChildUniverseRaw);
 
 		const repToken = new ethers.Contract(
 			repTokenAddr,
@@ -1331,16 +1399,16 @@ async function fetchForkActiveDetails(
 				const childAddr: string = await u.getChildUniverse(payoutHash);
 				const isZero = !childAddr || /^0x0+$/i.test(childAddr);
 				let migratedRep = 0;
-				let childRepLabel: string | null = null;
+				let childRepToken: string | null = null;
 				let label = positionalLabel(k);
 				if (!isZero) {
-					childRepLabel = childAddr;
 					const childUniverse = new ethers.Contract(
 						childAddr,
 						FORK_ACTIVE_UNIVERSE_ABI,
 						provider,
 					);
 					const childRepAddr = await childUniverse.getReputationToken();
+					childRepToken = childRepAddr;
 					const childRep = new ethers.Contract(
 						childRepAddr,
 						FORK_ACTIVE_ERC20_ABI,
@@ -1359,7 +1427,8 @@ async function fetchForkActiveDetails(
 				return {
 					index: k,
 					label,
-					childUniverse: childRepLabel,
+					childUniverse: isZero ? null : childAddr,
+					reputationToken: childRepToken,
 					migratedRep,
 				};
 			}),
@@ -1368,6 +1437,7 @@ async function fetchForkActiveDetails(
 		return {
 			forkingMarket,
 			forkEndTime: Number(forkEndTimeRaw),
+			winningChildUniverse,
 			forkReputationGoal: Number(ethers.formatEther(forkRepGoalWei)),
 			universeRepSupply: Number(ethers.formatEther(universeRepSupplyWei)),
 			outcomes,
@@ -1385,13 +1455,30 @@ async function getForkingResult(
 	connection: RpcConnection,
 	forkThresholdRep: number,
 	universe: ethers.Contract,
+	existingForkActive?: ForkRiskData["forkActive"],
 ): Promise<ForkRiskData> {
-	const forkActive = await fetchForkActiveDetails(
-		connection.provider,
-		universe,
-	);
-	return {
-		lastRiskChange: new Date().toISOString(),
+	const forkActive =
+		existingForkActive ??
+		(await fetchForkActiveDetails(connection.provider, universe));
+	if (!forkActive) {
+		throw new Error("Fork is active but fork details could not be read");
+	}
+
+	const generatedAt = new Date().toISOString();
+	const forkRecord: ForkRecordData = {
+		status: "migration-open",
+		parentUniverse: await universe.getAddress(),
+		forkingMarket: forkActive.forkingMarket,
+		migrationDeadline: forkActive.forkEndTime,
+		reputationGoal: forkActive.forkReputationGoal,
+		winningChildUniverse: forkActive.winningChildUniverse ?? null,
+		outcomes: forkActive.outcomes,
+		observedBlock: blockNumber,
+	};
+	const results: ForkRiskData = {
+		schemaVersion: 2,
+		generatedAt,
+		lastRiskChange: generatedAt,
 		blockNumber,
 		riskLevel: "critical",
 		riskPercentage: 100,
@@ -1424,7 +1511,22 @@ async function getForkingResult(
 		},
 		cacheValidation: { isHealthy: true },
 		forkActive,
+		fork: forkRecord,
 	};
+
+	const lifecycle = deriveForkLifecycle(
+		results,
+		Math.floor(Date.parse(generatedAt) / 1000),
+	);
+	forkRecord.status = lifecycle.state;
+	const validation = validateForkRiskData(results);
+	if (!validation.valid) {
+		throw new Error(
+			`Generated fork data failed validation:\n${validation.errors.join("\n")}`,
+		);
+	}
+
+	return results;
 }
 
 function getErrorResult(errorMessage: string): ForkRiskData {

--- a/scripts/fork-lifecycle.test.ts
+++ b/scripts/fork-lifecycle.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	deriveForkLifecycle,
+	getForkRecord,
+} from "../src/features/fork-monitor/derive-fork-lifecycle.ts";
+import type { ForkRiskData } from "../src/features/fork-monitor/types.ts";
+import { validateForkRiskData } from "../src/features/fork-monitor/validate-fork-data.ts";
+
+const parentUniverse = "0x1111111111111111111111111111111111111111";
+const market = "0x2222222222222222222222222222222222222222";
+const winningChild = "0x3333333333333333333333333333333333333333";
+const otherChild = "0x4444444444444444444444444444444444444444";
+
+const baseData = (
+	winningChildUniverse: string | null = null,
+): ForkRiskData => ({
+	schemaVersion: 2,
+	generatedAt: "2026-08-02T00:00:00.000Z",
+	lastRiskChange: "2026-08-02T00:00:00.000Z",
+	blockNumber: 100,
+	riskLevel: "critical",
+	riskPercentage: 100,
+	metrics: {
+		largestDisputeBond: 275000,
+		forkThresholdPercent: 100,
+		activeDisputes: 0,
+		currentRound: 99,
+		estimatedTotalRounds: null,
+		roundProgress: 100,
+		disputeDetails: [],
+	},
+	calculation: { forkThreshold: 275000 },
+	fork: {
+		status: "migration-open",
+		parentUniverse,
+		forkingMarket: market,
+		migrationDeadline: 2000,
+		reputationGoal: 500,
+		winningChildUniverse,
+		outcomes: [
+			{
+				index: 0,
+				label: "No",
+				childUniverse: otherChild,
+				migratedRep: 100,
+			},
+			{
+				index: 1,
+				label: "Yes",
+				childUniverse: winningChild,
+				migratedRep: 600,
+			},
+		],
+	},
+});
+
+test("derives monitoring when no fork record exists", () => {
+	const data = baseData();
+	delete data.fork;
+
+	assert.equal(deriveForkLifecycle(data, 1000).state, "monitoring");
+});
+
+test("keeps the migration-open state unresolved without a winner", () => {
+	assert.equal(deriveForkLifecycle(baseData(), 1000).state, "migration-open");
+});
+
+test("distinguishes a known winner while migration remains open", () => {
+	const data = baseData(winningChild);
+	assert.equal(
+		deriveForkLifecycle(data, 1000).state,
+		"migration-open-resolved",
+	);
+	assert.equal(deriveForkLifecycle(data, 1000).winnerKnown, true);
+});
+
+test("moves to a resolved Fork Record exactly at the deadline", () => {
+	const data = baseData(winningChild);
+	assert.equal(
+		deriveForkLifecycle(data, 2000).state,
+		"migration-closed-resolved",
+	);
+});
+
+test("keeps the migration CTA state one second before the deadline", () => {
+	const data = baseData(winningChild);
+	assert.equal(
+		deriveForkLifecycle(data, 1999).state,
+		"migration-open-resolved",
+	);
+});
+
+test("moves to pending verification after the deadline without a winner", () => {
+	assert.equal(
+		deriveForkLifecycle(baseData(), 2001).state,
+		"migration-closed-unverified",
+	);
+});
+
+test("rejects a resolved record whose winner is not an emitted outcome", () => {
+	const data = baseData(winningChild);
+	assert.ok(data.fork);
+	data.fork.status = "migration-closed-resolved";
+	data.fork.winningChildUniverse = "0x5555555555555555555555555555555555555555";
+
+	const validation = validateForkRiskData(data);
+	assert.equal(validation.valid, false);
+	assert.match(validation.errors.join("\n"), /does not match/u);
+});
+
+test("accepts a valid schema v2 resolved record", () => {
+	const data = baseData(winningChild);
+	assert.ok(data.fork);
+	data.fork.status = "migration-closed-resolved";
+
+	assert.equal(validateForkRiskData(data).valid, true);
+	assert.equal(getForkRecord(data)?.winningChildUniverse, winningChild);
+});
+
+test("rejects a record with missing outcome data without throwing", () => {
+	const data = baseData();
+	assert.ok(data.fork);
+	data.fork.outcomes = undefined as never;
+
+	const validation = validateForkRiskData(data);
+	assert.equal(validation.valid, false);
+	assert.match(validation.errors.join("\n"), /outcomes must be an array/u);
+});

--- a/scripts/fork-lifecycle.test.ts
+++ b/scripts/fork-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { readForkLifecycleSignals } from "./calculate-fork-risk.ts";
 import {
 	deriveForkLifecycle,
 	getForkRecord,
@@ -11,6 +12,39 @@ const parentUniverse = "0x1111111111111111111111111111111111111111";
 const market = "0x2222222222222222222222222222222222222222";
 const winningChild = "0x3333333333333333333333333333333333333333";
 const otherChild = "0x4444444444444444444444444444444444444444";
+
+test("keeps a successful pre-fork zero deadline as ordinary monitoring", async () => {
+	const signals = await readForkLifecycleSignals({
+		isForking: async () => false,
+		getForkEndTime: async () => 0n,
+	});
+
+	assert.deepEqual(signals, { isForking: false, forkEndTime: 0 });
+});
+
+test("does not guess when the forking status read fails", async () => {
+	await assert.rejects(
+		readForkLifecycleSignals({
+			isForking: async () => {
+				throw new Error("RPC unavailable");
+			},
+			getForkEndTime: async () => 0n,
+		}),
+		/RPC unavailable/u,
+	);
+});
+
+test("does not guess when the fork deadline read fails", async () => {
+	await assert.rejects(
+		readForkLifecycleSignals({
+			isForking: async () => false,
+			getForkEndTime: async () => {
+				throw new Error("RPC unavailable");
+			},
+		}),
+		/RPC unavailable/u,
+	);
+});
 
 const baseData = (
 	winningChildUniverse: string | null = null,

--- a/src/components/ui/border-beam.tsx
+++ b/src/components/ui/border-beam.tsx
@@ -77,6 +77,12 @@ const BorderBeam: React.FC<BorderBeamProps> = ({
           position: relative;
           z-index: 1;
         }
+
+        @media (prefers-reduced-motion: reduce) {
+          .border-beam-wrapper::before {
+            animation: none;
+          }
+        }
       `}</style>
 		</span>
 	);

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -5,13 +5,24 @@ description: "Learn about Augur protocol forks, how they work, and why fork risk
 
 import ProseCard from '../../../components/content/prose-card.astro'
 import MigrationCta from '../../../features/learn/migration-cta.tsx'
+import { getForkLifecycleAtBuild, isMigrationOpen, isVerifiedForkResolution } from '../../../lib/fork-data'
 
-<MigrationCta
-  className="not-prose mb-8"
-  eyebrow="CRITICAL · MIGRATION IMMINENT"
-  title="Migrate your REP before Aug 1, 2026"
-  description="Unmigrated REP will be left in a dead universe. Follow the step-by-step guide to move it safely."
-/>
+export const forkLifecycle = getForkLifecycleAtBuild()
+export const migrationOpen = isMigrationOpen(forkLifecycle.state)
+export const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state)
+
+{migrationOpen ? (
+  <MigrationCta
+    className="not-prose mb-8"
+    eyebrow="CRITICAL · MIGRATION IMMINENT"
+    title="Migrate your REP before the deadline"
+    description="Unmigrated REP will be left in a dead universe. Follow the step-by-step guide to move it safely."
+  />
+) : (
+  <ProseCard class="not-prose mb-8">
+  **MIGRATION CLOSED** — This guide is preserved as a record of the Moon Fork migration process. {resolutionVerified ? 'See the landing page for the verified Fork Record.' : 'The landing page is withholding the final resolution until it can be verified.'}
+  </ProseCard>
+)}
 
 > **New to Augur?** This guide assumes some familiarity with prediction markets. If you're completely new, start with Augur basics first.
 

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -5,23 +5,17 @@ description: "Learn about Augur protocol forks, how they work, and why fork risk
 
 import ProseCard from '../../../components/content/prose-card.astro'
 import MigrationCta from '../../../features/learn/migration-cta.tsx'
-import { getForkLifecycleAtBuild, isMigrationOpen, isVerifiedForkResolution } from '../../../lib/fork-data'
+import { getForkLifecycleAtBuild, isMigrationOpen } from '../../../lib/fork-data'
 
-export const forkLifecycle = getForkLifecycleAtBuild()
-export const migrationOpen = isMigrationOpen(forkLifecycle.state)
-export const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state)
+export const migrationOpen = isMigrationOpen(getForkLifecycleAtBuild().state)
 
-{migrationOpen ? (
+{migrationOpen && (
   <MigrationCta
     className="not-prose mb-8"
     eyebrow="CRITICAL · MIGRATION IMMINENT"
     title="Migrate your REP before the deadline"
     description="Unmigrated REP will be left in a dead universe. Follow the step-by-step guide to move it safely."
   />
-) : (
-  <ProseCard class="not-prose mb-8">
-  **MIGRATION CLOSED** — This guide is preserved as a record of the Moon Fork migration process. {resolutionVerified ? 'See the landing page for the verified Fork Record.' : 'The landing page is withholding the final resolution until it can be verified.'}
-  </ProseCard>
 )}
 
 > **New to Augur?** This guide assumes some familiarity with prediction markets. If you're completely new, start with Augur basics first.

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Moon Fork Migration Guide"
-description: "Step-by-step REP migration guide. Migrate before August 1, 2026 or lose your REP."
+description: "Step-by-step historical reference for the Augur Moon Fork REP migration."
 ---
 
 import { Image } from 'astro:assets'
@@ -11,6 +11,19 @@ import step03 from '../../../assets/learn/migration/step-03.png'
 import step04 from '../../../assets/learn/migration/step-04.png'
 import step05 from '../../../assets/learn/migration/step-05.png'
 import step06 from '../../../assets/learn/migration/step-06.png'
+import { getForkLifecycleAtBuild, isMigrationOpen } from '../../../lib/fork-data'
+
+export const forkLifecycle = getForkLifecycleAtBuild()
+export const migrationOpen = isMigrationOpen(forkLifecycle.state)
+export const migrationDeadline = forkLifecycle.record?.migrationDeadline
+  ? new Date(forkLifecycle.record.migrationDeadline * 1000).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  : 'the recorded deadline'
+
+{!migrationOpen && (
+<ProseCard>
+**MIGRATION CLOSED** — The migration window has closed. The instructions below remain available as a historical reference; verify the final outcome on the landing page before acting on any token information.
+</ProseCard>
+)}
 
 ## Why?
 
@@ -28,8 +41,10 @@ Augur is forking before the next version for three reasons:
 | If you…                       | You can take action after | The last day this will happen between |
 |-------------------------------|---------------------------|---------------------------------------|
 | migrate early (40% ROI)       | April 8ᵗʰ – May 12ᵗʰ      | June 4ᵗʰ – June 11ᵗʰ                  |
-| migrate late (1:1 conversion) | June 4ᵗʰ – June 11ᵗʰ      | August 2ⁿᵈ – August 10ᵗʰ              |
+| migrate late (1:1 conversion) | June 4ᵗʰ – June 11ᵗʰ      | the contract deadline shown below      |
 </ProseCard>
+
+**Recorded migration deadline:** {migrationDeadline}
 
 ## Moon Fork Migration Guide
 
@@ -76,7 +91,7 @@ Make sure the page says **"You have 0 REPv1"**. If not, convert all REPv1 into R
 
 ### 5. Wait until June 11ᵗʰ
 
-Augur will have forked by this date, enabling unlimited migration. You will have until **August 1ˢᵗ** to migrate or sell your REP before it becomes worthless — possibly up to 10 days longer.
+Augur will have forked by this date, enabling unlimited migration. The migration window ends at the **{migrationDeadline}** deadline shown by the deployed contract. {migrationOpen ? 'If the window is still open, migrate or sell your REP before it closes.' : 'The recorded migration deadline has passed; the remaining instructions are historical reference only.'}
 
 ### 6. Open the migration page
 

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -11,17 +11,18 @@ import step03 from '../../../assets/learn/migration/step-03.png'
 import step04 from '../../../assets/learn/migration/step-04.png'
 import step05 from '../../../assets/learn/migration/step-05.png'
 import step06 from '../../../assets/learn/migration/step-06.png'
-import { getForkLifecycleAtBuild, isMigrationOpen } from '../../../lib/fork-data'
+import { getForkLifecycleAtBuild, isMigrationClosed, isMigrationOpen } from '../../../lib/fork-data'
 
 export const forkLifecycle = getForkLifecycleAtBuild()
 export const migrationOpen = isMigrationOpen(forkLifecycle.state)
+export const migrationClosed = isMigrationClosed(forkLifecycle.state)
 export const migrationDeadline = forkLifecycle.record?.migrationDeadline
   ? new Date(forkLifecycle.record.migrationDeadline * 1000).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
   : 'the recorded deadline'
 
-{!migrationOpen && (
+{migrationClosed && (
 <ProseCard>
-**MIGRATION CLOSED** — The migration window has closed. The instructions below remain available as a historical reference; verify the final outcome on the landing page before acting on any token information.
+**HISTORICAL RECORD** — This page documents the Moon Fork migration procedure used by REP holders. The migration window is closed, but the steps remain available for reference.
 </ProseCard>
 )}
 
@@ -91,7 +92,7 @@ Make sure the page says **"You have 0 REPv1"**. If not, convert all REPv1 into R
 
 ### 5. Wait until June 11ᵗʰ
 
-Augur will have forked by this date, enabling unlimited migration. The migration window ends at the **{migrationDeadline}** deadline shown by the deployed contract. {migrationOpen ? 'If the window is still open, migrate or sell your REP before it closes.' : 'The recorded migration deadline has passed; the remaining instructions are historical reference only.'}
+Augur will have forked by this date, enabling unlimited migration. The migration window ends at the **{migrationDeadline}** deadline shown by the deployed contract. {migrationOpen ? 'If the window is still open, migrate or sell your REP before it closes.' : migrationClosed ? 'The recorded migration deadline has passed; the remaining instructions are historical reference only.' : 'The migration deadline will be established when the fork begins.'}
 
 ### 6. Open the migration page
 

--- a/src/content/learn/fork/what-to-do.mdx
+++ b/src/content/learn/fork/what-to-do.mdx
@@ -4,10 +4,19 @@ description: "Action items to take at different fork risk levels."
 ---
 
 import ProseCard from '../../../components/content/prose-card.astro'
+import { getForkLifecycleAtBuild, isMigrationOpen } from '../../../lib/fork-data'
 
-# What To Do During Rising Fork Risk
+export const migrationOpen = isMigrationOpen(getForkLifecycleAtBuild().state)
 
-**TL;DR** — Fork risk is manageable at low levels. Monitor more closely as it rises. At high levels, take concrete action to protect your positions.
+{!migrationOpen && (
+<ProseCard>
+**MIGRATION CLOSED** — The Moon Fork migration window has closed. The guidance below explains the fork process and its historical decision points; it is not a current instruction to migrate.
+</ProseCard>
+)}
+
+# What To Do Around Fork Risk
+
+**TL;DR** — Fork risk is manageable at low levels. Monitor more closely as it rises. During an active migration window, follow the current state and deadline shown on the landing page. {!migrationOpen && 'The current Moon Fork guidance is now historical.'}
 
 ## Risk Overview
 
@@ -18,10 +27,10 @@ import ProseCard from '../../../components/content/prose-card.astro'
 | Low (&lt;25%) | Early disputes | Identify which markets are disputed. Understand the disagreement. |
 | Moderate (25-50%) | Disputes escalating | Calculate your exposure. Think about exit strategies if needed. |
 | High (50-75%) | Large bonds active | Monitor daily. Consider reducing exposure. Prepare for fork governance. |
-| Critical (≥75%) | Fork imminent | Take action now. Prepare to choose a fork. Engage with community. |
+| Critical (≥75%) | Fork imminent or active | Check the landing page for the current fork state and deadline. |
 </ProseCard>
 
-## High Risk (50-75%) — Take Action
+## High Risk (50-75%) — Prepare
 
 The dispute has passed the halfway point. Fork is increasingly likely with continued escalation.
 
@@ -34,11 +43,11 @@ The dispute has passed the halfway point. Fork is increasingly likely with conti
 - **Avoid new large bets** — Don't enter high-risk markets during escalation
 - **Know your positions** — Understand exactly how a fork would affect you
 
-## Critical Risk (≥75%) — Fork Is Likely
+## Critical Risk (≥75%) — Fork Is Likely or Active
 
 The dispute is in its final rounds. A fork is imminent or may have been triggered. This is the highest-stakes scenario.
 
-**What you must do:**
+**If the migration window is open:**
 
 - **Understand your position** — Know exactly what outcome you're betting on in disputed markets
 - **Plan your fork choice** — Which fork version do you believe represents the correct outcomes?
@@ -52,14 +61,14 @@ The dispute is in its final rounds. A fork is imminent or may have been triggere
 ### The 60-Day Fork Period
 
 - **Markets freeze:** No new trades on disputed markets
-- **You must migrate REP:** Choose which fork version you support
+- **REP migration:** Choose which fork version to support before the migration window closes
 - **Voting occurs:** Your REP migration determines your choice on the disputed outcome
 - **Communicate:** Engage in governance discussions about the right outcome
 - **Wait for resolution:** The fork window is 60 days
 
-### After Fork Resolution
+### After a Verified Fork Resolution
 
-- **Check your REP:** You now have REP on the winning fork
+- **Check your REP:** Verify which REP token corresponds to the recorded winning fork
 - **Markets settle:** Markets settle according to the winning fork's outcomes
 - **Resume trading:** Normal Augur operations resume
 - **Evaluate impact:** Assess how the fork affected your positions

--- a/src/content/learn/fork/what-to-do.mdx
+++ b/src/content/learn/fork/what-to-do.mdx
@@ -4,19 +4,10 @@ description: "Action items to take at different fork risk levels."
 ---
 
 import ProseCard from '../../../components/content/prose-card.astro'
-import { getForkLifecycleAtBuild, isMigrationOpen } from '../../../lib/fork-data'
-
-export const migrationOpen = isMigrationOpen(getForkLifecycleAtBuild().state)
-
-{!migrationOpen && (
-<ProseCard>
-**MIGRATION CLOSED** — The Moon Fork migration window has closed. The guidance below explains the fork process and its historical decision points; it is not a current instruction to migrate.
-</ProseCard>
-)}
 
 # What To Do Around Fork Risk
 
-**TL;DR** — Fork risk is manageable at low levels. Monitor more closely as it rises. During an active migration window, follow the current state and deadline shown on the landing page. {!migrationOpen && 'The current Moon Fork guidance is now historical.'}
+**TL;DR** — Fork risk is manageable at low levels. Monitor more closely as it rises. During an active migration window, participants follow the current state and deadline shown on the landing page.
 
 ## Risk Overview
 

--- a/src/features/fork-monitor/active-card.tsx
+++ b/src/features/fork-monitor/active-card.tsx
@@ -1,8 +1,15 @@
-import { useEffect, useState } from "react";
-import { cn } from "@/lib/utils";
+import { useState } from "react";
 import Button from "@/components/ui/button";
-import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+	Dialog,
+	DialogContent,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { useForkClock } from "./clock";
 import { useForkData } from "./data-provider";
+import { deriveForkLifecycle, getForkRecord } from "./derive-fork-lifecycle";
 
 const TOTAL_SUPPLY = 11_000_000;
 
@@ -25,21 +32,20 @@ const pad = (n: number, w = 2) => String(n).padStart(w, "0");
 
 export const ForkActiveCard = (): React.JSX.Element | null => {
 	const { rawData } = useForkData();
-	const fork = rawData.forkActive;
-	const [now, setNow] = useState<number>(() => Date.now());
+	const record = getForkRecord(rawData);
+	const now = useForkClock();
 	const [isHelpOpen, setIsHelpOpen] = useState(false);
 
-	useEffect(() => {
-		const id = setInterval(() => setNow(Date.now()), 1000);
-		return () => clearInterval(id);
-	}, []);
+	if (!record) return null;
 
-	if (!fork) return null;
-
-	const migratedRep = fork.outcomes.reduce((sum, o) => sum + o.migratedRep, 0);
+	const migratedRep = record.outcomes.reduce(
+		(sum, o) => sum + o.migratedRep,
+		0,
+	);
 	const migratedPercent = Math.min(100, (migratedRep / TOTAL_SUPPLY) * 100);
+	const winnerKnown = deriveForkLifecycle(rawData).winnerKnown;
 
-	const t = getCountdownParts(fork.forkEndTime, now);
+	const t = getCountdownParts(record.migrationDeadline, now);
 	const timerCells: Array<{ value: string; label: string }> = [
 		{ value: pad(t.d, 2), label: "DAYS" },
 		{ value: pad(t.h), label: "HRS" },
@@ -59,9 +65,7 @@ export const ForkActiveCard = (): React.JSX.Element | null => {
 					>
 						<div className="flex justify-between items-center mb-4">
 							<div className="text-xs uppercase tracking-widest">
-								<span className="text-muted-foreground">
-									{"FORK ACTIVE //"}
-								</span>{" "}
+								<span className="text-muted-foreground">{"FORK ACTIVE // "}</span>
 								<span className="text-foreground">MIGRATING</span>
 							</div>
 							<div className="inline-flex items-center gap-1.5 text-xs uppercase tracking-widest text-muted-foreground group-hover:text-primary group-focus:text-primary transition">
@@ -107,8 +111,7 @@ export const ForkActiveCard = (): React.JSX.Element | null => {
 							</div>
 						</div>
 						<div className="text-center text-muted-foreground">
-							remaining in <span className="text-foreground">60-day</span>{" "}
-							migration window
+							time remaining to migrate
 						</div>
 					</button>
 				</DialogTrigger>
@@ -147,12 +150,12 @@ export const ForkActiveCard = (): React.JSX.Element | null => {
 					</div>
 				</div>
 			</div>
-			<ForkActiveHelpDialog />
+			<ForkActiveHelpDialog winnerKnown={winnerKnown} />
 		</Dialog>
 	);
 };
 
-const ForkActiveHelpDialog = () => (
+const ForkActiveHelpDialog = ({ winnerKnown }: { winnerKnown: boolean }) => (
 	<DialogContent className="bg-background border border-foreground/10 backdrop-blur-sm overflow-y-auto">
 		<DialogTitle className="sr-only">Fork migration help</DialogTitle>
 		<div className="mb-4">
@@ -182,10 +185,12 @@ const ForkActiveHelpDialog = () => (
 			</div>
 			<div>
 				<span className="uppercase font-display text-red-400 font-bold text-2xl tracking-wide">
-					Migration window closing
+					{winnerKnown ? "Migration window closing" : "The fork is here"}
 				</span>
 				<p className="text-base text-red-400/70 leading-5 tracking-tight">
-					Act now or risk permanently losing your REP!
+					{winnerKnown
+						? "Act now or risk permanently losing your REP!"
+						: "Own REP? Act now."}
 				</p>
 			</div>
 		</div>

--- a/src/features/fork-monitor/clock.tsx
+++ b/src/features/fork-monitor/clock.tsx
@@ -1,0 +1,29 @@
+import {
+	createContext,
+	useContext,
+	useEffect,
+	useState,
+	type ReactNode,
+} from "react";
+
+const ForkClockContext = createContext<number | null>(null);
+
+export const useForkClock = (): number => {
+	const now = useContext(ForkClockContext);
+	return now ?? Date.now();
+};
+
+export const ForkClockProvider = ({ children }: { children: ReactNode }) => {
+	const [now, setNow] = useState<number>(() => Date.now());
+
+	useEffect(() => {
+		const id = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(id);
+	}, []);
+
+	return (
+		<ForkClockContext.Provider value={now}>
+			{children}
+		</ForkClockContext.Provider>
+	);
+};

--- a/src/features/fork-monitor/controls.tsx
+++ b/src/features/fork-monitor/controls.tsx
@@ -34,9 +34,14 @@ export const ForkControls = (): React.JSX.Element | null => {
 
 	if (!isVisible) {
 		return ReactDOM.createPortal(
-			<div className="fixed top-4 left-4 z-50 text-xs text-muted-foreground bg-background/90 px-2 py-1 rounded">
+			<button
+				type="button"
+				onClick={() => setIsVisible(true)}
+				className="fixed top-4 left-4 z-50 text-xs text-muted-foreground bg-background/90 px-2 py-1 rounded hover:text-primary hover:fx-glow-sm focus:text-primary focus:fx-glow-sm focus:outline-none"
+				aria-label="Open fork demo controls"
+			>
 				DEV: F2 for demo
-			</div>,
+			</button>,
 			document.body,
 		);
 	}
@@ -64,7 +69,7 @@ export const ForkControls = (): React.JSX.Element | null => {
 						onClick={resetToLive}
 						className="text-xs bg-primary/20 hover:bg-primary/30 px-2 py-1 rounded"
 					>
-						Return to Live Data
+						Return to Fork JSON Data
 					</button>
 				</div>
 			)}
@@ -109,7 +114,7 @@ export const ForkControls = (): React.JSX.Element | null => {
 				<button
 					type="button"
 					onClick={() => generateScenario(DisputeBondScenario.ELEVATED_RISK)}
-					className="block w-full text-left text-xs bg-red-800/30 hover:bg-red-800/40 px-2 py-1 rounded animate-pulse"
+					className="block w-full text-left text-xs bg-red-800/30 hover:bg-red-800/40 px-2 py-1 rounded motion-safe:animate-pulse"
 				>
 					Extreme Risk (75%+)
 				</button>
@@ -147,7 +152,37 @@ export const ForkControls = (): React.JSX.Element | null => {
 					}
 					className="block w-full text-left text-xs bg-purple-900/40 hover:bg-purple-900/50 px-2 py-1 rounded"
 				>
-					Active Fork — Resolved (Yes &gt; goal)
+					Winner Known — Migration Still Open
+				</button>
+
+				<button
+					type="button"
+					onClick={() =>
+						generateScenario(DisputeBondScenario.ACTIVE_FORK_CLOSING)
+					}
+					className="block w-full text-left text-xs bg-red-900/40 hover:bg-red-900/50 px-2 py-1 rounded"
+				>
+					Winner Known — Closing (~1 Day)
+				</button>
+
+				<button
+					type="button"
+					onClick={() =>
+						generateScenario(DisputeBondScenario.ACTIVE_FORK_CLOSED)
+					}
+					className="block w-full text-left text-xs bg-green-900/30 hover:bg-green-900/40 px-2 py-1 rounded"
+				>
+					Migration Closed — Fork Record
+				</button>
+
+				<button
+					type="button"
+					onClick={() =>
+						generateScenario(DisputeBondScenario.ACTIVE_FORK_CLOSED_UNVERIFIED)
+					}
+					className="block w-full text-left text-xs bg-orange-900/30 hover:bg-orange-900/40 px-2 py-1 rounded"
+				>
+					Migration Closed — Winner Pending
 				</button>
 			</div>
 

--- a/src/features/fork-monitor/data-provider.tsx
+++ b/src/features/fork-monitor/data-provider.tsx
@@ -8,6 +8,7 @@ import {
 	useState,
 } from "react";
 import type { ForkRiskData, GaugeData, RiskLevel } from "./types";
+import { validateForkRiskData } from "./validate-fork-data";
 
 interface ForkDataContextValue {
 	gaugeData: GaugeData;
@@ -118,13 +119,23 @@ export const ForkDataProvider = ({
 			}
 
 			const data: ForkRiskData = await response.json();
+			const validation = validateForkRiskData(data);
+			if (!validation.valid) {
+				const message = `Fork data validation failed: ${validation.errors.join("; ")}`;
+				console.error(message);
+				setError(message);
+				setForkRiskData({ ...defaultData, error: message });
+				return;
+			}
 			setForkRiskData(data);
 		} catch (err) {
 			console.error("Error loading fork risk data:", err);
-			setError(err instanceof Error ? err.message : "Failed to load data");
+			const message =
+				err instanceof Error ? err.message : "Failed to load data";
+			setError(message);
 
 			// Fallback to default data if file doesn't exist
-			setForkRiskData(defaultData);
+			setForkRiskData({ ...defaultData, error: message });
 		} finally {
 			setIsLoading(false);
 		}

--- a/src/features/fork-monitor/demo-data.ts
+++ b/src/features/fork-monitor/demo-data.ts
@@ -1,4 +1,4 @@
-import type { ForkRiskData } from "./types";
+import type { ForkRecordData, ForkRiskData } from "./types";
 
 type ForkRiskLevel = ForkRiskData["riskLevel"];
 
@@ -16,6 +16,9 @@ export enum DisputeBondScenario {
 	ACTIVE_FORK_MID = "active_fork_mid",
 	ACTIVE_FORK_NEAR_GOAL = "active_fork_near_goal",
 	ACTIVE_FORK_RESOLVED = "active_fork_resolved",
+	ACTIVE_FORK_CLOSING = "active_fork_closing",
+	ACTIVE_FORK_CLOSED = "active_fork_closed",
+	ACTIVE_FORK_CLOSED_UNVERIFIED = "active_fork_closed_unverified",
 }
 
 // Representative round data per scenario
@@ -27,6 +30,9 @@ const SCENARIO_ROUNDS: Record<
 		| DisputeBondScenario.ACTIVE_FORK_MID
 		| DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL
 		| DisputeBondScenario.ACTIVE_FORK_RESOLVED
+		| DisputeBondScenario.ACTIVE_FORK_CLOSING
+		| DisputeBondScenario.ACTIVE_FORK_CLOSED
+		| DisputeBondScenario.ACTIVE_FORK_CLOSED_UNVERIFIED
 	>,
 	{
 		currentRound: number;
@@ -66,7 +72,10 @@ export const generateDemoForkRiskData = (
 		scenario === DisputeBondScenario.ACTIVE_FORK ||
 		scenario === DisputeBondScenario.ACTIVE_FORK_MID ||
 		scenario === DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL ||
-		scenario === DisputeBondScenario.ACTIVE_FORK_RESOLVED
+		scenario === DisputeBondScenario.ACTIVE_FORK_RESOLVED ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_CLOSING ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_CLOSED ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_CLOSED_UNVERIFIED
 	) {
 		return generateActiveForkDemo(scenario);
 	}
@@ -235,7 +244,10 @@ const ACTIVE_FORK_MIGRATIONS: Record<
 	| DisputeBondScenario.ACTIVE_FORK
 	| DisputeBondScenario.ACTIVE_FORK_MID
 	| DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL
-	| DisputeBondScenario.ACTIVE_FORK_RESOLVED,
+	| DisputeBondScenario.ACTIVE_FORK_RESOLVED
+	| DisputeBondScenario.ACTIVE_FORK_CLOSING
+	| DisputeBondScenario.ACTIVE_FORK_CLOSED
+	| DisputeBondScenario.ACTIVE_FORK_CLOSED_UNVERIFIED,
 	{ invalid: number; no: number; yes: number; daysRemaining: number }
 > = {
 	[DisputeBondScenario.ACTIVE_FORK]: {
@@ -262,6 +274,24 @@ const ACTIVE_FORK_MIGRATIONS: Record<
 		yes: 5_620_000,
 		daysRemaining: 12,
 	},
+	[DisputeBondScenario.ACTIVE_FORK_CLOSING]: {
+		invalid: 0,
+		no: 1_786,
+		yes: 6_454_838,
+		daysRemaining: 1,
+	},
+	[DisputeBondScenario.ACTIVE_FORK_CLOSED]: {
+		invalid: 0,
+		no: 1_786,
+		yes: 6_461_666,
+		daysRemaining: -1,
+	},
+	[DisputeBondScenario.ACTIVE_FORK_CLOSED_UNVERIFIED]: {
+		invalid: 198_000,
+		no: 940_000,
+		yes: 5_620_000,
+		daysRemaining: -1,
+	},
 };
 
 const generateActiveForkDemo = (
@@ -269,7 +299,10 @@ const generateActiveForkDemo = (
 		| DisputeBondScenario.ACTIVE_FORK
 		| DisputeBondScenario.ACTIVE_FORK_MID
 		| DisputeBondScenario.ACTIVE_FORK_NEAR_GOAL
-		| DisputeBondScenario.ACTIVE_FORK_RESOLVED = DisputeBondScenario.ACTIVE_FORK,
+		| DisputeBondScenario.ACTIVE_FORK_RESOLVED
+		| DisputeBondScenario.ACTIVE_FORK_CLOSING
+		| DisputeBondScenario.ACTIVE_FORK_CLOSED
+		| DisputeBondScenario.ACTIVE_FORK_CLOSED_UNVERIFIED = DisputeBondScenario.ACTIVE_FORK,
 ): ForkRiskData => {
 	const universeRepSupply = 8_174_577;
 	const forkReputationGoal = 5_497_186;
@@ -282,25 +315,55 @@ const generateActiveForkDemo = (
 		{
 			index: 0,
 			label: "Invalid",
-			childUniverse: "0xinvalid000000000000000000000000000000000",
+			childUniverse: "0x0000000000000000000000000000000000000100",
 			migratedRep: invalid,
 		},
 		{
 			index: 1,
-			label: "No",
-			childUniverse: "0xno0000000000000000000000000000000000000000",
-			migratedRep: no,
+			label: "Yes",
+			childUniverse: "0x0000000000000000000000000000000000000101",
+			migratedRep: yes,
 		},
 		{
 			index: 2,
-			label: "Yes",
-			childUniverse: "0xyes000000000000000000000000000000000000000",
-			migratedRep: yes,
+			label: "No",
+			childUniverse: "0x0000000000000000000000000000000000000102",
+			migratedRep: no,
 		},
 	];
+	const winnerKnown =
+		scenario === DisputeBondScenario.ACTIVE_FORK_RESOLVED ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_CLOSING ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_CLOSED;
+	const migrationClosed =
+		scenario === DisputeBondScenario.ACTIVE_FORK_CLOSED ||
+		scenario === DisputeBondScenario.ACTIVE_FORK_CLOSED_UNVERIFIED;
+	const winningChildUniverse = winnerKnown ? outcomes[1].childUniverse : null;
+	const generatedAt = new Date().toISOString();
+	const forkRecord: ForkRecordData = {
+		status: migrationClosed
+			? winnerKnown
+				? "migration-closed-resolved"
+				: "migration-closed-unverified"
+			: winnerKnown
+				? "migration-open-resolved"
+				: "migration-open",
+		parentUniverse: "0x0000000000000000000000000000000000000200",
+		forkingMarket: "0x0000000000000000000000000000000000000201",
+		migrationDeadline: forkEndTime,
+		reputationGoal: forkReputationGoal,
+		winningChildUniverse,
+		outcomes: outcomes.map((outcome) => ({
+			...outcome,
+			isWinner: outcome.childUniverse === winningChildUniverse,
+		})),
+		observedBlock: 25_185_608,
+	};
 
 	return {
-		lastRiskChange: new Date().toISOString(),
+		schemaVersion: 2,
+		generatedAt,
+		lastRiskChange: generatedAt,
 		blockNumber: 25_185_608,
 		riskLevel: "critical",
 		riskPercentage: 100,
@@ -332,12 +395,14 @@ const generateActiveForkDemo = (
 			forkThreshold,
 		},
 		forkActive: {
-			forkingMarket: "0x963eed85778cc23e2d4636cd4f29eecdf9827e9e",
+			forkingMarket: forkRecord.forkingMarket,
 			forkEndTime,
+			winningChildUniverse,
 			forkReputationGoal,
 			universeRepSupply,
-			outcomes,
+			outcomes: forkRecord.outcomes,
 		},
+		fork: forkRecord,
 	};
 };
 

--- a/src/features/fork-monitor/derive-fork-lifecycle.ts
+++ b/src/features/fork-monitor/derive-fork-lifecycle.ts
@@ -1,0 +1,104 @@
+import type {
+	ForkLifecycleState,
+	ForkRecordData,
+	ForkRiskData,
+} from "./types.ts";
+
+const ETHEREUM_ADDRESS = /^0x[0-9a-f]{40}$/iu;
+
+export interface DerivedForkLifecycle {
+	state: ForkLifecycleState;
+	record: ForkRecordData | null;
+	winnerKnown: boolean;
+	deadlinePassed: boolean;
+	reason?: string;
+}
+
+export const isEthereumAddress = (
+	value: string | null | undefined,
+): value is string => typeof value === "string" && ETHEREUM_ADDRESS.test(value);
+
+export const isNonZeroEthereumAddress = (
+	value: string | null | undefined,
+): value is string =>
+	isEthereumAddress(value) && !/^0x0{40}$/iu.test(value as string);
+
+const legacyRecord = (data: ForkRiskData): ForkRecordData | null => {
+	const fork = data.forkActive;
+	if (!fork) return null;
+
+	return {
+		status: "migration-open",
+		parentUniverse: null,
+		forkingMarket: fork.forkingMarket,
+		migrationDeadline: fork.forkEndTime,
+		reputationGoal: fork.forkReputationGoal,
+		winningChildUniverse: fork.winningChildUniverse ?? null,
+		outcomes: fork.outcomes,
+		observedBlock: data.blockNumber,
+	};
+};
+
+export const getForkRecord = (data: ForkRiskData): ForkRecordData | null =>
+	data.fork ?? legacyRecord(data);
+
+export const deriveForkLifecycle = (
+	data: ForkRiskData,
+	nowSeconds = Math.floor(Date.now() / 1000),
+): DerivedForkLifecycle => {
+	if (data.error) {
+		return {
+			state: "data-unavailable",
+			record: null,
+			winnerKnown: false,
+			deadlinePassed: false,
+			reason: data.error,
+		};
+	}
+
+	const record = getForkRecord(data);
+	if (!record) {
+		return {
+			state: "monitoring",
+			record: null,
+			winnerKnown: false,
+			deadlinePassed: false,
+		};
+	}
+
+	if (
+		!Number.isFinite(record.migrationDeadline) ||
+		record.migrationDeadline <= 0
+	) {
+		return {
+			state: "data-unavailable",
+			record,
+			winnerKnown: false,
+			deadlinePassed: false,
+			reason: "Migration deadline is missing or invalid.",
+		};
+	}
+
+	const winnerKnown =
+		Array.isArray(record.outcomes) &&
+		isNonZeroEthereumAddress(record.winningChildUniverse) &&
+		record.outcomes.some(
+			(outcome) =>
+				outcome.childUniverse?.toLowerCase() ===
+				record.winningChildUniverse?.toLowerCase(),
+		);
+	const deadlinePassed = nowSeconds >= record.migrationDeadline;
+
+	return {
+		state: deadlinePassed
+			? winnerKnown
+				? "migration-closed-resolved"
+				: "migration-closed-unverified"
+			: winnerKnown
+				? "migration-open-resolved"
+				: "migration-open",
+		record,
+		winnerKnown,
+		deadlinePassed,
+	};
+};

--- a/src/features/fork-monitor/display.tsx
+++ b/src/features/fork-monitor/display.tsx
@@ -1,9 +1,12 @@
 import type React from "react";
-import { useForkData } from "./data-provider";
 import { ForkActiveCard } from "./active-card";
+import { useForkClock } from "./clock";
 import { ForkControls } from "./controls";
+import { useForkData } from "./data-provider";
+import { deriveForkLifecycle } from "./derive-fork-lifecycle";
 import { ForkDetailsCard } from "./details-card";
 import { ForkGauge } from "./gauge";
+import { ForkRecord, ForkResolutionPending } from "./post-fork-record";
 import { ForkStats } from "./stats";
 
 // Helper function to format timestamps as relative time
@@ -32,7 +35,8 @@ interface ForkDisplayProps {
 const ForkDisplay: React.FC<ForkDisplayProps> = ({ animated = true }) => {
 	const { gaugeData, riskLevel, lastUpdated, isLoading, error, rawData } =
 		useForkData();
-	const isForking = rawData.metrics.disputeDetails[0]?.marketId === "FORKING";
+	const now = useForkClock();
+	const lifecycle = deriveForkLifecycle(rawData, Math.floor(now / 1000));
 
 	return (
 		<>
@@ -45,9 +49,28 @@ const ForkDisplay: React.FC<ForkDisplayProps> = ({ animated = true }) => {
 
 				{error && <div className="mb-4 text-orange-400">Warning: {error}</div>}
 
-				{isForking ? (
-					<ForkActiveCard />
-				) : (
+				{(lifecycle.state === "migration-open" ||
+					lifecycle.state === "migration-open-resolved") && <ForkActiveCard />}
+
+				{lifecycle.state === "migration-closed-resolved" && <ForkRecord />}
+
+				{lifecycle.state === "migration-closed-unverified" && (
+					<ForkResolutionPending />
+				)}
+
+				{lifecycle.state === "data-unavailable" && (
+					<div className="mx-auto max-w-xl border border-orange-500/30 bg-orange-500/5 p-5 text-left font-mono text-sm text-orange-300">
+						<div className="text-xs uppercase tracking-widest">
+							Fork data unavailable
+						</div>
+						<p className="mt-2 font-prose text-muted-foreground">
+							The site is withholding a fork status claim until the fork JSON
+							data can be verified.
+						</p>
+					</div>
+				)}
+
+				{lifecycle.state === "monitoring" && (
 					<>
 						{/* Gauge with Details Card - ForkDetailsCard wraps the gauge */}
 						<ForkDetailsCard

--- a/src/features/fork-monitor/fork-action.tsx
+++ b/src/features/fork-monitor/fork-action.tsx
@@ -1,0 +1,38 @@
+import { SirenIcon } from "@phosphor-icons/react";
+import type React from "react";
+import BorderBeam from "@/components/ui/border-beam";
+import { useForkClock } from "./clock";
+import { useForkData } from "./data-provider";
+import { deriveForkLifecycle } from "./derive-fork-lifecycle";
+
+const ForkAction = (): React.JSX.Element | null => {
+	const { rawData } = useForkData();
+	const now = useForkClock();
+
+	const lifecycle = deriveForkLifecycle(rawData, Math.floor(now / 1000));
+	const migrationIsOpen =
+		lifecycle.state === "migration-open" ||
+		lifecycle.state === "migration-open-resolved";
+
+	if (!migrationIsOpen) return null;
+
+	return (
+		<div className="hero-fork-cta">
+			<div className="motion-safe:animate-[bob_2s_ease-in-out_infinite]">
+				<BorderBeam duration={2.5}>
+					<a
+						href="/learn/fork/migration/"
+						className="font-display bg-foreground/5 tracking-wide flex items-center px-4 py-2 sm:text-xl font-semibold text-loud-foreground uppercase shadow-[0_0_10px_oklch(from_var(--color-foreground)_l_c_h/_0.4)] hover:fx-glow-sm focus:fx-glow-sm focus:outline-none whitespace-nowrap"
+					>
+						<SirenIcon className="w-6 h-6 border-muted-foreground/80 rounded-full p-1 mr-3" />
+						{lifecycle.winnerKnown
+							? "MIGRATION WINDOW CLOSING, ACT NOW!"
+							: "THE FORK IS HERE! OWN REP? ACT NOW."}
+					</a>
+				</BorderBeam>
+			</div>
+		</div>
+	);
+};
+
+export default ForkAction;

--- a/src/features/fork-monitor/monitor.tsx
+++ b/src/features/fork-monitor/monitor.tsx
@@ -1,16 +1,19 @@
 import type React from "react";
 import { ForkDataProvider } from "./data-provider";
-import { ErrorBoundary } from "./error-boundary";
 import ForkDisplay from "./display";
+import { ForkClockProvider } from "./clock";
+import { ErrorBoundary } from "./error-boundary";
 import { ForkMockProvider } from "./mock-provider";
 
 interface ForkMonitorProps {
 	animated?: boolean;
 }
 
-export const ForkMonitor: React.FC<ForkMonitorProps> = ({
-	animated = true,
-}) => {
+interface ForkExperienceProps {
+	children: React.ReactNode;
+}
+
+export const ForkExperience: React.FC<ForkExperienceProps> = ({ children }) => {
 	return (
 		<ErrorBoundary
 			fallback={
@@ -19,10 +22,24 @@ export const ForkMonitor: React.FC<ForkMonitorProps> = ({
 		>
 			<ForkDataProvider>
 				<ForkMockProvider>
-					<ForkDisplay animated={animated} />
+					<ForkClockProvider>
+						{children}
+					</ForkClockProvider>
 				</ForkMockProvider>
 			</ForkDataProvider>
 		</ErrorBoundary>
+	);
+};
+
+export const ForkMonitor: React.FC<ForkMonitorProps> = ({
+	animated = true,
+}) => {
+	return (
+		<ForkExperience>
+			<div className="hero-fork-meter py-6">
+				<ForkDisplay animated={animated} />
+			</div>
+		</ForkExperience>
 	);
 };
 

--- a/src/features/fork-monitor/post-fork-record.tsx
+++ b/src/features/fork-monitor/post-fork-record.tsx
@@ -1,0 +1,276 @@
+import type React from "react";
+import { useState } from "react";
+import Button from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { useForkData } from "./data-provider";
+import { getForkRecord } from "./derive-fork-lifecycle";
+import type { ForkOutcome, ForkRecordData } from "./types";
+
+const shortenAddress = (address: string | null | undefined): string => {
+	if (!address) return "Not available";
+	return `${address.slice(0, 6)}...${address.slice(-4)}`;
+};
+
+const formatRep = (value: number): string => Math.round(value).toLocaleString();
+
+const formatDate = (timestamp: number): string => {
+	const date = new Date(timestamp * 1000);
+	if (Number.isNaN(date.getTime())) return "Not available";
+	return date.toLocaleString([], {
+		dateStyle: "medium",
+		timeStyle: "short",
+	});
+};
+
+const formatShortDate = (timestamp: number): string => {
+	const date = new Date(timestamp * 1000);
+	if (Number.isNaN(date.getTime())) return "date unavailable";
+	return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+};
+
+const etherscanAddress = (address: string): string =>
+	`https://etherscan.io/address/${address}`;
+
+const FORKWATCH_URL = "https://v3.augur.net/";
+
+const AddressValue = ({
+	address,
+	label,
+}: {
+	address: string | null | undefined;
+	label: string;
+}) => {
+	if (!address) {
+		return (
+			<div className="flex items-center justify-between gap-4">
+				<span className="text-muted-foreground">{label}</span>
+				<span>Not available</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex items-center justify-between gap-4">
+			<span className="text-muted-foreground">{label}</span>
+			<a
+				href={etherscanAddress(address)}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="text-primary hover:text-loud-foreground hover:underline focus:underline"
+				title={address}
+			>
+				{shortenAddress(address)}
+			</a>
+		</div>
+	);
+};
+
+const OutcomeRow = ({
+	outcome,
+	isWinner,
+}: {
+	outcome: ForkOutcome;
+	isWinner: boolean;
+}) => (
+	<div
+		className={cn(
+			"grid grid-cols-[1fr_auto] gap-3 border-t border-foreground/15 py-3",
+			isWinner && "text-primary",
+		)}
+	>
+		<div>
+			<div className="uppercase tracking-wider">
+				{outcome.label}
+				{isWinner && (
+					<span className="ml-2 inline-flex items-center bg-primary px-1.5 py-0.5 align-middle text-[9px] leading-none tracking-widest text-background">
+						WINNER
+					</span>
+				)}
+			</div>
+			{outcome.childUniverse && (
+				<a
+					href={etherscanAddress(outcome.childUniverse)}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="text-xs text-muted-foreground hover:text-foreground hover:underline focus:underline"
+					title={outcome.childUniverse}
+				>
+					{shortenAddress(outcome.childUniverse)}
+				</a>
+			)}
+		</div>
+		<div className="text-right tabular-nums">
+			<div>{formatRep(outcome.migratedRep)} REP</div>
+			<div className="text-[10px] text-muted-foreground">MIGRATED</div>
+		</div>
+	</div>
+);
+
+const ForkResolutionDialog = ({ record }: { record: ForkRecordData }) => (
+	<DialogContent className="max-h-[85vh] overflow-y-auto bg-background border border-foreground/20 backdrop-blur-sm">
+		<DialogTitle className="font-display uppercase tracking-widest text-primary">
+			Fork resolution
+		</DialogTitle>
+		<DialogDescription>
+			The migration window closed with a verified winning child universe. The
+			addresses and migration totals below are the recorded protocol data.
+		</DialogDescription>
+
+		<div className="space-y-2 border-y border-foreground/20 py-4 text-sm font-mono">
+			<AddressValue label="Parent universe" address={record.parentUniverse} />
+			<AddressValue label="Forking market" address={record.forkingMarket} />
+			<AddressValue
+				label="Canonical universe"
+				address={record.winningChildUniverse}
+			/>
+			<div className="flex items-center justify-between gap-4">
+				<span className="text-muted-foreground">Migration closed</span>
+				<span>{formatDate(record.migrationDeadline)}</span>
+			</div>
+			{record.observedBlock && (
+				<div className="flex items-center justify-between gap-4">
+					<span className="text-muted-foreground">Observed block</span>
+					<span>{record.observedBlock.toLocaleString()}</span>
+				</div>
+			)}
+		</div>
+
+		<div>
+			<div className="mb-2 text-xs uppercase tracking-widest text-muted-foreground">
+				Recorded outcomes
+			</div>
+			{record.outcomes.map((outcome) => (
+				<OutcomeRow
+					key={`${outcome.index}-${outcome.childUniverse ?? "invalid"}`}
+					outcome={outcome}
+					isWinner={
+						outcome.childUniverse?.toLowerCase() ===
+						record.winningChildUniverse?.toLowerCase()
+					}
+				/>
+			))}
+		</div>
+
+		<div className="space-y-2">
+			<Button
+				variant="outline"
+				href={
+					record.winningChildUniverse
+						? etherscanAddress(record.winningChildUniverse)
+						: "https://etherscan.io/"
+				}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="w-full uppercase"
+			>
+				Verify on Etherscan
+			</Button>
+			<Button
+				variant="outline"
+				href={FORKWATCH_URL}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="w-full uppercase"
+			>
+				Open ForkWatch
+			</Button>
+		</div>
+	</DialogContent>
+);
+
+export const ForkRecord = (): React.JSX.Element | null => {
+	const { rawData } = useForkData();
+	const record = getForkRecord(rawData);
+	const [isOpen, setIsOpen] = useState(false);
+
+	if (!record?.winningChildUniverse) return null;
+
+	return (
+		<Dialog open={isOpen} onOpenChange={setIsOpen}>
+			<div className="mx-auto w-full max-w-xl px-8 text-left font-mono text-sm">
+				<DialogTrigger asChild>
+					<button
+						type="button"
+						className="group block w-full cursor-pointer text-left focus:outline-none"
+						aria-label="View fork resolution"
+					>
+						<div className="mb-2 flex items-center justify-between text-xs uppercase tracking-wide">
+							<span className="text-muted-foreground">fork resolution</span>
+							<span className="text-muted-foreground group-hover:text-loud-foreground">
+								what's this
+								<span className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full border border-current leading-none tracking-tight group-hover:fx-glow-sm group-focus:fx-glow-sm">
+									?
+								</span>
+							</span>
+
+						</div>
+
+						<div
+							className="bg-muted-foreground/40 p-px transition-colors group-hover:bg-foreground/50 group-focus:bg-foreground/50"
+							style={{
+								clipPath:
+									"polygon(14px 0, 100% 0, 100% calc(100% - 14px), calc(100% - 14px) 100%, 0 100%, 0 14px)",
+							}}
+						>
+							<div
+								className="bg-background py-4 text-center"
+								style={{
+									clipPath:
+										"polygon(14px 0, 100% 0, 100% calc(100% - 14px), calc(100% - 14px) 100%, 0 100%, 0 14px)",
+								}}
+							>
+								<div className="text-xs uppercase tracking-wide text-muted-foreground">
+									Canonical universe
+								</div>
+								<div className="break-all font-display text-xl text-foreground sm:text-xl">
+									<span className="sm:hidden">
+										{shortenAddress(record.winningChildUniverse)}
+									</span>
+									<span className="hidden sm:inline">
+										{record.winningChildUniverse}
+									</span>
+								</div>
+								<div className="text-muted-foreground text-xs">
+									Updated {formatShortDate(record.migrationDeadline)}
+								</div>
+								</div>
+							</div>
+
+            <div className={cn(
+              "pt-2 text-center text-xs text-muted-foreground group-hover:text-loud-foreground group-focus:text-loud-foreground group-hover:fx-glow-sm group-focus:fx-glow-sm",
+              "before:content-[''] before:border-b before:border-muted-foreground/60 before:w-8 before:inline-block before:align-middle before:mr-1",
+              "after:content-[''] after:border-b after:border-muted-foreground/60 after:w-8 after:inline-block after:align-middle after:ml-1"
+            )}>
+								Click to view resolution details
+						</div>
+					</button>
+				</DialogTrigger>
+			</div>
+			<ForkResolutionDialog record={record} />
+		</Dialog>
+	);
+};
+
+export const ForkResolutionPending = (): React.JSX.Element => (
+	<div className="mx-auto w-full max-w-xl px-8 text-left font-mono text-sm">
+		<div className="border border-orange-500/40 bg-orange-500/5 p-5">
+			<div className="mb-2 text-xs uppercase tracking-wide text-orange-400">
+				THE FORK RECORD
+			</div>
+			<div className="font-display text-2xl uppercase text-orange-300">
+				Resolution pending
+			</div>
+			<p className="mt-3 font-prose text-sm text-muted-foreground">
+				Migration has closed. The final winner is not verified in fork JSON data
+				yet, so the site is withholding a canonical-universe claim.
+			</p>
+		</div>
+	</div>
+);

--- a/src/features/fork-monitor/types.ts
+++ b/src/features/fork-monitor/types.ts
@@ -8,7 +8,37 @@ export interface RiskLevel {
 	level: "No Risk" | "Low" | "Moderate" | "High" | "Critical" | "Unknown";
 }
 
+export type ForkLifecycleState =
+	| "monitoring"
+	| "migration-open"
+	| "migration-open-resolved"
+	| "migration-closed-resolved"
+	| "migration-closed-unverified"
+	| "data-unavailable";
+
+export interface ForkOutcome {
+	index: number;
+	label: string;
+	childUniverse: string | null;
+	reputationToken?: string | null;
+	migratedRep: number;
+	isWinner?: boolean;
+}
+
+export interface ForkRecordData {
+	status: ForkLifecycleState;
+	parentUniverse: string | null;
+	forkingMarket: string;
+	migrationDeadline: number;
+	reputationGoal: number;
+	winningChildUniverse: string | null;
+	outcomes: ForkOutcome[];
+	observedBlock?: number;
+}
+
 export interface ForkRiskData {
+	schemaVersion?: number;
+	generatedAt?: string;
 	lastRiskChange: string;
 	blockNumber?: number;
 	riskLevel: "none" | "low" | "moderate" | "high" | "critical" | "unknown";
@@ -42,17 +72,14 @@ export interface ForkRiskData {
 		isHealthy: boolean;
 		discrepancy?: string;
 	};
+	fork?: ForkRecordData | null;
 	forkActive?: {
 		forkingMarket: string;
 		forkEndTime: number;
+		winningChildUniverse?: string | null;
 		forkReputationGoal: number;
 		universeRepSupply: number;
-		outcomes: Array<{
-			index: number;
-			label: string;
-			childUniverse: string | null;
-			migratedRep: number;
-		}>;
+		outcomes: ForkOutcome[];
 	};
 	error?: string;
 }

--- a/src/features/fork-monitor/validate-fork-data.ts
+++ b/src/features/fork-monitor/validate-fork-data.ts
@@ -1,0 +1,169 @@
+import {
+	isEthereumAddress,
+	isNonZeroEthereumAddress,
+} from "./derive-fork-lifecycle.ts";
+import type {
+	ForkLifecycleState,
+	ForkRecordData,
+	ForkRiskData,
+} from "./types.ts";
+
+const LIFECYCLE_STATES = new Set<ForkLifecycleState>([
+	"monitoring",
+	"migration-open",
+	"migration-open-resolved",
+	"migration-closed-resolved",
+	"migration-closed-unverified",
+	"data-unavailable",
+]);
+
+export interface ForkDataValidationResult {
+	valid: boolean;
+	errors: string[];
+}
+
+const validateRecord = (record: ForkRecordData, errors: string[]): void => {
+	if (!LIFECYCLE_STATES.has(record.status)) {
+		errors.push(`Unknown fork lifecycle status: ${record.status}`);
+	}
+
+	if (!isEthereumAddress(record.forkingMarket)) {
+		errors.push("Forking market is not a valid Ethereum address.");
+	}
+
+	if (
+		record.parentUniverse !== null &&
+		!isEthereumAddress(record.parentUniverse)
+	) {
+		errors.push("Parent universe is not a valid Ethereum address.");
+	}
+
+	if (
+		!Number.isFinite(record.migrationDeadline) ||
+		record.migrationDeadline <= 0
+	) {
+		errors.push("Migration deadline is missing or invalid.");
+	}
+
+	if (!Number.isFinite(record.reputationGoal) || record.reputationGoal < 0) {
+		errors.push("Fork reputation goal is missing or invalid.");
+	}
+
+	if (!Array.isArray(record.outcomes)) {
+		errors.push("Fork outcomes must be an array.");
+		return;
+	}
+
+	const childAddresses = record.outcomes
+		.map((outcome) => outcome.childUniverse)
+		.filter(isNonZeroEthereumAddress)
+		.map((address) => address.toLowerCase());
+	if (new Set(childAddresses).size !== childAddresses.length) {
+		errors.push("Duplicate child universe addresses were emitted.");
+	}
+
+	for (const outcome of record.outcomes) {
+		if (
+			outcome.childUniverse !== null &&
+			!isEthereumAddress(outcome.childUniverse)
+		) {
+			errors.push(`Outcome ${outcome.index} has an invalid child universe.`);
+		}
+		if (!Number.isFinite(outcome.migratedRep) || outcome.migratedRep < 0) {
+			errors.push(`Outcome ${outcome.index} has invalid migrated REP.`);
+		}
+	}
+
+	if (
+		record.winningChildUniverse !== null &&
+		!isEthereumAddress(record.winningChildUniverse)
+	) {
+		errors.push("Winning child universe is not a valid Ethereum address.");
+	}
+
+	const winner = record.winningChildUniverse?.toLowerCase();
+	const winnerMatchesOutcome = winner
+		? record.outcomes.some(
+				(outcome) => outcome.childUniverse?.toLowerCase() === winner,
+			)
+		: false;
+	if (winner && !winnerMatchesOutcome) {
+		errors.push("Winning child universe does not match an emitted outcome.");
+	}
+
+	const winnerRequired =
+		record.status === "migration-open-resolved" ||
+		record.status === "migration-closed-resolved";
+	if (winnerRequired && !winnerMatchesOutcome) {
+		errors.push(
+			`${record.status} requires a winning child universe that matches an outcome.`,
+		);
+	}
+	if (record.status === "migration-closed-unverified" && winnerMatchesOutcome) {
+		errors.push(
+			"migration-closed-unverified cannot include a verified winning child universe.",
+		);
+	}
+};
+
+export const validateForkRiskData = (
+	data: ForkRiskData,
+): ForkDataValidationResult => {
+	const errors: string[] = [];
+
+	if (data.fork) validateRecord(data.fork, errors);
+
+	if (data.forkActive) {
+		if (!Array.isArray(data.forkActive.outcomes)) {
+			errors.push("Legacy forkActive outcomes must be an array.");
+			return { valid: false, errors };
+		}
+
+		for (const outcome of data.forkActive.outcomes) {
+			if (
+				outcome.childUniverse !== null &&
+				!isEthereumAddress(outcome.childUniverse)
+			) {
+				errors.push(`Legacy outcome ${outcome.index} has an invalid child universe.`);
+			}
+			if (!Number.isFinite(outcome.migratedRep) || outcome.migratedRep < 0) {
+				errors.push(`Legacy outcome ${outcome.index} has invalid migrated REP.`);
+			}
+		}
+
+		if (
+			!Number.isFinite(data.forkActive.forkEndTime) ||
+			data.forkActive.forkEndTime <= 0
+		) {
+			errors.push("Legacy forkActive deadline is missing or invalid.");
+		}
+
+		const winner = data.forkActive.winningChildUniverse;
+		if (winner !== undefined && winner !== null) {
+			if (!isEthereumAddress(winner)) {
+				errors.push("Legacy winning child universe is invalid.");
+			} else if (
+				!data.forkActive.outcomes.some(
+					(outcome) =>
+						outcome.childUniverse?.toLowerCase() === winner.toLowerCase(),
+				)
+			) {
+				errors.push("Legacy winning child universe does not match an outcome.");
+			}
+		}
+	}
+
+	if (data.schemaVersion === 2) {
+		if (!data.generatedAt || Number.isNaN(Date.parse(data.generatedAt))) {
+			errors.push("Schema v2 data requires a valid generatedAt timestamp.");
+		}
+		if (!Number.isInteger(data.blockNumber) || (data.blockNumber ?? 0) <= 0) {
+			errors.push("Schema v2 data requires an observed block number.");
+		}
+		if (data.fork === undefined && !data.forkActive) {
+			errors.push("Schema v2 fork data requires a fork record.");
+		}
+	}
+
+	return { valid: errors.length === 0, errors };
+};

--- a/src/features/home/hero-banner.tsx
+++ b/src/features/home/hero-banner.tsx
@@ -1,11 +1,15 @@
-import { SirenIcon } from "@phosphor-icons/react";
 import { useEffect, useRef } from "react";
+import PageHeader from "@/components/shell/page-header";
 import AsciiText from "@/components/ui/ascii-text";
 import { AugurLogo } from "@/components/ui/icons";
-import PageHeader from "@/components/shell/page-header";
-import BorderBeam from "@/components/ui/border-beam";
-import { ForkMonitor } from "@/features/fork-monitor/monitor";
+import { useForkClock } from "@/features/fork-monitor/clock";
+import { useForkData } from "@/features/fork-monitor/data-provider";
+import { deriveForkLifecycle } from "@/features/fork-monitor/derive-fork-lifecycle";
+import ForkDisplay from "@/features/fork-monitor/display";
+import ForkAction from "@/features/fork-monitor/fork-action";
+import { ForkExperience } from "@/features/fork-monitor/monitor";
 import { ScrollIndicator } from "./scroll-indicator";
+import TypewriterSequence from "./typewriter-sequence";
 
 const ASCII_ART = `██╗ ███████╗     ██████╗  ███████╗ ██████╗   ██████╗   ██████╗  ████████╗ ██╗ ███╗   ██╗  ██████╗
 ██║ ██╔════╝     ██╔══██╗ ██╔════╝ ██╔══██╗ ██╔═══██╗ ██╔═══██╗ ╚══██╔══╝ ██║ ████╗  ██║ ██╔════╝
@@ -13,6 +17,35 @@ const ASCII_ART = `██╗ ███████╗     ██████╗ 
  ██║ ╚════██║     ██╔══██╗ ██╔══╝   ██╔══██╗ ██║   ██║ ██║   ██║    ██║    ██║ ██║╚██╗██║ ██║   ██║
  ██║ ███████║     ██║  ██║ ███████╗ ██████╔╝ ╚██████╔╝ ╚██████╔╝    ██║    ██║ ██║ ╚████║ ╚██████╔╝
 ╚═╝ ╚══════╝     ╚═╝  ╚═╝ ╚══════╝ ╚═════╝   ╚═════╝   ╚═════╝     ╚═╝    ╚═╝ ╚═╝  ╚═══╝  ╚═════╝`;
+
+const RESOLUTION_MESSAGES = [
+	"THE PROTOCOL REACHED CONSENSUS",
+	"A CANONICAL UNIVERSE EMERGED",
+	"THE REBOOT CONTINUES...",
+];
+
+const ForkResolutionMessage: React.FC = () => {
+	const { rawData } = useForkData();
+	const now = useForkClock();
+	const lifecycle = deriveForkLifecycle(rawData, Math.floor(now / 1000));
+
+	if (lifecycle.state !== "migration-closed-resolved") return null;
+
+	return (
+		<div
+			className="h-12 min-w-sm grid place-content-center text-sm text-center text-foreground font-light tracking-wide border border-muted-foreground/60 px-4"
+			aria-live="polite"
+		>
+			<TypewriterSequence
+				sentences={RESOLUTION_MESSAGES}
+				defaultTypingSpeed={45}
+				delayBetweenSentences={1000}
+				holdDuration={3800}
+				loop
+			/>
+		</div>
+	);
+};
 
 const HeroBanner: React.FC = () => {
 	const menuItem1Ref = useRef<HTMLAnchorElement>(null);
@@ -29,70 +62,62 @@ const HeroBanner: React.FC = () => {
 	}, []);
 
 	return (
-		<div className="h-screen min-h-fit w-full relative">
-			<div className="grid grid-rows-[auto_auto_auto] min-h-full z-10 text-center content-between">
-				<div className="hero-header-row">
-					<PageHeader />
-				</div>
-
-				{/* Middle Section */}
-				<div className="flex flex-col items-center place-items-center py-8 gap-y-4">
-					<span className="hero-logo">
-						<AugurLogo className="text-9xl" />
-					</span>
-					<p className="hero-prediction-market font-light font-display border border-foreground/20 px-3 py-1 mx-4 sm:text-xl tracking-widest leading-none uppercase">
-						THE FRONTIER OF PREDICTION MARKETS
-					</p>
-
-					<h2 className="grid grid-cols-[minmax(0.25rem,1rem)_1fr_minmax(0.25rem,1rem)] items-center gap-x-4">
-						<span className="hero-line-left h-px bg-foreground" />
-						<AsciiText
-							className="hero-ascii text-[clamp(0.325rem,1vw,0.625rem)] leading-[1.1]"
-							content={ASCII_ART}
-						/>
-						<span className="hero-line-right h-px bg-foreground" />
-					</h2>
-
-					<div className="flex flex-col place-items-center text-left w-full max-w-3xl mx-auto mb-3">
-						<a
-							ref={menuItem1Ref}
-							href="/mission"
-							className="hero-menu-1 menu-link font-display text-xl sm:text-3xl font-bold text-foreground hover:text-loud-foreground focus:text-loud-foreground block hover:fx-glow focus:fx-glow focus:outline-none uppercase"
-						>
-							THE NEXT GENERATION OF ORACLES
-						</a>
-						<a
-							href="/team"
-							className="hero-menu-2 menu-link font-display text-xl sm:text-3xl font-bold text-foreground hover:text-loud-foreground focus:text-loud-foreground block hover:fx-glow focus:fx-glow focus:outline-none uppercase"
-						>
-							THE MINDS BEHIND THE REBOOT
-						</a>
+		<ForkExperience>
+			<div className="h-screen min-h-fit w-full relative">
+				<div className="grid grid-rows-[auto_auto_auto] min-h-full z-10 text-center content-between">
+					<div className="hero-header-row">
+						<PageHeader />
 					</div>
 
-					{/* Fork CTA */}
-					<div className="hero-fork-cta">
-						<div className="animate-[bob_2s_ease-in-out_infinite]">
-							<BorderBeam duration={2.5}>
-								<a
-									href="/faq"
-									className="font-display bg-foreground/5 tracking-wide flex items-center px-4 py-2 sm:text-xl font-semibold text-loud-foreground uppercase shadow-[0_0_10px_oklch(from_var(--color-foreground)_l_c_h/_0.4)] hover:fx-glow-sm focus:fx-glow-sm focus:outline-none whitespace-nowrap"
-								>
-									<SirenIcon className="w-6 h-6 border-muted-foreground/80 rounded-full p-1 mr-3" />
-									THE FORK IS HERE! OWN REP? ACT NOW.
-								</a>
-							</BorderBeam>
+					{/* Middle Section */}
+					<div className="flex flex-col items-center place-items-center py-8 gap-y-4">
+						<span className="hero-logo">
+							<AugurLogo className="text-9xl" />
+						</span>
+						<p className="hero-prediction-market font-light font-display border border-foreground/20 px-3 py-1 mx-4 sm:text-xl tracking-widest leading-none uppercase">
+							THE FRONTIER OF PREDICTION MARKETS
+						</p>
+
+						<h2 className="grid grid-cols-[minmax(0.25rem,1rem)_1fr_minmax(0.25rem,1rem)] items-center gap-x-4">
+							<span className="hero-line-left h-px bg-foreground" />
+							<AsciiText
+								className="hero-ascii text-[clamp(0.325rem,1vw,0.625rem)] leading-[1.1]"
+								content={ASCII_ART}
+							/>
+							<span className="hero-line-right h-px bg-foreground" />
+						</h2>
+
+						<div className="flex flex-col place-items-center text-left w-full max-w-3xl mx-auto mb-3">
+							<a
+								ref={menuItem1Ref}
+								href="/mission"
+								className="hero-menu-1 menu-link font-display text-xl sm:text-3xl font-bold text-foreground hover:text-loud-foreground focus:text-loud-foreground block hover:fx-glow focus:fx-glow focus:outline-none uppercase"
+							>
+								THE NEXT GENERATION OF ORACLES
+							</a>
+							<a
+								href="/team"
+								className="hero-menu-2 menu-link font-display text-xl sm:text-3xl font-bold text-foreground hover:text-loud-foreground focus:text-loud-foreground block hover:fx-glow focus:fx-glow focus:outline-none uppercase"
+							>
+								THE MINDS BEHIND THE REBOOT
+							</a>
 						</div>
+
+						<ForkResolutionMessage />
+
+						{/* Fork CTA */}
+						<ForkAction />
+					</div>
+
+					{/* Bottom Section: Fork Monitor */}
+					<div className="hero-fork-meter py-6">
+						<ForkDisplay animated={true} />
 					</div>
 				</div>
 
-				{/* Bottom Section: Fork Monitor */}
-				<div className="hero-fork-meter py-6">
-					<ForkMonitor animated={true} />
-				</div>
+				<ScrollIndicator delay={3200} />
 			</div>
-
-			<ScrollIndicator delay={3200} />
-		</div>
+		</ForkExperience>
 	);
 };
 

--- a/src/features/home/typewriter-sequence.tsx
+++ b/src/features/home/typewriter-sequence.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Typewriter from "./typewriter";
 
 interface Segment {
@@ -11,6 +11,7 @@ interface TypewriterSequenceProps {
 	defaultTypingSpeed?: number;
 	delayBetweenSentences?: number;
 	holdDuration?: number;
+	loop?: boolean;
 	onSequenceComplete?: () => void;
 }
 
@@ -19,10 +20,17 @@ const TypewriterSequence: React.FC<TypewriterSequenceProps> = ({
 	defaultTypingSpeed = 60,
 	delayBetweenSentences = 300,
 	holdDuration = 2500,
+	loop = false,
 	onSequenceComplete,
 }) => {
 	const [currentSentenceIndex, setCurrentSentenceIndex] = useState(0);
 	const [showTypewriter, setShowTypewriter] = useState(true);
+	const transitionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
+	const nextSentenceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+		null,
+	);
 
 	const getSegmentsForSentence = (sentence: string): Segment[] => {
 		const parts = sentence.split(/(\.\.\.)/);
@@ -40,15 +48,33 @@ const TypewriterSequence: React.FC<TypewriterSequenceProps> = ({
 	};
 
 	const handleComplete = () => {
+		if (transitionTimeoutRef.current !== null) return;
+
 		// Keep the current sentence visible for holdDuration
-		setTimeout(() => {
+		transitionTimeoutRef.current = setTimeout(() => {
+			transitionTimeoutRef.current = null;
 			setShowTypewriter(false); // Hide current Typewriter
-			setTimeout(() => {
-				setCurrentSentenceIndex((prevIndex) => prevIndex + 1);
+			nextSentenceTimeoutRef.current = setTimeout(() => {
+				nextSentenceTimeoutRef.current = null;
+				setCurrentSentenceIndex((prevIndex) => {
+					const nextIndex = prevIndex + 1;
+					return loop && nextIndex >= sentences.length ? 0 : nextIndex;
+				});
 				setShowTypewriter(true); // Show next Typewriter
 			}, delayBetweenSentences);
 		}, holdDuration);
 	};
+
+	useEffect(() => {
+		return () => {
+			if (transitionTimeoutRef.current !== null) {
+				clearTimeout(transitionTimeoutRef.current);
+			}
+			if (nextSentenceTimeoutRef.current !== null) {
+				clearTimeout(nextSentenceTimeoutRef.current);
+			}
+		};
+	}, []);
 
 	useEffect(() => {
 		if (currentSentenceIndex >= sentences.length) {

--- a/src/features/learn/navigation.tsx
+++ b/src/features/learn/navigation.tsx
@@ -114,7 +114,7 @@ export default function LearnNavigation({
 										<span>{topic.title}</span>
 										{topic.critical && (
 											<span className="ml-auto text-[0.65rem] opacity-80">
-												{"// ACT NOW"}
+												{"ACT NOW"}
 											</span>
 										)}
 									</a>

--- a/src/layouts/LearnLayout.astro
+++ b/src/layouts/LearnLayout.astro
@@ -5,6 +5,7 @@ import PageHeader from "../components/shell/page-header.tsx";
 import PageTitle from "../components/shell/page-title.astro";
 import LearnNavigation from "../features/learn/navigation.tsx";
 import Layout from "../layouts/Layout.astro";
+import { getForkLifecycleAtBuild, isMigrationOpen } from "../lib/fork-data";
 
 interface Props {
 	title: string;
@@ -12,6 +13,7 @@ interface Props {
 }
 
 const { title, description } = Astro.props;
+const migrationOpen = isMigrationOpen(getForkLifecycleAtBuild().state);
 
 // Topic navigation data
 const topics = [
@@ -19,7 +21,7 @@ const topics = [
 		title: "MIGRATION GUIDE",
 		slug: "fork/migration",
 		path: "/learn/fork/migration/",
-		critical: true,
+		critical: migrationOpen,
 	},
 	{ title: "WHAT IS A FORK?", slug: "fork/index", path: "/learn/fork/" },
 	{

--- a/src/layouts/MigrationGuideLayout.astro
+++ b/src/layouts/MigrationGuideLayout.astro
@@ -5,6 +5,7 @@ import LearnNavigation from "../features/learn/navigation.tsx";
 import Layout from "../layouts/Layout.astro";
 import {
 	getForkLifecycleAtBuild,
+	isMigrationClosed,
 	isMigrationOpen,
 	isVerifiedForkResolution,
 } from "../lib/fork-data";
@@ -18,6 +19,7 @@ interface Props {
 const { title, description, deadline = "THE RECORDED DEADLINE" } = Astro.props;
 const forkLifecycle = getForkLifecycleAtBuild();
 const migrationOpen = isMigrationOpen(forkLifecycle.state);
+const migrationClosed = isMigrationClosed(forkLifecycle.state);
 const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
 const recordedDeadline = forkLifecycle.record?.migrationDeadline
 	? new Date(forkLifecycle.record.migrationDeadline * 1000)
@@ -65,13 +67,13 @@ const currentPath = Astro.url.pathname;
 				<header class:list={["relative px-6 py-8 mb-8", migrationOpen ? "border border-red-500/60 bg-red-500/4" : "border border-primary/40 bg-primary/4"]}>
 					<div class:list={["font-display uppercase tracking-wider text-sm mb-3 flex items-center gap-2", migrationOpen ? "text-red-500" : "text-primary"]}>
 						<span class:list={["inline-block w-2 h-2", migrationOpen ? "bg-red-500" : "bg-primary"]} aria-hidden="true"></span>
-						<span>{migrationOpen ? "CRITICAL · MIGRATION IMMINENT" : resolutionVerified ? "FORK RECORD · MIGRATION CLOSED" : "FORK STATE · VERIFICATION PENDING"}</span>
+						<span>{migrationOpen ? "CRITICAL · MIGRATION IMMINENT" : migrationClosed ? resolutionVerified ? "FORK RECORD · MIGRATION CLOSED" : "FORK STATE · VERIFICATION PENDING" : "MIGRATION GUIDE"}</span>
 					</div>
 					<h1 class="font-display uppercase leading-[0.95] text-3xl sm:text-3xl">
-						<span class="block text-loud-foreground">{migrationOpen ? "You will lose all of your REP" : resolutionVerified ? "The migration window is closed" : "Resolution is pending verification"}</span>
+						<span class="block text-loud-foreground">{migrationOpen ? "You will lose all of your REP" : migrationClosed ? resolutionVerified ? "The migration window is closed" : "Resolution is pending verification" : "Historical migration procedure"}</span>
 						<span class="block text-foreground text-2xl sm:text-2xl mt-2">
-							{migrationOpen ? "if you do not migrate before" : resolutionVerified ? "Review the verified resolution recorded after" : "Review the recorded fork state after"}
-							<span class:list={["fx-glow-sm-red-500", migrationOpen ? "text-red-500" : "text-primary"]}>{recordedDeadline}</span>
+							{migrationOpen ? "if you do not migrate before" : migrationClosed ? resolutionVerified ? "Review the verified resolution recorded after" : "Review the recorded fork state after" : "Documentation of the Moon Fork migration"}
+							{(migrationOpen || migrationClosed) && <span class:list={["fx-glow-sm-red-500", migrationOpen ? "text-red-500" : "text-primary"]}>{recordedDeadline}</span>}
 						</span>
 					</h1>
 				</header>

--- a/src/layouts/MigrationGuideLayout.astro
+++ b/src/layouts/MigrationGuideLayout.astro
@@ -3,6 +3,11 @@ import Footer from "../components/shell/footer.astro";
 import PageHeader from "../components/shell/page-header.tsx";
 import LearnNavigation from "../features/learn/navigation.tsx";
 import Layout from "../layouts/Layout.astro";
+import {
+	getForkLifecycleAtBuild,
+	isMigrationOpen,
+	isVerifiedForkResolution,
+} from "../lib/fork-data";
 
 interface Props {
 	title: string;
@@ -10,14 +15,26 @@ interface Props {
 	deadline?: string;
 }
 
-const { title, description, deadline = "AUGUST 1, 2026" } = Astro.props;
+const { title, description, deadline = "THE RECORDED DEADLINE" } = Astro.props;
+const forkLifecycle = getForkLifecycleAtBuild();
+const migrationOpen = isMigrationOpen(forkLifecycle.state);
+const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
+const recordedDeadline = forkLifecycle.record?.migrationDeadline
+	? new Date(forkLifecycle.record.migrationDeadline * 1000)
+			.toLocaleDateString("en-US", {
+				month: "long",
+				day: "numeric",
+				year: "numeric",
+			})
+			.toUpperCase()
+	: deadline;
 
 const topics = [
 	{
 		title: "MIGRATION GUIDE",
 		slug: "fork/migration",
 		path: "/learn/fork/migration/",
-		critical: true,
+		critical: migrationOpen,
 	},
 	{ title: "WHAT IS A FORK?", slug: "fork/index", path: "/learn/fork/" },
 	{
@@ -45,17 +62,16 @@ const currentPath = Astro.url.pathname;
 
 		<main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">
 			<div class="max-w-3xl mx-auto">
-				{/* Alert hero — dramatic, critical-coded, glow-pulsed */}
-				<header class="relative border border-red-500/60 bg-red-500/4 px-6 py-8 mb-8">
-					<div class="font-display uppercase tracking-wider text-sm text-red-500 mb-3 flex items-center gap-2">
-						<span class="inline-block w-2 h-2 bg-red-500" aria-hidden="true"></span>
-						<span>CRITICAL · MIGRATION IMMINENT</span>
+				<header class:list={["relative px-6 py-8 mb-8", migrationOpen ? "border border-red-500/60 bg-red-500/4" : "border border-primary/40 bg-primary/4"]}>
+					<div class:list={["font-display uppercase tracking-wider text-sm mb-3 flex items-center gap-2", migrationOpen ? "text-red-500" : "text-primary"]}>
+						<span class:list={["inline-block w-2 h-2", migrationOpen ? "bg-red-500" : "bg-primary"]} aria-hidden="true"></span>
+						<span>{migrationOpen ? "CRITICAL · MIGRATION IMMINENT" : resolutionVerified ? "FORK RECORD · MIGRATION CLOSED" : "FORK STATE · VERIFICATION PENDING"}</span>
 					</div>
 					<h1 class="font-display uppercase leading-[0.95] text-3xl sm:text-3xl">
-						<span class="block text-loud-foreground">You will lose all of your REP</span>
+						<span class="block text-loud-foreground">{migrationOpen ? "You will lose all of your REP" : resolutionVerified ? "The migration window is closed" : "Resolution is pending verification"}</span>
 						<span class="block text-foreground text-2xl sm:text-2xl mt-2">
-							if you do not migrate before
-							<span class="text-red-500 fx-glow-sm-red-500">{deadline}</span>
+							{migrationOpen ? "if you do not migrate before" : resolutionVerified ? "Review the verified resolution recorded after" : "Review the recorded fork state after"}
+							<span class:list={["fx-glow-sm-red-500", migrationOpen ? "text-red-500" : "text-primary"]}>{recordedDeadline}</span>
 						</span>
 					</h1>
 				</header>

--- a/src/lib/fork-data.ts
+++ b/src/lib/fork-data.ts
@@ -33,6 +33,10 @@ export const isMigrationOpen = (
 	state: ReturnType<typeof getForkLifecycleAtBuild>["state"],
 ) => state === "migration-open" || state === "migration-open-resolved";
 
+export const isMigrationClosed = (
+	state: ReturnType<typeof getForkLifecycleAtBuild>["state"],
+) => state === "migration-closed-resolved" || state === "migration-closed-unverified";
+
 export const isVerifiedForkResolution = (
 	state: ReturnType<typeof getForkLifecycleAtBuild>["state"],
 ) => state === "migration-closed-resolved";

--- a/src/lib/fork-data.ts
+++ b/src/lib/fork-data.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { deriveForkLifecycle } from "@/features/fork-monitor/derive-fork-lifecycle";
+import type { ForkRiskData } from "@/features/fork-monitor/types";
+import { validateForkRiskData } from "@/features/fork-monitor/validate-fork-data";
+
+const forkDataPath = path.resolve(process.cwd(), "public/data/fork-risk.json");
+
+export const getForkLifecycleAtBuild = () => {
+	if (!existsSync(forkDataPath)) {
+		return deriveForkLifecycle({
+			error: "Fork JSON data is not available during the site build.",
+		} as ForkRiskData);
+	}
+
+	try {
+		const data = JSON.parse(readFileSync(forkDataPath, "utf8")) as ForkRiskData;
+		const validation = validateForkRiskData(data);
+		if (!validation.valid) {
+			return deriveForkLifecycle({
+				error: `Fork JSON data failed validation: ${validation.errors.join("; ")}`,
+			} as ForkRiskData);
+		}
+		return deriveForkLifecycle(data);
+	} catch {
+		return deriveForkLifecycle({
+			error: "Fork JSON data could not be read during the site build.",
+		} as ForkRiskData);
+	}
+};
+
+export const isMigrationOpen = (
+	state: ReturnType<typeof getForkLifecycleAtBuild>["state"],
+) => state === "migration-open" || state === "migration-open-resolved";
+
+export const isVerifiedForkResolution = (
+	state: ReturnType<typeof getForkLifecycleAtBuild>["state"],
+) => state === "migration-closed-resolved";

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,11 +1,20 @@
 ---
-import FaqItem from "../features/faq/item.astro";
-import MigrationCta from "../features/learn/migration-cta.tsx";
+import SectionHeading from "../components/content/section-heading.astro";
 import Footer from "../components/shell/footer.astro";
 import PageHeader from "../components/shell/page-header.tsx";
 import PageTitle from "../components/shell/page-title.astro";
-import SectionHeading from "../components/content/section-heading.astro";
+import FaqItem from "../features/faq/item.astro";
+import MigrationCta from "../features/learn/migration-cta.tsx";
 import Layout from "../layouts/Layout.astro";
+import {
+  getForkLifecycleAtBuild,
+  isMigrationOpen,
+  isVerifiedForkResolution,
+} from "../lib/fork-data";
+
+const forkLifecycle = getForkLifecycleAtBuild();
+const migrationOpen = isMigrationOpen(forkLifecycle.state);
+const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
 ---
 
 <Layout
@@ -36,26 +45,42 @@ import Layout from "../layouts/Layout.astro";
         <!-- IMAGE SLOT: Task 5 will insert the hero image here -->
 
         <!-- Intro -->
-        <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
-          Augur is going through its first algorithmic fork. If you own REP, you must act —
-          <span class="text-loud-foreground">failing to migrate your tokens within the window
-          will likely render them worthless.</span>
-          This page answers the most important questions.
-        </p>
+        {migrationOpen ? (
+          <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
+            Augur is going through its first algorithmic fork. If you own REP, you must act —
+            <span class="text-loud-foreground"> failing to migrate your tokens within the window
+            will likely render them worthless.</span>
+            This page answers the most important questions.
+          </p>
+        ) : (
+          <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
+            {resolutionVerified
+              ? "Augur's first algorithmic fork is now recorded. This page explains what happened, how migration worked, and where to verify the resulting universe."
+              : "Augur's first algorithmic fork has reached the end of its migration window. This page explains what happened while the final resolution remains pending verification."}
+          </p>
+        )}
 
         <!-- Migration guide CTA -->
-        <MigrationCta
-          className="mb-12"
-          eyebrow="CRITICAL · MIGRATION IMMINENT"
-          title="Your REP is worthless if you don't migrate"
-          description="The full procedure — wallet, token contracts, signing order — before Aug 1, 2026."
-        />
+        {migrationOpen ? (
+          <MigrationCta
+            className="mb-12"
+            eyebrow="CRITICAL · MIGRATION IMMINENT"
+            title="Your REP is worthless if you don't migrate"
+            description="The full procedure — wallet, token contracts, signing order — before the migration deadline."
+          />
+        ) : (
+          <div class="mb-12 border border-primary/40 bg-primary/[0.04] px-6 py-5">
+            <div class="font-display uppercase tracking-wider text-[0.7rem] text-primary mb-2">{resolutionVerified ? "FORK RECORD · MIGRATION CLOSED" : "FORK STATE · VERIFICATION PENDING"}</div>
+            <div class="text-loud-foreground font-display uppercase text-xl sm:text-2xl leading-tight">{resolutionVerified ? "Review the recorded resolution →" : "Resolution pending verification"}</div>
+            <div class="text-muted-foreground text-sm mt-1">{resolutionVerified ? "The migration window has closed. Verify the recorded universe from the landing page and on Etherscan." : "The migration window has closed. The landing page is withholding a canonical-universe claim until the final state is verified."}</div>
+          </div>
+        )}
 
         <!-- WHAT IS HAPPENING -->
         <SectionHeading text="What is happening?" />
         <div class="faq-group mb-12">
           <FaqItem question="I OWN REPV2. WHAT IS HAPPENING?">
-              <p>Micah Zoltu, an Augur community member, raised funds to trigger a fork over whether the Artemis II mission successfully lifted off (it did). The fork is now live: Augur has split into universes, one for each outcome, and REP holders must migrate their REP to the universe they believe is correct before August 1, 2026.</p>
+              <p>Micah Zoltu, an Augur community member, raised funds to trigger a fork over whether the Artemis II mission successfully lifted off (it did). The fork split Augur into universes, one for each outcome. {migrationOpen ? "REP holders must migrate their REP before the migration deadline." : resolutionVerified ? "The migration window has closed; the landing page records the verified outcome." : "The migration window has closed; the landing page is waiting for resolution verification."}</p>
               <p><strong>Learn more:</strong></p>
               <ul>
                 <li><a href="/blog/the-augur-fork-is-here/" target="_blank">The Augur Fork is Here</a></li>
@@ -77,10 +102,10 @@ import Layout from "../layouts/Layout.astro";
           <FaqItem question="WHEN DOES THE FORK START AND END?">
               <p><strong>Start:</strong> April 8, 2026</p>
               <p><strong>Escalation Game (Phase 1):</strong> April - early June. Complete.</p>
-              <p><strong>Migration Window (Phase 2):</strong> early June - early August. Open now.</p>
+              <p><strong>Migration Window (Phase 2):</strong> early June - early August. {migrationOpen ? "Open now." : resolutionVerified ? "Closed; see the Fork Record for the recorded resolution." : "Closed; see the landing page for the resolution status."}</p>
             </FaqItem>
           <FaqItem question="WHEN DO I NEED TO TAKE ACTION?">
-              <p>If you hold REP, you need to migrate before August 1, 2026. Early migration has already ended, so the remaining action is to complete the migration before the deadline.</p>
+              <p>{migrationOpen ? "If you hold REP, you need to migrate before the deadline. Early migration has already ended, so the remaining action is to complete the migration before the window closes." : resolutionVerified ? "The migration deadline has passed. The landing page records the verified outcome and the migration guide remains available as a historical reference." : "The migration deadline has passed. The landing page is withholding a final outcome until it can be verified; the migration guide remains available as a historical reference."}</p>
             </FaqItem>
         </div>
 
@@ -92,17 +117,16 @@ import Layout from "../layouts/Layout.astro";
               <p>Phase 1 is complete: enough REP was staked to reach the fork threshold.</p>
             </FaqItem>
           <FaqItem question="WHAT HAPPENS DURING THE MIGRATION WINDOW (PHASE 2)?">
-              <p>The fork occurs, splitting Augur into multiple universes, one for each outcome. REP holders must migrate their tokens 1:1 to the universe they believe is correct, receiving the new token that reflects where they believe future usage and value will remain. The true universe retains value, while the others become worthless — this is to make attacks economically costly.</p>
+              <p>The fork split Augur into multiple universes, one for each outcome. REP holders could migrate their tokens 1:1 to the universe they believed was correct, receiving the new token for that universe. The recorded outcome is shown on the landing page.</p>
             </FaqItem>
           <FaqItem question="WHAT HAPPENS IF I DON'T MIGRATE?">
-              <p>Your REP will remain in an old version that no one uses. It will likely have no value.</p>
+              <p>{migrationOpen ? "Your REP will remain in the parent universe if you do not migrate before the deadline, and it will likely have no value." : resolutionVerified ? "REP left in the parent universe was not part of the migration path; consult the recorded Fork Record for the resulting universe." : "The migration window is closed; consult the landing page for the verified resolution once it is available."}</p>
             </FaqItem>
           <FaqItem question="WHAT HAPPENS IF I MIGRATE TO THE WRONG UNIVERSE?">
               <p>Your REP will likely become worthless, since that universe will not be used going forward.</p>
             </FaqItem>
           <FaqItem question="HOW DO I MIGRATE?">
-              <p>You will use the official tool at <a href="https://6.augurfork.eth.limo/#/migration" target="_blank">6.augurfork.eth.limo/#/migration</a>.</p>
-              <p><strong><a href="/learn/fork/migration/">→ Read the full step-by-step migration guide</a></strong> for wallet setup, token addresses, and every step in order.</p>
+              {migrationOpen ? <><p>You will use the official tool at <a href="https://6.augurfork.eth.limo/#/migration" target="_blank">6.augurfork.eth.limo/#/migration</a>.</p><p><strong><a href="/learn/fork/migration/">→ Read the full step-by-step migration guide</a></strong> for wallet setup, token addresses, and every step in order.</p></> : <p>The migration window is closed. The <a href="/learn/fork/migration/">migration guide</a> remains available as historical reference; review the landing page for the current Fork Record or verification status.</p>}
             </FaqItem>
         </div>
 
@@ -129,7 +153,7 @@ import Layout from "../layouts/Layout.astro";
         <SectionHeading text="REPv1 Holders" />
         <div class="faq-group mb-12">
           <FaqItem question="I OWN REPV1. WHAT SHOULD I DO?">
-              <p>Convert it to REPv2 first, then complete the migration like any other REP holder. The <a href="/learn/fork/migration/">migration guide</a> walks you through both steps with the official tool at <a href="https://6.augurfork.eth.limo" target="_blank">6.augurfork.eth.limo</a>.</p>
+              <p>{migrationOpen ? <>Convert it to REPv2 first, then complete the migration like any other REP holder. The <a href="/learn/fork/migration/">migration guide</a> walks you through both steps with the official tool at <a href="https://6.augurfork.eth.limo" target="_blank">6.augurfork.eth.limo</a>.</> : <>The migration window is closed. The <a href="/learn/fork/migration/">migration guide</a> preserves the historical REPv1-to-REPv2 and migration steps.</>}</p>
             </FaqItem>
           <FaqItem question="CAN I SKIP REPV2 AND GO DIRECTLY TO THE NEW TOKEN?">
               <p>No. You must go through REPv2 first.</p>
@@ -144,7 +168,7 @@ import Layout from "../layouts/Layout.astro";
               <p><strong><a href="https://support.kraken.com/articles/augur-migration" target="_blank">→ Read Kraken's full migration notice</a></strong></p>
             </FaqItem>
           <FaqItem question="MY REP IS ON AN EXCHANGE (GATE, UPBIT). WHAT SHOULD I DO?">
-              <p><strong>Best option:</strong> withdraw to your own wallet and migrate yourself. Exchange support status changes frequently — verify the latest at <a href="https://v3.augur.net/#exchange-support" target="_blank">v3.augur.net</a> before making a decision.</p>
+              <p>{migrationOpen ? <><strong>Best option:</strong> withdraw to your own wallet and migrate yourself. Exchange support status changes frequently — verify the latest at <a href="https://v3.augur.net/#exchange-support" target="_blank">v3.augur.net</a> before making a decision.</> : <>The migration window is closed. This FAQ preserves the historical exchange-support context; check the landing page for the current Fork Record.</>}</p>
             </FaqItem>
           <FaqItem question="WHAT HAPPENS IF I LEAVE MY REP ON AN EXCHANGE?">
               <p>If the exchange does not support migration, you may end up holding a worthless version of REP.</p>
@@ -158,10 +182,10 @@ import Layout from "../layouts/Layout.astro";
               <p>No. Once you migrate, it cannot be undone.</p>
             </FaqItem>
           <FaqItem question="IS THERE A DEADLINE?">
-              <p>Yes. You have until August 1, 2026 to migrate. REP that is not migrated before the deadline will remain in the parent universe and is expected to become worthless.</p>
+              <p>{migrationOpen ? "Yes. You have until the migration deadline to migrate. REP that is not migrated before the deadline will remain in the parent universe and is expected to become worthless." : resolutionVerified ? "The migration window is closed. The landing page's Fork Record preserves the verified resolution and links to the relevant on-chain addresses." : "The migration window is closed. The landing page is waiting for resolution verification before making a canonical-universe claim."}</p>
             </FaqItem>
           <FaqItem question="WHERE CAN I TRACK THE FORK AND MIGRATION STATUS?">
-              <p><a href="https://v3.augur.net/" target="_blank">ForkWatch</a> is the official support page for the migration window. It shows live fork status, the deadline, migration progress, the exchange-support list, and a REP checker that shows whether an address holds REPv1 or REPv2.</p>
+              <p><a href="https://v3.augur.net/" target="_blank">ForkWatch</a> was the official support page for the migration window. It showed fork status, the deadline, migration progress, the exchange-support list, and a REP checker that showed whether an address held REPv1 or REPv2.</p>
             </FaqItem>
         </div>
 

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -17,6 +17,20 @@ const forkLifecycle = getForkLifecycleAtBuild();
 const migrationOpen = isMigrationOpen(forkLifecycle.state);
 const migrationClosed = isMigrationClosed(forkLifecycle.state);
 const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
+const faqIntro = (() => {
+	switch (forkLifecycle.state) {
+		case "migration-closed-resolved":
+			return "Augur's first algorithmic fork is now recorded. This page explains what happened, how migration worked, and where to verify the resulting universe.";
+		case "migration-closed-unverified":
+			return "Augur's first algorithmic fork has reached the end of its migration window. This page explains what happened while the final resolution remains pending verification.";
+		case "data-unavailable":
+			return "Current fork status is temporarily unavailable. This page remains available as an educational reference.";
+		case "monitoring":
+			return "There is no active migration window at this time. This page explains Augur's fork and migration process.";
+		default:
+			return "This page explains Augur's fork and migration process.";
+	}
+})();
 ---
 
 <Layout
@@ -56,9 +70,7 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
           </p>
         ) : (
           <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
-            {resolutionVerified
-              ? "Augur's first algorithmic fork is now recorded. This page explains what happened, how migration worked, and where to verify the resulting universe."
-              : "Augur's first algorithmic fork has reached the end of its migration window. This page explains what happened while the final resolution remains pending verification."}
+            {faqIntro}
           </p>
         )}
 

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -8,12 +8,14 @@ import MigrationCta from "../features/learn/migration-cta.tsx";
 import Layout from "../layouts/Layout.astro";
 import {
   getForkLifecycleAtBuild,
+  isMigrationClosed,
   isMigrationOpen,
   isVerifiedForkResolution,
 } from "../lib/fork-data";
 
 const forkLifecycle = getForkLifecycleAtBuild();
 const migrationOpen = isMigrationOpen(forkLifecycle.state);
+const migrationClosed = isMigrationClosed(forkLifecycle.state);
 const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
 ---
 
@@ -60,27 +62,20 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
           </p>
         )}
 
-        <!-- Migration guide CTA -->
-        {migrationOpen ? (
+        {migrationOpen && (
           <MigrationCta
             className="mb-12"
             eyebrow="CRITICAL · MIGRATION IMMINENT"
             title="Your REP is worthless if you don't migrate"
             description="The full procedure — wallet, token contracts, signing order — before the migration deadline."
           />
-        ) : (
-          <div class="mb-12 border border-primary/40 bg-primary/[0.04] px-6 py-5">
-            <div class="font-display uppercase tracking-wider text-[0.7rem] text-primary mb-2">{resolutionVerified ? "FORK RECORD · MIGRATION CLOSED" : "FORK STATE · VERIFICATION PENDING"}</div>
-            <div class="text-loud-foreground font-display uppercase text-xl sm:text-2xl leading-tight">{resolutionVerified ? "Review the recorded resolution →" : "Resolution pending verification"}</div>
-            <div class="text-muted-foreground text-sm mt-1">{resolutionVerified ? "The migration window has closed. Verify the recorded universe from the landing page and on Etherscan." : "The migration window has closed. The landing page is withholding a canonical-universe claim until the final state is verified."}</div>
-          </div>
         )}
 
         <!-- WHAT IS HAPPENING -->
         <SectionHeading text="What is happening?" />
         <div class="faq-group mb-12">
           <FaqItem question="I OWN REPV2. WHAT IS HAPPENING?">
-              <p>Micah Zoltu, an Augur community member, raised funds to trigger a fork over whether the Artemis II mission successfully lifted off (it did). The fork split Augur into universes, one for each outcome. {migrationOpen ? "REP holders must migrate their REP before the migration deadline." : resolutionVerified ? "The migration window has closed; the landing page records the verified outcome." : "The migration window has closed; the landing page is waiting for resolution verification."}</p>
+              <p>Micah Zoltu, an Augur community member, raised funds to trigger a fork over whether the Artemis II mission successfully lifted off (it did). The fork split Augur into universes, one for each outcome. {migrationOpen ? "REP holders must migrate their REP before the migration deadline." : migrationClosed ? resolutionVerified ? "The migration window has closed; the landing page records the verified outcome." : "The migration window has closed; the landing page is waiting for resolution verification." : "The fork is not currently in its migration window."}</p>
               <p><strong>Learn more:</strong></p>
               <ul>
                 <li><a href="/blog/the-augur-fork-is-here/" target="_blank">The Augur Fork is Here</a></li>
@@ -102,10 +97,10 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
           <FaqItem question="WHEN DOES THE FORK START AND END?">
               <p><strong>Start:</strong> April 8, 2026</p>
               <p><strong>Escalation Game (Phase 1):</strong> April - early June. Complete.</p>
-              <p><strong>Migration Window (Phase 2):</strong> early June - early August. {migrationOpen ? "Open now." : resolutionVerified ? "Closed; see the Fork Record for the recorded resolution." : "Closed; see the landing page for the resolution status."}</p>
+              <p><strong>Migration Window (Phase 2):</strong> early June - early August. {migrationOpen ? "Open now." : migrationClosed ? resolutionVerified ? "Closed; see the Fork Record for the recorded resolution." : "Closed; see the landing page for the resolution status." : "Not currently active."}</p>
             </FaqItem>
           <FaqItem question="WHEN DO I NEED TO TAKE ACTION?">
-              <p>{migrationOpen ? "If you hold REP, you need to migrate before the deadline. Early migration has already ended, so the remaining action is to complete the migration before the window closes." : resolutionVerified ? "The migration deadline has passed. The landing page records the verified outcome and the migration guide remains available as a historical reference." : "The migration deadline has passed. The landing page is withholding a final outcome until it can be verified; the migration guide remains available as a historical reference."}</p>
+              <p>{migrationOpen ? "If you hold REP, you need to migrate before the deadline. Early migration has already ended, so the remaining action is to complete the migration before the window closes." : migrationClosed ? resolutionVerified ? "The migration deadline has passed. The landing page records the verified outcome and the migration guide remains available as a historical reference." : "The migration deadline has passed. The landing page is withholding a final outcome until it can be verified; the migration guide remains available as a historical reference." : "There is no active migration deadline. This page explains the fork process and its historical migration procedure."}</p>
             </FaqItem>
         </div>
 
@@ -120,13 +115,13 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
               <p>The fork split Augur into multiple universes, one for each outcome. REP holders could migrate their tokens 1:1 to the universe they believed was correct, receiving the new token for that universe. The recorded outcome is shown on the landing page.</p>
             </FaqItem>
           <FaqItem question="WHAT HAPPENS IF I DON'T MIGRATE?">
-              <p>{migrationOpen ? "Your REP will remain in the parent universe if you do not migrate before the deadline, and it will likely have no value." : resolutionVerified ? "REP left in the parent universe was not part of the migration path; consult the recorded Fork Record for the resulting universe." : "The migration window is closed; consult the landing page for the verified resolution once it is available."}</p>
+              <p>{migrationOpen ? "Your REP will remain in the parent universe if you do not migrate before the deadline, and it will likely have no value." : migrationClosed ? resolutionVerified ? "REP left in the parent universe was not part of the migration path; consult the recorded Fork Record for the resulting universe." : "The migration window is closed; consult the landing page for the verified resolution once it is available." : "The migration window is not currently active."}</p>
             </FaqItem>
           <FaqItem question="WHAT HAPPENS IF I MIGRATE TO THE WRONG UNIVERSE?">
               <p>Your REP will likely become worthless, since that universe will not be used going forward.</p>
             </FaqItem>
           <FaqItem question="HOW DO I MIGRATE?">
-              {migrationOpen ? <><p>You will use the official tool at <a href="https://6.augurfork.eth.limo/#/migration" target="_blank">6.augurfork.eth.limo/#/migration</a>.</p><p><strong><a href="/learn/fork/migration/">→ Read the full step-by-step migration guide</a></strong> for wallet setup, token addresses, and every step in order.</p></> : <p>The migration window is closed. The <a href="/learn/fork/migration/">migration guide</a> remains available as historical reference; review the landing page for the current Fork Record or verification status.</p>}
+              {migrationOpen ? <><p>You will use the official tool at <a href="https://6.augurfork.eth.limo/#/migration" target="_blank">6.augurfork.eth.limo/#/migration</a>.</p><p><strong><a href="/learn/fork/migration/">→ Read the full step-by-step migration guide</a></strong> for wallet setup, token addresses, and every step in order.</p></> : migrationClosed ? <p>The migration window is closed. The <a href="/learn/fork/migration/">migration guide</a> remains available as historical reference; review the landing page for the current Fork Record or verification status.</p> : <p>Migration instructions will be available if a fork enters the migration phase.</p>}
             </FaqItem>
         </div>
 
@@ -153,7 +148,7 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
         <SectionHeading text="REPv1 Holders" />
         <div class="faq-group mb-12">
           <FaqItem question="I OWN REPV1. WHAT SHOULD I DO?">
-              <p>{migrationOpen ? <>Convert it to REPv2 first, then complete the migration like any other REP holder. The <a href="/learn/fork/migration/">migration guide</a> walks you through both steps with the official tool at <a href="https://6.augurfork.eth.limo" target="_blank">6.augurfork.eth.limo</a>.</> : <>The migration window is closed. The <a href="/learn/fork/migration/">migration guide</a> preserves the historical REPv1-to-REPv2 and migration steps.</>}</p>
+              <p>{migrationOpen ? <>Convert it to REPv2 first, then complete the migration like any other REP holder. The <a href="/learn/fork/migration/">migration guide</a> walks you through both steps with the official tool at <a href="https://6.augurfork.eth.limo" target="_blank">6.augurfork.eth.limo</a>.</> : migrationClosed ? <>The migration window is closed. The <a href="/learn/fork/migration/">migration guide</a> preserves the historical REPv1-to-REPv2 and migration steps.</> : <>The migration window is not currently active.</>}</p>
             </FaqItem>
           <FaqItem question="CAN I SKIP REPV2 AND GO DIRECTLY TO THE NEW TOKEN?">
               <p>No. You must go through REPv2 first.</p>
@@ -168,7 +163,7 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
               <p><strong><a href="https://support.kraken.com/articles/augur-migration" target="_blank">→ Read Kraken's full migration notice</a></strong></p>
             </FaqItem>
           <FaqItem question="MY REP IS ON AN EXCHANGE (GATE, UPBIT). WHAT SHOULD I DO?">
-              <p>{migrationOpen ? <><strong>Best option:</strong> withdraw to your own wallet and migrate yourself. Exchange support status changes frequently — verify the latest at <a href="https://v3.augur.net/#exchange-support" target="_blank">v3.augur.net</a> before making a decision.</> : <>The migration window is closed. This FAQ preserves the historical exchange-support context; check the landing page for the current Fork Record.</>}</p>
+              <p>{migrationOpen ? <><strong>Best option:</strong> withdraw to your own wallet and migrate yourself. Exchange support status changes frequently — verify the latest at <a href="https://v3.augur.net/#exchange-support" target="_blank">v3.augur.net</a> before making a decision.</> : migrationClosed ? <>The migration window is closed. This FAQ preserves the historical exchange-support context; check the landing page for the current Fork Record.</> : <>The migration window is not currently active.</>}</p>
             </FaqItem>
           <FaqItem question="WHAT HAPPENS IF I LEAVE MY REP ON AN EXCHANGE?">
               <p>If the exchange does not support migration, you may end up holding a worthless version of REP.</p>
@@ -182,7 +177,7 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
               <p>No. Once you migrate, it cannot be undone.</p>
             </FaqItem>
           <FaqItem question="IS THERE A DEADLINE?">
-              <p>{migrationOpen ? "Yes. You have until the migration deadline to migrate. REP that is not migrated before the deadline will remain in the parent universe and is expected to become worthless." : resolutionVerified ? "The migration window is closed. The landing page's Fork Record preserves the verified resolution and links to the relevant on-chain addresses." : "The migration window is closed. The landing page is waiting for resolution verification before making a canonical-universe claim."}</p>
+              <p>{migrationOpen ? "Yes. You have until the migration deadline to migrate. REP that is not migrated before the deadline will remain in the parent universe and is expected to become worthless." : migrationClosed ? resolutionVerified ? "The migration window is closed. The landing page's Fork Record preserves the verified resolution and links to the relevant on-chain addresses." : "The migration window is closed. The landing page is waiting for resolution verification before making a canonical-universe claim." : "There is no active migration deadline."}</p>
             </FaqItem>
           <FaqItem question="WHERE CAN I TRACK THE FORK AND MIGRATION STATUS?">
               <p><a href="https://v3.augur.net/" target="_blank">ForkWatch</a> was the official support page for the migration window. It showed fork status, the deadline, migration progress, the exchange-support list, and a REP checker that showed whether an address held REPv1 or REPv2.</p>

--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -1,10 +1,19 @@
 ---
-import TimelineSection from "../features/mission/timeline-section.astro";
+import SectionHeading from "../components/content/section-heading.astro";
 import Footer from "../components/shell/footer.astro";
 import PageHeader from "../components/shell/page-header.tsx";
 import PageTitle from "../components/shell/page-title.astro";
-import SectionHeading from "../components/content/section-heading.astro";
+import TimelineSection from "../features/mission/timeline-section.astro";
 import Layout from "../layouts/Layout.astro";
+import {
+  getForkLifecycleAtBuild,
+  isMigrationOpen,
+  isVerifiedForkResolution,
+} from "../lib/fork-data";
+
+const forkLifecycle = getForkLifecycleAtBuild();
+const migrationOpen = isMigrationOpen(forkLifecycle.state);
+const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
 ---
 
 <Layout
@@ -129,9 +138,9 @@ import Layout from "../layouts/Layout.astro";
 
           <TimelineSection title="Migration Window Opens" date="June 2026">
             <h3>Phase 2: Mandatory Migration</h3>
-            <p>In early June, the fork backstop activated and Augur forked into competing universes—one per outcome. The <strong>2-month migration window is now open</strong>; every REP holder must migrate their tokens 1:1 into a chosen universe before it closes in early August.</p>
+            <p>In early June, the fork backstop activated and Augur forked into competing universes—one per outcome. {migrationOpen ? <><strong>The 2-month migration window is now open</strong>; every REP holder must migrate their tokens 1:1 into a chosen universe before it closes.</> : resolutionVerified ? <>The 2-month migration window is now closed; the landing page preserves the verified Fork Record and its on-chain references.</> : <>The 2-month migration window is now closed; the landing page records the fork state while resolution remains pending verification.</>}</p>
             <ul>
-              <li><strong>Deadline—early August:</strong> REP holders are being notified to migrate before the window closes; tokens left behind are stranded in the old universe</li>
+              <li><strong>Deadline—early August:</strong> {migrationOpen ? "REP holders are being notified to migrate before the window closes; tokens left behind are stranded in the old universe" : resolutionVerified ? "The migration window is closed; the landing page preserves the verified Fork Record and its on-chain references" : "The migration window is closed; the landing page records the fork state while resolution remains pending verification"}</li>
               <li><strong>Exchange support:</strong> the Lituus Foundation is coordinating with exchanges to migrate on behalf of users</li>
             </ul>
             <p>This is the first live run of Augur's fork backstop—the security model's final layer, where REP migration determines which universe carries the canonical outcome.</p>
@@ -140,7 +149,7 @@ import Layout from "../layouts/Layout.astro";
           <TimelineSection title="The Fork and Beyond" date="2026" isLast>
             <h3>Execution Begins</h3>
             <p>Full development of <strong>Augur Lituus</strong> begins this year, with continued focus on a unified REP infrastructure across both the B2C and B2B tracks.</p>
-            <p>With the Moon Fork demonstrating Augur's security model under real conditions, future official Augur development—funded by the Foundation—will continue on the fork corresponding with truth.</p>
+            <p>With the Moon Fork demonstrating Augur's security model under real conditions, future official Augur development—funded by the Foundation—will continue on the fork corresponding with truth. {migrationOpen ? "The migration window remains the current action for REP holders." : "The historical record can be revisited if future protocol work changes the implementation."}</p>
           </TimelineSection>
         </div>
       </div>

--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -7,12 +7,14 @@ import TimelineSection from "../features/mission/timeline-section.astro";
 import Layout from "../layouts/Layout.astro";
 import {
   getForkLifecycleAtBuild,
+  isMigrationClosed,
   isMigrationOpen,
   isVerifiedForkResolution,
 } from "../lib/fork-data";
 
 const forkLifecycle = getForkLifecycleAtBuild();
 const migrationOpen = isMigrationOpen(forkLifecycle.state);
+const migrationClosed = isMigrationClosed(forkLifecycle.state);
 const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
 ---
 
@@ -138,9 +140,9 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
 
           <TimelineSection title="Migration Window Opens" date="June 2026">
             <h3>Phase 2: Mandatory Migration</h3>
-            <p>In early June, the fork backstop activated and Augur forked into competing universes—one per outcome. {migrationOpen ? <><strong>The 2-month migration window is now open</strong>; every REP holder must migrate their tokens 1:1 into a chosen universe before it closes.</> : resolutionVerified ? <>The 2-month migration window is now closed; the landing page preserves the verified Fork Record and its on-chain references.</> : <>The 2-month migration window is now closed; the landing page records the fork state while resolution remains pending verification.</>}</p>
+            <p>In early June, the fork backstop activated and Augur forked into competing universes—one per outcome. {migrationOpen ? <><strong>The 2-month migration window is now open</strong>; every REP holder must migrate their tokens 1:1 into a chosen universe before it closes.</> : migrationClosed ? resolutionVerified ? <>The 2-month migration window is now closed; the landing page preserves the verified Fork Record and its on-chain references.</> : <>The 2-month migration window is now closed; the landing page records the fork state while resolution remains pending verification.</> : <>The migration window will open when the fork backstop activates.</>}</p>
             <ul>
-              <li><strong>Deadline—early August:</strong> {migrationOpen ? "REP holders are being notified to migrate before the window closes; tokens left behind are stranded in the old universe" : resolutionVerified ? "The migration window is closed; the landing page preserves the verified Fork Record and its on-chain references" : "The migration window is closed; the landing page records the fork state while resolution remains pending verification"}</li>
+              <li><strong>Deadline—early August:</strong> {migrationOpen ? "REP holders are being notified to migrate before the window closes; tokens left behind are stranded in the old universe" : migrationClosed ? resolutionVerified ? "The migration window is closed; the landing page preserves the verified Fork Record and its on-chain references" : "The migration window is closed; the landing page records the fork state while resolution remains pending verification" : "No migration deadline is currently active"}</li>
               <li><strong>Exchange support:</strong> the Lituus Foundation is coordinating with exchanges to migrate on behalf of users</li>
             </ul>
             <p>This is the first live run of Augur's fork backstop—the security model's final layer, where REP migration determines which universe carries the canonical outcome.</p>
@@ -149,7 +151,7 @@ const resolutionVerified = isVerifiedForkResolution(forkLifecycle.state);
           <TimelineSection title="The Fork and Beyond" date="2026" isLast>
             <h3>Execution Begins</h3>
             <p>Full development of <strong>Augur Lituus</strong> begins this year, with continued focus on a unified REP infrastructure across both the B2C and B2B tracks.</p>
-            <p>With the Moon Fork demonstrating Augur's security model under real conditions, future official Augur development—funded by the Foundation—will continue on the fork corresponding with truth. {migrationOpen ? "The migration window remains the current action for REP holders." : "The historical record can be revisited if future protocol work changes the implementation."}</p>
+            <p>With the Moon Fork demonstrating Augur's security model under real conditions, future official Augur development—funded by the Foundation—will continue on the fork corresponding with truth. {migrationOpen ? "The migration window remains the current action for REP holders." : migrationClosed ? "The historical record can be revisited if future protocol work changes the implementation." : "The fork remains part of the protocol's historical development."}</p>
           </TimelineSection>
         </div>
       </div>


### PR DESCRIPTION
## Summary

This PR introduces the post-fork landing-page experience and the supporting fork JSON lifecycle contract.

### What changed

- Add explicit fork lifecycle states for monitoring, open migration, open migration with a known winner, closed verified resolution, closed pending verification, and unavailable data.
- Keep the original migration CTA while the winner is unknown; use `MIGRATION WINDOW CLOSING, ACT NOW!` only when a winner is known and migration remains open.
- Replace the migration CTA/countdown presentation after closure with a historical Fork Record and resolution dialog.
- Add a shared clock so the CTA and countdown transition consistently at the migration deadline.
- Add development-only F2 demo scenarios for each lifecycle state.
- Extend fork JSON generation with the winner, normalized schema v2 data, outcome details, validation, and post-deadline fork-record preservation.
- Make FAQ, Mission, migration guide, and fork-learning content respond to the migration state.
- Add lifecycle tests and document the landing-page data contract and architecture.

### Deliberately not included

- No GitHub Actions schedule, cache, or deployment-flow changes.
- No final frozen JSON snapshot or freeze command.
- Monitoring continues; cadence changes are a separate follow-up after the post-close observation period.

### Validation

- `npm run typecheck`
- `npm run typecheck:scripts`
- `npm run lint`
- `npm run test:fork-lifecycle`
- `npm run build`
- `git diff --check`