### PR TITLE
Update REP links to current Augur token

### DIFF
--- a/src/components/shell/footer.astro
+++ b/src/components/shell/footer.astro
@@ -50,28 +50,28 @@ import Button from "../ui/button.tsx";
             </li>
           </ul>
         </div>
-        <!-- Column 3: AUGUR -->
+        <!-- Column 3: REPv2_Yes_1 -->
         <div>
-          <h4 class="text-muted-foreground mb-4 font-display">&gt;_ AUGUR</h4>
+          <h4 class="text-muted-foreground mb-4 font-display">&gt;_ REP (REPv2_Yes_1)</h4>
           <ul class="space-y-2">
             <li>
               <Button variant="link" href="https://etherscan.io/token/0xcf6a0a7826fa124b7705d6f3c675ead76f1e540d">
-                AUGUR TOKEN (ETHERSCAN)
+                ETHERSCAN
               </Button>
             </li>
             <li>
               <Button variant="link" href="https://pro.kraken.com/app/trade/augur-usd">
-                AUGUR/USD (KRAKEN)
+                KRAKEN (AUGUR/USD)
               </Button>
             </li>
             <li>
               <Button variant="link" href="https://app.uniswap.org/explore/tokens/ethereum/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D">
-                AUGUR (UNISWAP)
+                UNISWAP
               </Button>
             </li>
             <li>
               <Button variant="link" href="https://www.geckoterminal.com/eth/tokens/0xcf6a0a7826fa124b7705d6f3c675ead76f1e540d">
-                AUGUR (GECKO UI)
+                GECKO UI
               </Button>
             </li>
           </ul>

--- a/src/components/shell/footer.astro
+++ b/src/components/shell/footer.astro
@@ -50,43 +50,28 @@ import Button from "../ui/button.tsx";
             </li>
           </ul>
         </div>
-        <!-- Column 3: REP -->
+        <!-- Column 3: AUGUR -->
         <div>
-          <h4 class="text-muted-foreground mb-4 font-display">&gt;_ REP</h4>
+          <h4 class="text-muted-foreground mb-4 font-display">&gt;_ AUGUR</h4>
           <ul class="space-y-2">
             <li>
-              <Button variant="link" href="https://etherscan.io/token/0x221657776846890989a759ba2973e427dff5c9bb">
-                REPV2 (ETHERSCAN)
+              <Button variant="link" href="https://etherscan.io/token/0xcf6a0a7826fa124b7705d6f3c675ead76f1e540d">
+                AUGUR TOKEN (ETHERSCAN)
               </Button>
             </li>
             <li>
-              <Button variant="link" href="https://etherscan.io/token/0x1985365e9f78359a9B6AD760e32412f4a445E862">
-                REPV1 (ETHERSCAN)
+              <Button variant="link" href="https://pro.kraken.com/app/trade/augur-usd">
+                AUGUR/USD (KRAKEN)
               </Button>
             </li>
             <li>
-              <Button variant="link" href="https://pro.kraken.com/app/trade/rep-usd">
-                REPV1/USD (KRAKEN)
+              <Button variant="link" href="https://app.uniswap.org/explore/tokens/ethereum/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D">
+                AUGUR (UNISWAP)
               </Button>
             </li>
             <li>
-              <Button variant="link" href="https://pro.kraken.com/app/trade/repv2-usd">
-                REPV2/USD (KRAKEN)
-              </Button>
-            </li>
-            <li>
-              <Button variant="link" href="https://pro.kraken.com/app/trade/repv2-eur">
-                REPV2/EUR (KRAKEN)
-              </Button>
-            </li>
-            <li>
-              <Button variant="link" href="https://app.uniswap.org/tokens/ethereum/0x221657776846890989a759ba2973e427dff5c9bb">
-                REPV2 UNISWAP
-              </Button>
-            </li>
-            <li>
-              <Button variant="link" href="https://www.geckoterminal.com/eth/tokens/0x221657776846890989a759ba2973e427dff5c9bb">
-                REPV2 UNISWAP GECKO UI
+              <Button variant="link" href="https://www.geckoterminal.com/eth/tokens/0xcf6a0a7826fa124b7705d6f3c675ead76f1e540d">
+                AUGUR (GECKO UI)
               </Button>
             </li>
           </ul>

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -55,8 +55,10 @@ If your REP is not on Ethereum (exchanges, L2s), send it to your Ethereum addres
 
 Sometimes wallets will not automatically detect your REP. You can manually add tokens by pasting the token address:
 
-- **REPv2** — [`0x221657776846890989a759ba2973e427dff5c9bb`](https://etherscan.io/token/0x221657776846890989a759ba2973e427dff5c9bb)
-- **REPv1** — [`0x1985365e9f78359a9B6AD760e32412f4a445E862`](https://etherscan.io/token/0x1985365e9f78359a9B6AD760e32412f4a445E862)
+- **Legacy REPv2 (pre-fork)** — [`0x221657776846890989a759ba2973e427dff5c9bb`](https://etherscan.io/token/0x221657776846890989a759ba2973e427dff5c9bb)
+- **Legacy REPv1** — [`0x1985365e9f78359a9B6AD760e32412f4a445E862`](https://etherscan.io/token/0x1985365e9f78359a9B6AD760e32412f4a445E862)
+
+These are the legacy input tokens for the migration. The surviving fork token is **REPv2_Yes_1**, listed by Kraken as AUGUR: [`0xcf6a0a7826fa124b7705d6f3c675ead76f1e540d`](https://etherscan.io/token/0xcf6a0a7826fa124b7705d6f3c675ead76f1e540d). Do not use the legacy REPv1 or REPv2 address as the current token after migration.
 
 If you have REP in multiple places, send it all to a single Ethereum address on the original Ethereum. Don't forget REP you might have on Layer 2, Coinbase, or other exchanges. You must own your Ethereum address — an Ethereum address is yours if you have the private key.
 

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -110,7 +110,7 @@ If you are unsure what to pick, research and debate on the [Augur Discord](https
 
 ### 8. Verify the new token
 
-After the migration is complete, verify you hold the new token **REPv2_1** in your wallet.
+After the migration is complete, verify you hold the new token **REPv2_Yes_1** in your wallet.
 
 ### 9. If you only did late migration, you are done
 
@@ -122,7 +122,7 @@ Return to the [migration page](https://6.augurfork.eth.limo/#/migration?market=0
 
 ### 11. Redeem fork disputes
 
-Refresh possible claims, check all boxes, then redeem fork disputes. This will give you **140%** of your early migration REP. You are done when no boxes are left to check and you have additional REPv2_1 in your wallet.
+Refresh possible claims, check all boxes, then redeem fork disputes. This will give you **140%** of your early migration REP. You are done when no boxes are left to check and you have additional REPv2_Yes_1 in your wallet.
 
 <Image src={step06} alt="Fork dispute redemption screen" />
 


### PR DESCRIPTION
## Summary

- Point the footer at the current REPv2_Yes_1/AUGUR token and live trading/liquidity pages.
- Remove dead legacy Kraken links from current navigation.
- Preserve legacy REPv1/REPv2 addresses in the migration guide with explicit labels and a link to the surviving token.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Verified the new Etherscan, Kraken, Uniswap, and GeckoTerminal URLs.

## Notes

- Existing untracked `bun.lock` was not included.