### PR TITLE
feat: generalize Learn content model

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"lint:blog": "node --experimental-strip-types scripts/blog-lint/index.ts",
 		"test:blog-lint": "node --experimental-strip-types --test scripts/blog-lint/*.test.ts",
 		"test:fork-lifecycle": "node --experimental-strip-types --test scripts/fork-lifecycle.test.ts",
+		"test:learn-model": "node --experimental-strip-types --test scripts/learn-model.test.ts",
 		"typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
 		"preview": "astro build && wrangler dev",
 		"astro": "astro",

--- a/scripts/learn-model.test.ts
+++ b/scripts/learn-model.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import {
+	assertLearnEntries,
+	getLearnNavigation,
+	getLearnPageContext,
+	learnTopicRegistry,
+	usesHistoricalPresentation,
+	type LearnEntryLike,
+	type LearnMetadata,
+} from "../src/lib/learn.ts";
+
+const entry = (slug: string, data: LearnMetadata): LearnEntryLike => ({
+	slug,
+	data,
+});
+
+test("orders navigation within each registered topic and omits planned entries", () => {
+	const entries = [
+		entry("fork/what-to-do", {
+			topic: "fork",
+			order: 3,
+			contentType: "guide",
+			label: "WHAT TO DO",
+			historical: false,
+			status: "available",
+			presentation: "standard",
+		}),
+		entry("fork/index", {
+			topic: "fork",
+			order: 1,
+			contentType: "topic",
+			label: "WHAT IS A FORK?",
+			historical: false,
+			status: "available",
+			presentation: "standard",
+		}),
+		entry("fork/future-lesson", {
+			topic: "fork",
+			order: 4,
+			contentType: "lesson",
+			label: "FUTURE LESSON",
+			historical: false,
+			status: "planned",
+			presentation: "standard",
+		}),
+		entry("fork/disputes-and-bonds", {
+			topic: "fork",
+			order: 2,
+			contentType: "lesson",
+			label: "HOW DISPUTES & BONDS WORK",
+			historical: false,
+			status: "available",
+			presentation: "standard",
+		}),
+	];
+
+	assert.deepEqual(
+		getLearnNavigation(entries, "fork").map(({ label, path }) => ({ label, path })),
+		[
+			{ label: "WHAT IS A FORK?", path: "/learn/fork/" },
+			{
+				label: "HOW DISPUTES & BONDS WORK",
+				path: "/learn/fork/disputes-and-bonds/",
+			},
+			{ label: "WHAT TO DO", path: "/learn/fork/what-to-do/" },
+		],
+	);
+});
+
+test("adds a second topic through the registry without layout changes", () => {
+	const registry = {
+		...learnTopicRegistry,
+		oracle: {
+			label: "Oracle",
+			description: "Learn how the oracle works.",
+		},
+	};
+	const entries = [
+		entry("oracle/reference", {
+			topic: "oracle",
+			order: 2,
+			contentType: "reference",
+			label: "ORACLE REFERENCE",
+			historical: false,
+			status: "available",
+			presentation: "reference",
+		}),
+		entry("oracle/index", {
+			topic: "oracle",
+			order: 1,
+			contentType: "topic",
+			label: "ORACLE BASICS",
+			historical: false,
+			status: "available",
+			presentation: "standard",
+		}),
+	];
+
+	assertLearnEntries(entries, registry);
+	const context = getLearnPageContext(entries[0], entries, registry);
+
+	assert.deepEqual(context.topic, {
+		key: "oracle",
+		path: "/learn/oracle/",
+		label: "Oracle",
+		description: "Learn how the oracle works.",
+	});
+	assert.deepEqual(
+		context.navigation.map(({ label, path }) => ({ label, path })),
+		[
+			{ label: "ORACLE BASICS", path: "/learn/oracle/" },
+			{ label: "ORACLE REFERENCE", path: "/learn/oracle/reference/" },
+		],
+	);
+
+	const layout = readFileSync(
+		fileURLToPath(new URL("../src/layouts/LearnLayout.astro", import.meta.url)),
+		"utf8",
+	);
+	assert.doesNotMatch(layout, /fork/u);
+});
+
+test("selects the specialized layout from declarative presentation metadata", () => {
+	assert.equal(usesHistoricalPresentation("historical-record"), true);
+	assert.equal(usesHistoricalPresentation("standard"), false);
+
+	const route = readFileSync(
+		fileURLToPath(new URL("../src/pages/learn/[...slug].astro", import.meta.url)),
+		"utf8",
+	);
+	assert.match(route, /usesHistoricalPresentation\(presentation\)/u);
+	assert.doesNotMatch(route, /entry\.slug.*fork\/migration/u);
+});
+
+test("rejects unknown topics and duplicate order values", () => {
+	const invalidEntries = [
+		entry("unknown/lesson", {
+			topic: "unknown",
+			order: 1,
+			contentType: "lesson",
+			label: "UNKNOWN",
+			historical: false,
+			status: "available",
+			presentation: "standard",
+		}),
+	];
+
+	assert.throws(() => assertLearnEntries(invalidEntries), /Unknown Learn topic/u);
+	assert.throws(
+		() =>
+			assertLearnEntries([
+				entry("oracle/lesson", {
+					topic: "fork",
+					order: 1,
+					contentType: "lesson",
+					label: "MISROUTED",
+					historical: false,
+					status: "available",
+					presentation: "standard",
+				}),
+			]),
+		/routed under topic fork/u,
+	);
+
+	const duplicateEntries = [
+		entry("fork/first", {
+			topic: "fork",
+			order: 1,
+			contentType: "lesson",
+			label: "FIRST",
+			historical: false,
+			status: "available",
+			presentation: "standard",
+		}),
+		entry("fork/second", {
+			topic: "fork",
+			order: 1,
+			contentType: "lesson",
+			label: "SECOND",
+			historical: false,
+			status: "available",
+			presentation: "standard",
+		}),
+	];
+
+	assert.throws(
+		() => assertLearnEntries(duplicateEntries),
+		/duplicate order 1/u,
+	);
+});

--- a/src/components/content/learn-breadcrumbs.astro
+++ b/src/components/content/learn-breadcrumbs.astro
@@ -1,0 +1,18 @@
+---
+import type { LearnTopicContext } from "../../lib/learn";
+
+interface Props {
+	topic: LearnTopicContext;
+	currentLabel: string;
+}
+
+const { topic, currentLabel } = Astro.props;
+---
+
+<nav aria-label="Learn breadcrumbs" class="mb-6 font-display text-xs uppercase tracking-[0.2em] text-muted-foreground">
+	<span>LEARN</span>
+	<span class="mx-2" aria-hidden="true">/</span>
+	<a href={topic.path} class="hover:text-primary transition-colors">{topic.label}</a>
+	<span class="mx-2" aria-hidden="true">/</span>
+	<span aria-current="page" class="text-foreground">{currentLabel}</span>
+</nav>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,10 +1,22 @@
 import { defineCollection, z } from "astro:content";
+import {
+	LEARN_CONTENT_TYPES,
+	LEARN_PRESENTATIONS,
+	LEARN_STATUSES,
+} from "../lib/learn";
 
 const learnCollection = defineCollection({
 	type: "content",
 	schema: z.object({
 		title: z.string(),
 		description: z.string().optional(),
+		topic: z.string().min(1),
+		order: z.number().int().nonnegative(),
+		contentType: z.enum(LEARN_CONTENT_TYPES),
+		label: z.string().min(1),
+		historical: z.boolean(),
+		status: z.enum(LEARN_STATUSES),
+		presentation: z.enum(LEARN_PRESENTATIONS),
 	}),
 });
 

--- a/src/content/learn/fork/disputes-and-bonds.mdx
+++ b/src/content/learn/fork/disputes-and-bonds.mdx
@@ -1,6 +1,13 @@
 ---
 title: "How Disputes & Bonds Work"
 description: "Understand dispute escalation, bond mechanics, and how fork risk is calculated."
+topic: fork
+order: 2
+contentType: lesson
+label: "HOW DISPUTES & BONDS WORK"
+historical: false
+status: available
+presentation: standard
 ---
 
 import ProseCard from '../../../components/content/prose-card.astro'

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -1,6 +1,13 @@
 ---
 title: "What is a Fork?"
 description: "Learn about Augur protocol forks, how they work, and why fork risk matters."
+topic: fork
+order: 1
+contentType: topic
+label: "WHAT IS A FORK?"
+historical: false
+status: available
+presentation: standard
 ---
 
 import ProseCard from '../../../components/content/prose-card.astro'

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -1,6 +1,13 @@
 ---
 title: "Moon Fork Migration Guide"
 description: "Step-by-step historical reference for the Augur Moon Fork REP migration."
+topic: fork
+order: 4
+contentType: historical-record
+label: "MIGRATION GUIDE"
+historical: true
+status: archived
+presentation: historical-record
 ---
 
 import { Image } from 'astro:assets'

--- a/src/content/learn/fork/what-to-do.mdx
+++ b/src/content/learn/fork/what-to-do.mdx
@@ -1,6 +1,13 @@
 ---
 title: "What To Do"
 description: "Action items to take at different fork risk levels."
+topic: fork
+order: 3
+contentType: guide
+label: "WHAT TO DO"
+historical: false
+status: available
+presentation: standard
 ---
 
 import ProseCard from '../../../components/content/prose-card.astro'

--- a/src/features/learn/navigation.tsx
+++ b/src/features/learn/navigation.tsx
@@ -1,31 +1,33 @@
 import { useEffect, useRef, useState } from "react";
 
-interface Topic {
-	title: string;
-	slug: string;
+interface LearnNavigationEntry {
+	label: string;
 	path: string;
-	critical?: boolean;
+	status: "available" | "archived" | "planned";
 }
 
 interface LearnNavigationProps {
 	currentPath: string;
-	currentTitle: string;
-	topics: Topic[];
+	topicLabel: string;
+	entries: LearnNavigationEntry[];
+}
+
+function getNavigationLabel(entry: LearnNavigationEntry): string {
+	return entry.status === "archived" ? `${entry.label} · ARCHIVED` : entry.label;
 }
 
 export default function LearnNavigation({
 	currentPath,
-	topics,
+	topicLabel,
+	entries,
 }: LearnNavigationProps) {
 	const [isExpanded, setIsExpanded] = useState(false);
 	const drawerRef = useRef<HTMLDivElement>(null);
 
-	// Find current topic and next topic
-	const currentIndex = topics.findIndex((t) => t.path === currentPath);
-	const nextTopic =
-		currentIndex < topics.length - 1 ? topics[currentIndex + 1] : null;
+	const currentIndex = entries.findIndex((entry) => entry.path === currentPath);
+	const nextEntry =
+		currentIndex < entries.length - 1 ? entries[currentIndex + 1] : null;
 
-	// Close drawer when clicking outside
 	useEffect(() => {
 		function handleClickOutside(event: MouseEvent) {
 			if (
@@ -51,10 +53,8 @@ export default function LearnNavigation({
 				zIndex: isExpanded ? 50 : 10,
 			}}
 		>
-			{/* Collapsed State */}
 			<div className="max-w-2xl mx-auto px-4 md:px-8 py-3 md:py-6 w-full">
 				<div className="flex items-center justify-between">
-					{/* Left: Jump to Topic */}
 					<button
 						type="button"
 						onClick={() => setIsExpanded(!isExpanded)}
@@ -64,62 +64,50 @@ export default function LearnNavigation({
 								: "text-muted-foreground hover:text-primary"
 						}`}
 					>
-						{isExpanded ? "[ X ] CLOSE" : "JUMP TO TOPIC →"}
+						{isExpanded
+							? "[ X ] CLOSE"
+							: `JUMP TO ${topicLabel.toUpperCase()} →`}
 					</button>
 
-					{/* Right: Up Next */}
-					{nextTopic ? (
+					{nextEntry ? (
 						<a
-							href={nextTopic.path}
+							href={nextEntry.path}
 							className="text-sm font-light tracking-widest text-muted-foreground hover:text-primary transition-colors"
 						>
-							UP NEXT: {nextTopic.title}
+							UP NEXT: {getNavigationLabel(nextEntry)}
 						</a>
 					) : (
 						<span className="text-sm font-light tracking-widest text-muted-foreground">
-							END OF TOPICS
+							END OF {topicLabel.toUpperCase()}
 						</span>
 					)}
 				</div>
 			</div>
 
-			{/* Expanded Drawer */}
 			{isExpanded && (
 				<div className="border-t border-foreground/30 bg-background overflow-hidden animate-in fade-in duration-200 w-full">
 					<div className="max-w-2xl mx-auto px-4 md:px-8 py-4 w-full">
+						<div className="mb-3 text-xs tracking-widest text-muted-foreground">
+							{topicLabel}
+						</div>
 						<div className="space-y-2">
-							{topics.map((topic) => {
-								const isActive = currentPath === topic.path;
+							{entries.map((entry) => {
+								const isActive = currentPath === entry.path;
 								const base =
 									"flex items-center gap-2 text-sm font-light uppercase tracking-widest px-3 py-2 transition-colors";
-								const cls = topic.critical
-									? isActive
-										? "bg-red-500/10 text-red-500 border border-red-500/60"
-										: "text-red-500 hover:bg-red-500/10 border border-red-500/40"
-									: isActive
-										? "bg-foreground/10 text-primary border border-foreground/30"
-										: "text-muted-foreground hover:text-foreground hover:bg-foreground/5";
+								const cls = isActive
+									? "bg-foreground/10 text-primary border border-foreground/30"
+									: "text-muted-foreground hover:text-foreground hover:bg-foreground/5";
 								return (
 									<a
-										key={topic.path}
-										href={topic.path}
+										key={entry.path}
+										href={entry.path}
 										className={`${base} ${cls}`}
 									>
-										{topic.critical && (
-											<span
-												className="inline-block w-1.5 h-1.5 bg-red-500"
-												aria-hidden="true"
-											/>
-										)}
-										<span>{topic.title}</span>
-										{topic.critical && (
-											<span className="ml-auto text-[0.65rem] opacity-80">
-												{"ACT NOW"}
-											</span>
-										)}
+										<span>{getNavigationLabel(entry)}</span>
 									</a>
 								);
-							})}
+								})}
 						</div>
 					</div>
 				</div>

--- a/src/layouts/LearnLayout.astro
+++ b/src/layouts/LearnLayout.astro
@@ -1,68 +1,49 @@
 ---
 import ArticleContent from "../components/content/article-content.astro";
+import LearnBreadcrumbs from "../components/content/learn-breadcrumbs.astro";
 import Footer from "../components/shell/footer.astro";
 import PageHeader from "../components/shell/page-header.tsx";
 import PageTitle from "../components/shell/page-title.astro";
 import LearnNavigation from "../features/learn/navigation.tsx";
 import Layout from "../layouts/Layout.astro";
-import { getForkLifecycleAtBuild, isMigrationOpen } from "../lib/fork-data";
+import type { LearnNavigationItem, LearnTopicContext } from "../lib/learn";
 
 interface Props {
 	title: string;
 	description?: string;
+	topic: LearnTopicContext;
+	navigation: LearnNavigationItem[];
 }
 
-const { title, description } = Astro.props;
-const migrationOpen = isMigrationOpen(getForkLifecycleAtBuild().state);
-
-// Topic navigation data
-const topics = [
-	{
-		title: "MIGRATION GUIDE",
-		slug: "fork/migration",
-		path: "/learn/fork/migration/",
-		critical: migrationOpen,
-	},
-	{ title: "WHAT IS A FORK?", slug: "fork/index", path: "/learn/fork/" },
-	{
-		title: "HOW DISPUTES & BONDS WORK",
-		slug: "fork/disputes-and-bonds",
-		path: "/learn/fork/disputes-and-bonds/",
-	},
-	{
-		title: "WHAT TO DO",
-		slug: "fork/what-to-do",
-		path: "/learn/fork/what-to-do/",
-	},
-];
-
+const { title, description, topic, navigation } = Astro.props;
 const currentPath = Astro.url.pathname;
 ---
 
 <Layout
-	title={`${title} - Augur Fork Mechanics`}
-	description={description || "Learn about Augur protocol forks and fork mechanics"}
+	title={`${title} - ${topic.label}`}
+	description={description ?? topic.description}
 	ogType="article"
 >
 	<div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
-		{/* Top Section: Navigation */}
 		<PageHeader client:load backHref="/" />
 
-		{/* Middle Section: Scrollable Content */}
 		<main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">
 			<div class="max-w-3xl mx-auto">
+				<LearnBreadcrumbs topic={topic} currentLabel={title} />
 				<PageTitle prefix="LEARN" title={title} />
 
-				{/* Main Content */}
 				<ArticleContent>
 					<slot />
 				</ArticleContent>
 			</div>
 		</main>
 
-		{/* Bottom Section: Sticky Navigation + Footer */}
-		<LearnNavigation client:load currentPath={currentPath} currentTitle={title} topics={topics} />
+		<LearnNavigation
+			client:load
+			currentPath={currentPath}
+			topicLabel={topic.label}
+			entries={navigation}
+		/>
 		<Footer />
 	</div>
-
 </Layout>

--- a/src/layouts/MigrationGuideLayout.astro
+++ b/src/layouts/MigrationGuideLayout.astro
@@ -1,4 +1,5 @@
 ---
+import LearnBreadcrumbs from "../components/content/learn-breadcrumbs.astro";
 import Footer from "../components/shell/footer.astro";
 import PageHeader from "../components/shell/page-header.tsx";
 import LearnNavigation from "../features/learn/navigation.tsx";
@@ -9,14 +10,23 @@ import {
 	isMigrationOpen,
 	isVerifiedForkResolution,
 } from "../lib/fork-data";
+import type { LearnNavigationItem, LearnTopicContext } from "../lib/learn";
 
 interface Props {
 	title: string;
 	description?: string;
+	topic: LearnTopicContext;
+	navigation: LearnNavigationItem[];
 	deadline?: string;
 }
 
-const { title, description, deadline = "THE RECORDED DEADLINE" } = Astro.props;
+const {
+	title,
+	description,
+	topic,
+	navigation,
+	deadline = "THE RECORDED DEADLINE",
+} = Astro.props;
 const forkLifecycle = getForkLifecycleAtBuild();
 const migrationOpen = isMigrationOpen(forkLifecycle.state);
 const migrationClosed = isMigrationClosed(forkLifecycle.state);
@@ -31,32 +41,12 @@ const recordedDeadline = forkLifecycle.record?.migrationDeadline
 			.toUpperCase()
 	: deadline;
 
-const topics = [
-	{
-		title: "MIGRATION GUIDE",
-		slug: "fork/migration",
-		path: "/learn/fork/migration/",
-		critical: migrationOpen,
-	},
-	{ title: "WHAT IS A FORK?", slug: "fork/index", path: "/learn/fork/" },
-	{
-		title: "HOW DISPUTES & BONDS WORK",
-		slug: "fork/disputes-and-bonds",
-		path: "/learn/fork/disputes-and-bonds/",
-	},
-	{
-		title: "WHAT TO DO",
-		slug: "fork/what-to-do",
-		path: "/learn/fork/what-to-do/",
-	},
-];
-
 const currentPath = Astro.url.pathname;
 ---
 
 <Layout
-	title={`${title} - Moon Fork Migration`}
-	description={description || "Step-by-step REP migration guide for the Augur Moon Fork."}
+	title={`${title} - ${topic.label}`}
+	description={description ?? topic.description}
 	ogType="article"
 >
 	<div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
@@ -64,28 +54,83 @@ const currentPath = Astro.url.pathname;
 
 		<main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">
 			<div class="max-w-3xl mx-auto">
-				<header class:list={["relative px-6 py-8 mb-8", migrationOpen ? "border border-red-500/60 bg-red-500/4" : "border border-primary/40 bg-primary/4"]}>
-					<div class:list={["font-display uppercase tracking-wider text-sm mb-3 flex items-center gap-2", migrationOpen ? "text-red-500" : "text-primary"]}>
-						<span class:list={["inline-block w-2 h-2", migrationOpen ? "bg-red-500" : "bg-primary"]} aria-hidden="true"></span>
-						<span>{migrationOpen ? "CRITICAL · MIGRATION IMMINENT" : migrationClosed ? resolutionVerified ? "FORK RECORD · MIGRATION CLOSED" : "FORK STATE · VERIFICATION PENDING" : "MIGRATION GUIDE"}</span>
+				<LearnBreadcrumbs topic={topic} currentLabel={title} />
+
+				<header
+					class:list={[
+						"relative px-6 py-8 mb-8",
+						migrationOpen
+							? "border border-red-500/60 bg-red-500/4"
+							: "border border-primary/40 bg-primary/4",
+					]}
+				>
+					<div
+						class:list={[
+							"font-display uppercase tracking-wider text-sm mb-3 flex items-center gap-2",
+							migrationOpen ? "text-red-500" : "text-primary",
+						]}
+					>
+						<span
+							class:list={[
+								"inline-block w-2 h-2",
+								migrationOpen ? "bg-red-500" : "bg-primary",
+							]}
+							aria-hidden="true"
+						></span>
+						<span>
+							{migrationOpen
+								? "CRITICAL · MIGRATION IMMINENT"
+								: migrationClosed
+									? resolutionVerified
+										? "FORK RECORD · MIGRATION CLOSED"
+										: "FORK STATE · VERIFICATION PENDING"
+									: "MIGRATION GUIDE"}
+						</span>
 					</div>
 					<h1 class="font-display uppercase leading-[0.95] text-3xl sm:text-3xl">
-						<span class="block text-loud-foreground">{migrationOpen ? "You will lose all of your REP" : migrationClosed ? resolutionVerified ? "The migration window is closed" : "Resolution is pending verification" : "Historical migration procedure"}</span>
+						<span class="block text-loud-foreground">
+							{migrationOpen
+								? "You will lose all of your REP"
+								: migrationClosed
+									? resolutionVerified
+										? "The migration window is closed"
+										: "Resolution is pending verification"
+									: "Historical migration procedure"}
+						</span>
 						<span class="block text-foreground text-2xl sm:text-2xl mt-2">
-							{migrationOpen ? "if you do not migrate before" : migrationClosed ? resolutionVerified ? "Review the verified resolution recorded after" : "Review the recorded fork state after" : "Documentation of the Moon Fork migration"}
-							{(migrationOpen || migrationClosed) && <span class:list={["fx-glow-sm-red-500", migrationOpen ? "text-red-500" : "text-primary"]}>{recordedDeadline}</span>}
+							{migrationOpen
+								? "if you do not migrate before"
+								: migrationClosed
+									? resolutionVerified
+										? "Review the verified resolution recorded after"
+										: "Review the recorded fork state after"
+									: "Documentation of the Moon Fork migration"}
+							{(migrationOpen || migrationClosed) && (
+								<span
+									class:list={[
+										"fx-glow-sm-red-500",
+										migrationOpen ? "text-red-500" : "text-primary",
+									]}
+								>
+									{recordedDeadline}
+								</span>
+							)}
 						</span>
 					</h1>
 				</header>
 
-				{/* Body: standard prose shell, same as LearnLayout */}
 				<article class="prose prose-invert max-w-none pt-2 px-1 prose-headings:font-display prose-headings:uppercase prose-headings:tracking-wide prose-p:leading-snug prose-li:leading-snug prose-ul:list-[square] prose-li:marker:text-muted-foreground prose-ol:marker:text-muted-foreground prose-blockquote:border-l-muted-foreground prose-blockquote:text-foreground prose-img:border prose-img:border-muted-foreground/30 prose-img:shadow-[0_0_2em_oklch(from_var(--color-primary)_l_c_h_/0.1)]">
 					<slot />
 				</article>
 			</div>
 		</main>
 
-		<LearnNavigation client:load currentPath={currentPath} currentTitle={title} topics={topics} />
+		<LearnNavigation
+			client:load
+			currentPath={currentPath}
+			topicLabel={topic.label}
+			entries={navigation}
+		/>
 		<Footer />
 	</div>
 </Layout>

--- a/src/lib/learn.ts
+++ b/src/lib/learn.ts
@@ -1,0 +1,158 @@
+export const LEARN_CONTENT_TYPES = [
+	"topic",
+	"lesson",
+	"guide",
+	"reference",
+	"case-study",
+	"historical-record",
+] as const;
+
+export const LEARN_STATUSES = ["available", "archived", "planned"] as const;
+
+export const LEARN_PRESENTATIONS = [
+	"standard",
+	"reference",
+	"case-study",
+	"historical-record",
+] as const;
+
+export type LearnContentType = (typeof LEARN_CONTENT_TYPES)[number];
+export type LearnStatus = (typeof LEARN_STATUSES)[number];
+export type LearnPresentation = (typeof LEARN_PRESENTATIONS)[number];
+
+export interface LearnMetadata {
+	topic: string;
+	order: number;
+	contentType: LearnContentType;
+	label: string;
+	historical: boolean;
+	status: LearnStatus;
+	presentation: LearnPresentation;
+}
+
+export interface LearnTopicDefinition {
+	label: string;
+	description: string;
+}
+
+export type LearnTopicRegistry = Record<string, LearnTopicDefinition>;
+
+export const learnTopicRegistry = {
+	fork: {
+		label: "Fork",
+		description: "Learn about Augur protocol forks and fork mechanics.",
+	},
+} as const satisfies LearnTopicRegistry;
+
+export interface LearnTopicContext extends LearnTopicDefinition {
+	key: string;
+	path: string;
+}
+
+export interface LearnEntryLike {
+	slug: string;
+	data: LearnMetadata;
+}
+
+export interface LearnNavigationItem {
+	label: string;
+	path: string;
+	order: number;
+	contentType: LearnContentType;
+	historical: boolean;
+	status: LearnStatus;
+}
+
+export function getLearnTopic(
+	topicKey: string,
+	registry: LearnTopicRegistry = learnTopicRegistry,
+): LearnTopicContext {
+	const definition = registry[topicKey];
+
+	if (!definition) {
+		throw new Error(`Unknown Learn topic: ${topicKey}`);
+	}
+
+	return {
+		key: topicKey,
+		path: `/learn/${topicKey}/`,
+		...definition,
+	};
+}
+
+export function getLearnEntryPath(slug: string): string {
+	const normalizedSlug = slug.replace(/^\/+|\/+$/gu, "").replace(/\/index$/u, "");
+	return `/learn/${normalizedSlug}/`;
+}
+
+export function assertLearnEntries(
+	entries: readonly LearnEntryLike[],
+	registry: LearnTopicRegistry = learnTopicRegistry,
+): void {
+	const orders = new Map<string, Set<number>>();
+
+	for (const entry of entries) {
+		getLearnTopic(entry.data.topic, registry);
+
+		const routeTopic = entry.slug.split("/")[0];
+		if (routeTopic !== entry.data.topic) {
+			throw new Error(
+				`Learn entry ${entry.slug} must be routed under topic ${entry.data.topic}`,
+			);
+		}
+
+		if (!Number.isInteger(entry.data.order) || entry.data.order < 0) {
+			throw new Error(
+				`Learn entry ${entry.slug} must have a non-negative integer order`,
+			);
+		}
+
+		const topicOrders = orders.get(entry.data.topic) ?? new Set<number>();
+		if (topicOrders.has(entry.data.order)) {
+			throw new Error(
+				`Learn topic ${entry.data.topic} has duplicate order ${entry.data.order}`,
+			);
+		}
+		topicOrders.add(entry.data.order);
+		orders.set(entry.data.topic, topicOrders);
+	}
+}
+
+export function getLearnNavigation(
+	entries: readonly LearnEntryLike[],
+	topicKey: string,
+): LearnNavigationItem[] {
+	return entries
+		.filter(
+			(entry) =>
+				entry.data.topic === topicKey && entry.data.status !== "planned",
+		)
+		.sort((left, right) => left.data.order - right.data.order)
+		.map((entry) => ({
+			label: entry.data.label,
+			path: getLearnEntryPath(entry.slug),
+			order: entry.data.order,
+			contentType: entry.data.contentType,
+			historical: entry.data.historical,
+			status: entry.data.status,
+		}));
+}
+
+export function getLearnPageContext(
+	entry: LearnEntryLike,
+	entries: readonly LearnEntryLike[],
+	registry: LearnTopicRegistry = learnTopicRegistry,
+) {
+	const topic = getLearnTopic(entry.data.topic, registry);
+
+	return {
+		topic,
+		navigation: getLearnNavigation(entries, topic.key),
+	};
+}
+
+export function usesHistoricalPresentation(
+	presentation: LearnPresentation,
+): boolean {
+	return presentation === "historical-record";
+}

--- a/src/pages/learn/[...slug].astro
+++ b/src/pages/learn/[...slug].astro
@@ -2,38 +2,60 @@
 import { type CollectionEntry, getCollection } from "astro:content";
 import LearnLayout from "../../layouts/LearnLayout.astro";
 import MigrationGuideLayout from "../../layouts/MigrationGuideLayout.astro";
+import {
+	assertLearnEntries,
+	getLearnPageContext,
+	usesHistoricalPresentation,
+} from "../../lib/learn";
+import type { LearnNavigationItem, LearnTopicContext } from "../../lib/learn";
 
 export const prerender = true;
 
 interface Props {
 	entry: CollectionEntry<"learn">;
+	topic: LearnTopicContext;
+	navigation: LearnNavigationItem[];
 }
 
 export async function getStaticPaths() {
 	const learnCollection = await getCollection("learn");
+	assertLearnEntries(learnCollection);
 
 	return learnCollection.map((entry) => {
-		// Create slug from the entry's file path
-		const slug = entry.slug;
+		const { topic, navigation } = getLearnPageContext(
+			entry,
+			learnCollection,
+		);
 
 		return {
-			params: { slug },
-			props: { entry },
+			params: { slug: entry.slug },
+			props: { entry, topic, navigation },
 		};
 	});
 }
 
-const { entry } = Astro.props;
+const { entry, topic, navigation } = Astro.props;
 const { Content } = await entry.render();
-const { title, description } = entry.data;
+const { title, description, presentation } = entry.data;
+const historicalPresentation = usesHistoricalPresentation(presentation);
 ---
 
-{entry.slug === 'fork/migration' ? (
-  <MigrationGuideLayout title={title} description={description}>
-    <Content />
-  </MigrationGuideLayout>
+{historicalPresentation ? (
+	<MigrationGuideLayout
+		title={title}
+		description={description}
+		topic={topic}
+		navigation={navigation}
+	>
+		<Content />
+	</MigrationGuideLayout>
 ) : (
-  <LearnLayout title={title} description={description}>
-    <Content />
-  </LearnLayout>
+	<LearnLayout
+		title={title}
+		description={description}
+		topic={topic}
+		navigation={navigation}
+	>
+		<Content />
+	</LearnLayout>
 )}


### PR DESCRIPTION
## Summary

- add reviewed topic, order, content-type, lifecycle, and presentation metadata to Learn entries
- centralize topic definitions and metadata-driven navigation in a reusable Learn model
- make layouts and breadcrumbs topic-aware without Fork-specific defaults
- select the historical migration presentation declaratively
- add focused coverage for second-topic extensibility, ordering, route validation, and presentation selection

## Acceptance evidence

- a second topic fixture works by extending the registry without editing `LearnLayout.astro`
- navigation order comes from entry metadata and planned entries are excluded
- all four existing Fork routes build successfully
- topic labels and navigation data flow from the central registry/content metadata
- the migration layout is selected from `presentation: historical-record`, not its slug

## Verification

- `npm run test:learn-model` — 4 passed
- `npm run typecheck`
- `npm run typecheck:scripts`
- `npm run lint`
- `npm run build`
- generated-route checks for all existing Fork Learn pages
- `git diff --check`

Closes #148
