### PR TITLE
fix: preserve the verified Moon Fork record

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,6 +9,7 @@ Start here to find the right doc. Read deeper only when the task calls for it.
 | [Fork Mechanics](fork-mechanics.md) | What a fork is, how dispute bonds escalate, why the monitor exists. Start here for context. |
 | [Fork Monitoring Pipeline](fork-monitoring-pipeline.md) | The CI/CD pipeline: three-job workflow, cache strategy, concurrency, failure handling |
 | [Fork Monitoring Methodology](fork-monitoring-methodology.md) | How the calculation script discovers markets, reads bonds, computes the threshold percentage |
+| [Final Moon Fork Record](moon-fork-final-record.md) | Authoritative post-deadline block observation, winner/current REP, exact migration totals, provenance, and finality boundaries |
 
 ## Protocol Reference
 

--- a/docs/moon-fork-final-record.md
+++ b/docs/moon-fork-final-record.md
@@ -1,0 +1,131 @@
+---
+title: Final Moon Fork Record
+tags: [augur, moon-fork, fork-record, provenance, rep]
+---
+
+# Final Moon Fork Record
+
+## Status and observation anchor
+
+This is the authoritative post-deadline factual record for the Moon Fork. It is an Ethereum mainnet observation, not an interpretation of migration percentages or a copy of a pre-close website snapshot.
+
+| Observation | Value |
+|---|---|
+| Chain | Ethereum mainnet (`chainId` 1) |
+| Finalized block | [`25,677,103`](https://etherscan.io/block/25677103) |
+| Block hash | `0xab19846fa87d598ab7cf801092d94533b1fd4f3a0ebe2dc442c49f188f3af5b7` |
+| Block time | `2026-08-03T21:36:23Z` |
+| Migration deadline | `1785718859` — `2026-08-03T01:00:59Z` |
+| Post-deadline distance | 74,124 seconds (20 hours, 35 minutes, 24 seconds) |
+| Independent reads | PublicNode and dRPC returned the same block hash, deadline, winner, current REP identity, and migration totals |
+
+All contract reads below were pinned to block `25,677,103`. The current generator pins the fork-state calls and lifecycle classification to `observedBlock` and its timestamp, so a record cannot mix values from different heads or use process wall time to classify a lagging block.
+
+## Final record
+
+| Fact | Verified value | Authority |
+|---|---|---|
+| Parent/forking universe | [`0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA`](https://etherscan.io/address/0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA) | The forking market's `getUniverse()` and the Augur v2 mainnet deployment record agree. |
+| Forking market | [`0x963EED85778CC23E2D4636Cd4f29eECDF9827E9e`](https://etherscan.io/address/0x963EED85778CC23E2D4636Cd4f29eECDF9827E9e) | Parent universe `getForkingMarket()`; market `isFinalized()` returned `true`. |
+| Winning universe | [`0x281171519Fb41540528398d8ED3EA257f0F32A9f`](https://etherscan.io/address/0x281171519Fb41540528398d8ED3EA257f0F32A9f) | Parent universe `getWinningChildUniverse()`. |
+| Canonical universe | `0x281171519Fb41540528398d8ED3EA257f0F32A9f` | Public presentation name for the contract-reported winning universe; not inferred from a tally. |
+| Winning outcome | Outcome index 1, `Yes` | The winning child matches index 1's payout hash; its on-chain REP symbol is `REPv2_Yes_1`. |
+| Current REP | [`REPv2_Yes_1` — `0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D`](https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D) | Winning universe `getReputationToken()` plus token `symbol()`. This matches Augur ForkWatch's version-controlled token registry. |
+| Fork reputation goal | `5,497,186.882986651334933313 REP` (`5497186882986651334933313` wei) | Parent universe `getForkReputationGoal()`. |
+
+“Canonical universe” is a site term for the exact child returned by `getWinningChildUniverse()`.
+
+## Final migration totals
+
+The final tallies are each child reputation token's `getTotalMigrated()`, not ERC-20 `totalSupply()`.
+
+| Index / outcome | Payout hash | Child universe | REP token | Final migrated REP |
+|---|---|---|---|---|
+| 0 / Invalid | `0x8120c1e924d9d073442a1f9615009583146a839d1e0aaae6efd4e0b554d493c5` | No child at the observed block | None | `0` wei — `0 REP` |
+| 1 / Yes | `0x544cbfd6b85821f7bbff5de4b999b0b4b701354a3f2d0c4707fd0358295b0173` | `0x281171519Fb41540528398d8ED3EA257f0F32A9f` | `0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D` (`REPv2_Yes_1`) | `6398081413681494610869400` wei — `6,398,081.4136814946108694 REP` |
+| 2 / No | `0x99c9250f58203a3183137eae3a39da9d9d956cd08d1707a58cff5cddf957afe5` | `0xbaaD633FAa0E4847A4b66043E3E92102e5800546` | `0x2F4005456c2F098358213f01DbE34abDAa2989A4` (`REPv2_No_1`) | `1786227400866527400056` wei — `1,786.227400866527400056 REP` |
+
+These values are safe to call final migration totals because the deployed Augur v2 `ReputationToken.migrateIn()` increments `totalMigrated` and rejects migration at or after the parent universe's fork end time. `getTotalMigrated()` returns that dedicated counter.
+
+## Source and provenance matrix
+
+### Primary: Ethereum contract and block state
+
+The observation queried these methods with block tag `25,677,103`:
+
+- Parent universe: `isForking()`, `getForkingMarket()`, `getForkEndTime()`, `getForkReputationGoal()`, `getWinningChildUniverse()`, `getReputationToken()`, and `getChildUniverse(bytes32)`.
+- Forking market: `getUniverse()`, `isFinalized()`, `getNumberOfOutcomes()`, and `getNumTicks()`.
+- Child universes: `getParentUniverse()` and `getReputationToken()`.
+- Child REP tokens: `symbol()`, `getTotalMigrated()`, and `totalSupply()`.
+- Block: number, hash, and timestamp from Ethereum JSON-RPC. A second endpoint reproduced the material values at the same block.
+
+### Version-controlled Augur records
+
+- [Augur v2 mainnet deployment record at commit `bd13a797`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-artifacts/src/environments/mainnet.json#L81-L86) identifies network 1, the parent universe, and the REPv1 legacy contract.
+- [`Universe.fork()`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/Universe.sol#L99-L106) sets the fork end time; [`getForkEndTime()`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/Universe.sol#L158-L160) exposes it.
+- [`getWinningChildUniverse()`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/Universe.sol#L351-L358) is the winner authority. It uses the child token's dedicated migrated amount and the fork goal/deadline.
+- [`ReputationToken.migrateIn()`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/ReputationToken.sol#L60-L72) enforces the deadline and increments `totalMigrated`; [`getTotalMigrated()`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/ReputationToken.sol#L135-L137) exposes the tally.
+- [Augur ForkWatch's REP registry at commit `19a05e5c`](https://github.com/AugurProject/augur-forkwatch-website/blob/19a05e5c276e0b9088ae57d8db54241797a95a22/src/domain/tokens/rep-tokens.ts#L20-L48) independently preserves REPv1, pre-fork REPv2, and `REPv2_Yes_1` identities on Ethereum mainnet.
+
+No official publication or archived artifact was needed to override a contract value.
+
+## Conflict resolved: token supply is not migrated REP
+
+The deployed `/data/fork-risk.json` snapshot generated at `2026-08-03T21:40:44.836Z` and block `25,677,124` reported the Yes child's ERC-20 `totalSupply()` (`6,545,760.433666705… REP`) as `migratedRep`. At the finalized evidence block, the same token reported:
+
+- `totalSupply()`: `6,545,760.433666705616389974 REP`
+- `getTotalMigrated()`: `6,398,081.4136814946108694 REP`
+- difference: `147,679.019985211005520574 REP`
+
+`totalSupply()` can include protocol mints and burns and is not the contract's migration counter. The generator now uses `getTotalMigrated()` for `migratedRep` and adds exact `migratedRepWei` strings while retaining the existing numeric field for compatibility. The earlier supply-derived number is not a final migration total.
+
+## Final versus observed-only fields
+
+### Safe to present as final
+
+- Migration deadline.
+- Winning/canonical child universe and outcome.
+- Current REP contract associated with the winning universe.
+- Per-outcome `getTotalMigrated()` tallies after the deadline.
+- Parent universe, forking market, and legacy REP contract identities.
+
+### Observation metadata, not final retrospective totals
+
+- `isForking()` returned `true` at the evidence block. In the deployed source it means “forking or has forked” (`forkingMarket != 0`), so it does **not** mean migration remains open.
+- Child-token `totalSupply()` is a block-specific supply observation and must not be labeled migrated REP.
+- Parent `universeRepSupply`, risk percentages, RPC latency, `generatedAt`, and monitoring metrics are operational snapshots.
+- Any migration percentage using an assumed 11 million REP denominator is derived presentation, not a final protocol fact.
+
+## Post-close preservation and compatibility
+
+The generated endpoint remains schema version 2 and keeps all pre-existing top-level risk fields and the `forkActive` compatibility shape unchanged. `fork.outcomes[].migratedRep` remains a number; additive optional `fork.outcomes[].migratedRepWei` carries exact totals without changing older consumers. Generation fails rather than publishing if the winning universe reports a current REP address or symbol other than the verified `REPv2_Yes_1` identity.
+
+The deployed Augur v2 parent still returned `isForking() == true` after the deadline, consistent with [its source implementation](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/Universe.sol#L204-L210). The defensive generator path is nevertheless tested with `isForking() == false` and a passed nonzero deadline: it selects the post-deadline record path, re-reads fork metadata at one block, and emits both `fork` and legacy `forkActive` data rather than reverting to ordinary monitoring.
+
+Consumers audited for compatibility:
+
+- `src/features/fork-monitor/data-provider.tsx`
+- `src/features/fork-monitor/validate-fork-data.ts`
+- `src/features/fork-monitor/derive-fork-lifecycle.ts`
+- `src/features/fork-monitor/active-card.tsx`
+- `src/features/fork-monitor/post-fork-record.tsx`
+- `src/features/fork-monitor/mock-provider.tsx`
+- `src/lib/fork-data.ts`
+
+## Preserved REP identities
+
+| Role | Ethereum mainnet address | Status |
+|---|---|---|
+| REPv1 | `0x1985365e9f78359a9B6AD760e32412f4a445E862` | Legacy input token; not current REP |
+| REPv2 | `0x221657776846890989a759BA2973e427DfF5C9bB` | Pre-fork parent-universe token; not current REP |
+| REPv2_Yes_1 | `0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D` | Current REP in the winning/canonical universe |
+| REPv2_No_1 | `0x2F4005456c2F098358213f01DbE34abDAa2989A4` | Losing child-universe token; preserved for provenance |
+
+## Related documentation
+
+- [[public-data-endpoints]] — compatible public JSON contract
+- [[fork-monitoring-pipeline]] — generation and deployment path
+- [[fork-monitoring-methodology]] — monitoring implementation
+- [[public-knowledge-architecture]] — retrospective evidence policy
+- [[post-fork-landing-page-implementation-plan]] — lifecycle presentation
+- [[migration-guide-feature]] — preserved historical procedure

--- a/docs/post-fork-landing-page-implementation-plan.md
+++ b/docs/post-fork-landing-page-implementation-plan.md
@@ -7,7 +7,7 @@ tags: [homepage, fork, post-fork, implementation, github-actions]
 
 ## Status
 
-**Implementation complete locally; post-deadline observation pending.** This document defines the change from the current fork-migration hero to a durable post-fork record. Protocol signals are verified, the versioned fork JSON contract and lifecycle derivation are implemented, the on-chain generator emits the winner, the data job preserves the record when `isForking()` flips false at closure, and the local UI now covers open, resolved-open, closed-resolved, and closed-unverified states. Monitoring continues after closure; reducing its cadence is a separate operational follow-up.
+**Implementation and post-deadline verification complete.** This document defines the change from the fork-migration hero to a durable post-fork record. The authoritative evidence is preserved in [[moon-fork-final-record]]. The versioned fork JSON contract and lifecycle derivation are implemented, the generator reads exact migration counters at one observed block, and the defensive post-deadline path preserves the record if a compatible parent reports `isForking() == false`. The deployed Augur v2 parent continued to return `true` after closure, consistent with its “forking or has forked” source semantics. Monitoring continues after closure; reducing its cadence is a separate operational follow-up.
 
 ## Local Review Demo
 
@@ -28,15 +28,15 @@ The local CTA copy is tied to the lifecycle signal: an unknown winner keeps the 
 
 ## Protocol Verification Snapshot
 
-The read-only probe confirmed the Phase 0 contract semantics against Ethereum mainnet at block `25,662,284`:
+A finalized, post-deadline read at Ethereum mainnet block `25,677,103` (`2026-08-03T21:36:23Z`) established the durable record:
 
-- Forking universe: `0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA`.
-- `isForking()` is `true`.
-- `getForkEndTime()` is `2026-08-03T01:00:59Z`, the current migration deadline exposed by the contract.
-- `getWinningChildUniverse()` returns `0x281171519Fb41540528398d8ED3EA257f0F32A9f` before the deadline.
-- That child matches outcome index `1` (`Yes`) and its migrated REP supply exceeds the fork reputation goal.
+- The migration deadline was `2026-08-03T01:00:59Z`, 20 hours, 35 minutes, and 24 seconds before the observation.
+- `getWinningChildUniverse()` returned `0x281171519Fb41540528398d8ED3EA257f0F32A9f`, outcome index `1` (`Yes`).
+- The winning universe's REP token was `REPv2_Yes_1` at `0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D`.
+- Final migration counters were `6,398,081.4136814946108694 REP` for Yes, `1,786.227400866527400056 REP` for No, and `0 REP` for Invalid.
+- Two RPC endpoints reproduced the material values at the same finalized block.
 
-This confirms the transitional state used by the local demo: a winner can be established while migration remains open. The probe result is an acceptance fixture, not a permanent claim about future chain state; generated data must continue to read these values from the contract.
+See [[moon-fork-final-record]] for exact wei values, the block hash, contract methods, source-code permalinks, conflict resolution, and final versus observed-only fields.
 
 ## Confirmed Product Decisions
 

--- a/docs/public-data-endpoints.md
+++ b/docs/public-data-endpoints.md
@@ -9,7 +9,7 @@ Augur.net serves structured JSON at stable URLs under `/data/` for external cons
 
 ## Compatibility
 
-The endpoint now emits additive schema version 2 fields. Treat renaming, removing, or changing the type of an existing field as a breaking change and coordinate it with known consumers. Older consumers can continue reading the existing risk and `forkActive` fields.
+The endpoint emits additive schema version 2 fields. Treat renaming, removing, or changing the type of an existing field as a breaking change and coordinate it with known consumers. Older consumers can continue reading the existing risk and unchanged `forkActive` shape. Exact migration tallies are additive `fork.outcomes[].migratedRepWei` strings; the existing numeric `migratedRep` field remains available.
 
 ## Endpoints
 
@@ -32,7 +32,7 @@ Pipeline: scripts/calculate-fork-risk.ts
 |---|---|---|
 | `lastRiskChange` | `string` (ISO 8601) | Timestamp of the latest calculation. Poll this to detect staleness. |
 | `schemaVersion` | `number`, optional | Versioned data contract; current generated records use `2`. |
-| `generatedAt` | `string` (ISO 8601), optional | Timestamp used to derive the emitted lifecycle status. |
+| `generatedAt` | `string` (ISO 8601), optional | Generation metadata; not the authority for the observed record's lifecycle status. |
 | `blockNumber` | `number`, optional | Ethereum block at time of calculation; omitted from error results |
 | `riskLevel` | `enum` | `none` \| `low` \| `moderate` \| `high` \| `critical` \| `unknown` |
 | `riskPercentage` | `number \| null` | Round progress as percentage (0–100). `null` when projection unavailable. |
@@ -76,7 +76,7 @@ older consumers. New consumers should use `fork` as the lifecycle source.
 | `index` | `number` | Outcome index (0 = Invalid, 1+ = outcome labels) |
 | `label` | `string` | Human-readable outcome label |
 | `childUniverse` | `string \| null` | Child universe address, or `null` if none created |
-| `migratedRep` | `number` | REP migrated to this outcome so far |
+| `migratedRep` | `number` | REP migrated to this outcome, read from the child token's `getTotalMigrated()` counter; final after the migration deadline |
 
 #### `fork` (schema v2)
 
@@ -84,18 +84,28 @@ The normalized record is the source for lifecycle presentation. `status` can be 
 
 | Field | Type | Description |
 |---|---|---|
-| `status` | `enum` | Lifecycle status emitted at generation time |
+| `status` | `enum` | Lifecycle status classified at the observed block's timestamp |
 | `parentUniverse` | `string \| null` | Parent/forking universe address |
 | `forkingMarket` | `string` | Market that triggered the fork |
 | `migrationDeadline` | `number` | Unix timestamp at which migration closes |
 | `reputationGoal` | `number` | REP needed for early resolution |
 | `winningChildUniverse` | `string \| null` | Contract-reported winner, when known |
 | `outcomes` | `array` | Outcome records, including child universe, REP token, and migrated REP |
-| `observedBlock` | `number`, optional | Ethereum block used for the record |
+| `observedBlock` | `number`, optional | Ethereum block used for the record; fork-state calls and generated lifecycle classification use this block and its timestamp |
+
+`fork.outcomes[]` retains the numeric compatibility fields and adds:
+
+| Field | Type | Description |
+|---|---|---|
+| `reputationToken` | `string \| null`, optional | Child universe REP token address |
+| `migratedRepWei` | `string`, optional | Exact integer form of `getTotalMigrated()` in wei |
+| `isWinner` | `boolean`, optional | Whether the outcome matches `winningChildUniverse` |
 
 The browser derives the current display state from `fork.winningChildUniverse`, `fork.migrationDeadline`, and current time. A winner known before the deadline does not make the endpoint post-fork; it remains `migration-open-resolved` until the deadline.
 
 **Risk level thresholds**: `none` (0%), `low` (1–24%), `moderate` (25–49%), `high` (50–74%), `critical` (75–100%). When `forkActive` is present, `riskLevel` is always `critical` and `roundProgress` is `100`.
+
+Do not substitute an outcome token's ERC-20 `totalSupply()` for `migratedRep`. Supply can differ from the dedicated migration counter after protocol mints or burns. The verified final values and the superseded supply-derived snapshot are documented in [[moon-fork-final-record]].
 
 For pipeline internals, see [[fork-monitoring-pipeline]].
 

--- a/scripts/calculate-fork-risk.ts
+++ b/scripts/calculate-fork-risk.ts
@@ -239,6 +239,43 @@ export const readForkLifecycleSignals = async (readers: {
 	return { isForking: false, forkEndTime };
 };
 
+export type ForkDataMode =
+	| "active-fork"
+	| "post-deadline-record"
+	| "monitoring";
+
+export const selectForkDataMode = (
+	signals: ForkLifecycleSignals,
+	observedBlockTimestamp: number,
+): ForkDataMode => {
+	if (signals.isForking) return "active-fork";
+	if (
+		signals.forkEndTime !== null &&
+		signals.forkEndTime > 0 &&
+		observedBlockTimestamp >= signals.forkEndTime
+	) {
+		return "post-deadline-record";
+	}
+	return "monitoring";
+};
+
+export const readObservedBlockTimestamp = async (
+	readBlock: (blockNumber: number) => Promise<{ timestamp: number } | null>,
+	blockNumber: number,
+): Promise<number> => {
+	const block = await readBlock(blockNumber);
+	if (!block || !Number.isInteger(block.timestamp) || block.timestamp <= 0) {
+		throw new Error(`Observed block ${blockNumber} could not be read.`);
+	}
+	return block.timestamp;
+};
+
+export const classifyForkRecordAtObservedTime = (
+	data: Parameters<typeof deriveForkLifecycle>[0],
+	observedBlockTimestamp: number,
+): ForkRecordData["status"] =>
+	deriveForkLifecycle(data, observedBlockTimestamp).state;
+
 async function loadContracts(
 	provider: ethers.JsonRpcProvider,
 ): Promise<Record<string, ethers.Contract>> {
@@ -336,13 +373,21 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 		return await executeWithRpcFallback(async (connection, contracts) => {
 			// Get current blockchain state
 			const blockNumber = await connection.provider.getBlockNumber();
+			const observedBlockTimestamp = await readObservedBlockTimestamp(
+				(blockTag) => connection.provider.getBlock(blockTag),
+				blockNumber,
+			);
 			console.log(`Block Number: ${blockNumber}`);
+			console.log(
+				`Block Time: ${new Date(observedBlockTimestamp * 1000).toISOString()}`,
+			);
 
 			// Read fork threshold from chain (varies per universe)
 			let forkThresholdRep = 275000; // fallback constant
 			try {
 				const thresholdWei = await retryContractCall(
-					() => contracts.universe.getDisputeThresholdForFork(),
+					() =>
+						contracts.universe.getDisputeThresholdForFork({ blockTag: blockNumber }),
 					"universe.getDisputeThresholdForFork()",
 				);
 				forkThresholdRep = Number(ethers.formatEther(thresholdWei));
@@ -358,43 +403,44 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 			const lifecycle = await readForkLifecycleSignals({
 				isForking: () =>
 					retryContractCall(
-						() => contracts.universe.isForking(),
+						() => contracts.universe.isForking({ blockTag: blockNumber }),
 						"universe.isForking()",
 					),
 				getForkEndTime: () =>
 					retryContractCall(
-						() => contracts.universe.getForkEndTime(),
+						() => contracts.universe.getForkEndTime({ blockTag: blockNumber }),
 						"universe.getForkEndTime()",
 					),
 			});
-			const { isForking, forkEndTime: recordedForkEndTime } = lifecycle;
+			const forkDataMode = selectForkDataMode(
+				lifecycle,
+				observedBlockTimestamp,
+			);
 
-			if (isForking) {
-				console.log("⚠️ UNIVERSE IS FORKING! Setting maximum risk level");
+			if (forkDataMode === "active-fork") {
+				console.log(
+					"⚠️ UNIVERSE REPORTS A FORK RECORD! Setting maximum risk level",
+				);
 				return await getForkingResult(
 					blockNumber,
+					observedBlockTimestamp,
 					connection,
 					forkThresholdRep,
 					contracts.universe,
 				);
 			}
 
-			// Some deployed universe implementations stop reporting `isForking()`
-			// immediately after the migration deadline. Preserve the historical fork
-			// record in that case instead of falling back to an unrelated pre-fork
-			// risk calculation.
-
-			if (
-				recordedForkEndTime !== null &&
-				recordedForkEndTime > 0 &&
-				Math.floor(Date.now() / 1000) >= recordedForkEndTime
-			) {
+			// Preserve a closed record even if a compatible parent universe no longer
+			// reports `isForking()` after its recorded migration deadline.
+			if (forkDataMode === "post-deadline-record") {
 				console.log(
 					"⚠️ Migration deadline has passed; preserving the fork record snapshot",
 				);
 				const closedFork = await fetchForkActiveDetails(
 					connection.provider,
 					contracts.universe,
+					blockNumber,
+					observedBlockTimestamp,
 				);
 				if (!closedFork) {
 					throw new Error(
@@ -403,6 +449,7 @@ async function calculateForkRisk(): Promise<ForkRiskData> {
 				}
 				return await getForkingResult(
 					blockNumber,
+					observedBlockTimestamp,
 					connection,
 					forkThresholdRep,
 					contracts.universe,
@@ -1324,8 +1371,13 @@ const FORK_ACTIVE_MARKET_ABI = [
 ];
 const FORK_ACTIVE_ERC20_ABI = [
 	"function totalSupply() view returns (uint256)",
+	"function getTotalMigrated() view returns (uint256)",
 	"function symbol() view returns (string)",
 ];
+const EXPECTED_CURRENT_REP = {
+	address: "0xcf6a0a7826fa124b7705d6f3c675ead76f1e540d",
+	symbol: "REPv2_Yes_1",
+};
 
 function positionalLabel(index: number): string {
 	// Fallback label — actual outcome names are market-specific and
@@ -1347,6 +1399,8 @@ function labelFromTokenSymbol(symbol: string): string | null {
 async function fetchForkActiveDetails(
 	provider: ethers.JsonRpcProvider,
 	universe: ethers.Contract,
+	blockTag: number,
+	observedBlockTimestamp: number,
 ): Promise<ForkRiskData["forkActive"] | undefined> {
 	try {
 		const u = new ethers.Contract(
@@ -1357,14 +1411,22 @@ async function fetchForkActiveDetails(
 
 		const [forkingMarket, forkEndTimeRaw, forkRepGoalWei, repTokenAddr] =
 			await Promise.all([
-				u.getForkingMarket(),
-				u.getForkEndTime(),
-				u.getForkReputationGoal(),
-				u.getReputationToken(),
+				u.getForkingMarket({ blockTag }),
+				u.getForkEndTime({ blockTag }),
+				u.getForkReputationGoal({ blockTag }),
+				u.getReputationToken({ blockTag }),
 			]);
-		const winningChildUniverseRaw = await u
-			.getWinningChildUniverse()
-			.catch(() => ethers.ZeroAddress);
+		let winningChildUniverseRaw: unknown;
+		try {
+			winningChildUniverseRaw = await u.getWinningChildUniverse({ blockTag });
+		} catch (error) {
+			if (observedBlockTimestamp >= Number(forkEndTimeRaw)) {
+				throw new Error(
+					`Winning child universe could not be verified after the migration deadline: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+			winningChildUniverseRaw = ethers.ZeroAddress;
+		}
 		const winningChildUniverse =
 			String(winningChildUniverseRaw).toLowerCase() ===
 			ethers.ZeroAddress.toLowerCase()
@@ -1376,7 +1438,7 @@ async function fetchForkActiveDetails(
 			FORK_ACTIVE_ERC20_ABI,
 			provider,
 		);
-		const universeRepSupplyWei = await repToken.totalSupply();
+		const universeRepSupplyWei = await repToken.totalSupply({ blockTag });
 
 		const market = new ethers.Contract(
 			forkingMarket,
@@ -1384,8 +1446,8 @@ async function fetchForkActiveDetails(
 			provider,
 		);
 		const [numOutcomesRaw, numTicksRaw] = await Promise.all([
-			market.getNumberOfOutcomes(),
-			market.getNumTicks(),
+			market.getNumberOfOutcomes({ blockTag }),
+			market.getNumTicks({ blockTag }),
 		]);
 		const numOutcomes = Number(numOutcomesRaw);
 		const numTicks = BigInt(numTicksRaw);
@@ -1405,9 +1467,12 @@ async function fetchForkActiveDetails(
 				const payoutHash = ethers.keccak256(
 					ethers.solidityPacked(packedTypes, numerators),
 				);
-				const childAddr: string = await u.getChildUniverse(payoutHash);
+				const childAddr: string = await u.getChildUniverse(payoutHash, {
+					blockTag,
+				});
 				const isZero = !childAddr || /^0x0+$/i.test(childAddr);
 				let migratedRep = 0;
+				let migratedRepWei = "0";
 				let childRepToken: string | null = null;
 				let label = positionalLabel(k);
 				if (!isZero) {
@@ -1416,21 +1481,30 @@ async function fetchForkActiveDetails(
 						FORK_ACTIVE_UNIVERSE_ABI,
 						provider,
 					);
-					const childRepAddr = await childUniverse.getReputationToken();
+					const childRepAddr = await childUniverse.getReputationToken({ blockTag });
 					childRepToken = childRepAddr;
 					const childRep = new ethers.Contract(
 						childRepAddr,
 						FORK_ACTIVE_ERC20_ABI,
 						provider,
 					);
-					const [supplyWei, symbol] = await Promise.all([
-						childRep.totalSupply(),
-						childRep.symbol().catch(() => null as string | null),
+					const [totalMigratedWei, symbol] = await Promise.all([
+						childRep.getTotalMigrated({ blockTag }),
+						childRep.symbol({ blockTag }),
 					]);
-					migratedRep = Number(ethers.formatEther(supplyWei));
-					if (symbol) {
-						const parsed = labelFromTokenSymbol(symbol);
-						if (parsed) label = parsed;
+					migratedRepWei = totalMigratedWei.toString();
+					migratedRep = Number(ethers.formatEther(totalMigratedWei));
+					const parsed = labelFromTokenSymbol(symbol);
+					if (parsed) label = parsed;
+
+					if (
+						winningChildUniverse?.toLowerCase() === childAddr.toLowerCase() &&
+						(childRepAddr.toLowerCase() !== EXPECTED_CURRENT_REP.address ||
+							symbol !== EXPECTED_CURRENT_REP.symbol)
+					) {
+						throw new Error(
+							`Current REP discrepancy: expected ${EXPECTED_CURRENT_REP.symbol} at ${EXPECTED_CURRENT_REP.address}, received ${symbol} at ${childRepAddr}.`,
+						);
 					}
 				}
 				return {
@@ -1439,6 +1513,7 @@ async function fetchForkActiveDetails(
 					childUniverse: isZero ? null : childAddr,
 					reputationToken: childRepToken,
 					migratedRep,
+					migratedRepWei,
 				};
 			}),
 		);
@@ -1461,6 +1536,7 @@ async function fetchForkActiveDetails(
 
 async function getForkingResult(
 	blockNumber: number,
+	observedBlockTimestamp: number,
 	connection: RpcConnection,
 	forkThresholdRep: number,
 	universe: ethers.Contract,
@@ -1468,12 +1544,26 @@ async function getForkingResult(
 ): Promise<ForkRiskData> {
 	const forkActive =
 		existingForkActive ??
-		(await fetchForkActiveDetails(connection.provider, universe));
+		(await fetchForkActiveDetails(
+			connection.provider,
+			universe,
+			blockNumber,
+			observedBlockTimestamp,
+		));
 	if (!forkActive) {
 		throw new Error("Fork is active but fork details could not be read");
 	}
 
 	const generatedAt = new Date().toISOString();
+	const compatibilityOutcomes = forkActive.outcomes.map((outcome) => {
+		const compatibilityOutcome = { ...outcome };
+		delete compatibilityOutcome.migratedRepWei;
+		return compatibilityOutcome;
+	});
+	const forkActiveCompatibility = {
+		...forkActive,
+		outcomes: compatibilityOutcomes,
+	};
 	const forkRecord: ForkRecordData = {
 		status: "migration-open",
 		parentUniverse: await universe.getAddress(),
@@ -1519,15 +1609,14 @@ async function getForkingResult(
 			forkThreshold: forkThresholdRep,
 		},
 		cacheValidation: { isHealthy: true },
-		forkActive,
+		forkActive: forkActiveCompatibility,
 		fork: forkRecord,
 	};
 
-	const lifecycle = deriveForkLifecycle(
+	forkRecord.status = classifyForkRecordAtObservedTime(
 		results,
-		Math.floor(Date.parse(generatedAt) / 1000),
+		observedBlockTimestamp,
 	);
-	forkRecord.status = lifecycle.state;
 	const validation = validateForkRiskData(results);
 	if (!validation.valid) {
 		throw new Error(

--- a/scripts/fork-lifecycle.test.ts
+++ b/scripts/fork-lifecycle.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readForkLifecycleSignals } from "./calculate-fork-risk.ts";
+import {
+	classifyForkRecordAtObservedTime,
+	readForkLifecycleSignals,
+	readObservedBlockTimestamp,
+	selectForkDataMode,
+} from "./calculate-fork-risk.ts";
 import {
 	deriveForkLifecycle,
 	getForkRecord,
@@ -20,6 +25,26 @@ test("keeps a successful pre-fork zero deadline as ordinary monitoring", async (
 	});
 
 	assert.deepEqual(signals, { isForking: false, forkEndTime: 0 });
+	assert.equal(selectForkDataMode(signals, 2000), "monitoring");
+});
+
+test("uses observed block time when selecting post-deadline preservation", async () => {
+	const signals = await readForkLifecycleSignals({
+		isForking: async () => false,
+		getForkEndTime: async () => 2000n,
+	});
+	const processWallTime = 2001;
+
+	assert.ok(processWallTime >= 2000);
+	assert.equal(selectForkDataMode(signals, 1999), "monitoring");
+	assert.equal(selectForkDataMode(signals, 2000), "post-deadline-record");
+});
+
+test("fails closed when the observed block cannot be read", async () => {
+	await assert.rejects(
+		readObservedBlockTimestamp(async () => null, 100),
+		/Observed block 100 could not be read/u,
+	);
 });
 
 test("does not guess when the forking status read fails", async () => {
@@ -78,12 +103,14 @@ const baseData = (
 				label: "No",
 				childUniverse: otherChild,
 				migratedRep: 100,
+				migratedRepWei: "100000000000000000000",
 			},
 			{
 				index: 1,
 				label: "Yes",
 				childUniverse: winningChild,
 				migratedRep: 600,
+				migratedRepWei: "600000000000000000000",
 			},
 		],
 	},
@@ -113,6 +140,20 @@ test("moves to a resolved Fork Record exactly at the deadline", () => {
 	const data = baseData(winningChild);
 	assert.equal(
 		deriveForkLifecycle(data, 2000).state,
+		"migration-closed-resolved",
+	);
+});
+
+test("classifies the generated record from observed block time, not generatedAt", () => {
+	const data = baseData(winningChild);
+	assert.ok(Date.parse(data.generatedAt ?? "") / 1000 > 2000);
+
+	assert.equal(
+		classifyForkRecordAtObservedTime(data, 1999),
+		"migration-open-resolved",
+	);
+	assert.equal(
+		classifyForkRecordAtObservedTime(data, 2000),
 		"migration-closed-resolved",
 	);
 });
@@ -150,6 +191,41 @@ test("accepts a valid schema v2 resolved record", () => {
 
 	assert.equal(validateForkRiskData(data).valid, true);
 	assert.equal(getForkRecord(data)?.winningChildUniverse, winningChild);
+});
+
+test("keeps the legacy forkActive shape while schema v2 carries exact totals", () => {
+	const data = baseData(winningChild);
+	assert.ok(data.fork);
+	const compatibilityOutcomes = data.fork.outcomes.map((outcome) => {
+		const compatibilityOutcome = { ...outcome };
+		delete compatibilityOutcome.migratedRepWei;
+		return compatibilityOutcome;
+	});
+	data.forkActive = {
+		forkingMarket: data.fork.forkingMarket,
+		forkEndTime: data.fork.migrationDeadline,
+		winningChildUniverse: data.fork.winningChildUniverse,
+		forkReputationGoal: data.fork.reputationGoal,
+		universeRepSupply: 1000,
+		outcomes: compatibilityOutcomes,
+	};
+
+	assert.equal(
+		data.fork.outcomes[1].migratedRepWei,
+		"600000000000000000000",
+	);
+	assert.equal(data.forkActive.outcomes[1].migratedRepWei, undefined);
+	delete data.fork;
+
+	const validation = validateForkRiskData(data);
+	const lifecycle = deriveForkLifecycle(data, 2000);
+
+	assert.equal(validation.valid, true);
+	assert.equal(lifecycle.state, "migration-closed-resolved");
+	assert.equal(data.riskLevel, "critical");
+	assert.equal(data.riskPercentage, 100);
+	assert.equal(data.forkActive.forkEndTime, 2000);
+	assert.equal(lifecycle.record?.outcomes[1].migratedRep, 600);
 });
 
 test("rejects a record with missing outcome data without throwing", () => {

--- a/src/features/fork-monitor/types.ts
+++ b/src/features/fork-monitor/types.ts
@@ -22,6 +22,7 @@ export interface ForkOutcome {
 	childUniverse: string | null;
 	reputationToken?: string | null;
 	migratedRep: number;
+	migratedRepWei?: string;
 	isWinner?: boolean;
 }
 

--- a/src/features/fork-monitor/validate-fork-data.ts
+++ b/src/features/fork-monitor/validate-fork-data.ts
@@ -69,8 +69,21 @@ const validateRecord = (record: ForkRecordData, errors: string[]): void => {
 		) {
 			errors.push(`Outcome ${outcome.index} has an invalid child universe.`);
 		}
+		if (
+			outcome.reputationToken !== undefined &&
+			outcome.reputationToken !== null &&
+			!isEthereumAddress(outcome.reputationToken)
+		) {
+			errors.push(`Outcome ${outcome.index} has an invalid reputation token.`);
+		}
 		if (!Number.isFinite(outcome.migratedRep) || outcome.migratedRep < 0) {
 			errors.push(`Outcome ${outcome.index} has invalid migrated REP.`);
+		}
+		if (
+			outcome.migratedRepWei !== undefined &&
+			!/^\d+$/u.test(outcome.migratedRepWei)
+		) {
+			errors.push(`Outcome ${outcome.index} has invalid migrated REP wei.`);
 		}
 	}
 
@@ -126,8 +139,25 @@ export const validateForkRiskData = (
 			) {
 				errors.push(`Legacy outcome ${outcome.index} has an invalid child universe.`);
 			}
+			if (
+				outcome.reputationToken !== undefined &&
+				outcome.reputationToken !== null &&
+				!isEthereumAddress(outcome.reputationToken)
+			) {
+				errors.push(
+					`Legacy outcome ${outcome.index} has an invalid reputation token.`,
+				);
+			}
 			if (!Number.isFinite(outcome.migratedRep) || outcome.migratedRep < 0) {
 				errors.push(`Legacy outcome ${outcome.index} has invalid migrated REP.`);
+			}
+			if (
+				outcome.migratedRepWei !== undefined &&
+				!/^\d+$/u.test(outcome.migratedRepWei)
+			) {
+				errors.push(
+					`Legacy outcome ${outcome.index} has invalid migrated REP wei.`,
+				);
 			}
 		}
 


### PR DESCRIPTION
## Summary

- record the authoritative post-deadline Moon Fork outcome with block-pinned provenance
- correct migration tallies to use `getTotalMigrated()` instead of token `totalSupply()`
- preserve the fork record when the parent no longer reports an active fork
- classify lifecycle state from the observed block timestamp rather than process wall time
- retain the legacy public JSON shape while adding exact wei tallies to schema-v2 outcomes

## Verified record

- evidence block: `25,677,103` (`2026-08-03T21:36:23Z`)
- migration deadline: `2026-08-03T01:00:59Z`
- winner/canonical universe: `0x281171519Fb41540528398d8ED3EA257f0F32A9f`
- winning outcome: Yes
- current REP: `REPv2_Yes_1` at `0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D`
- exact Yes migration tally: `6398081413681494610869400` wei

Two RPC providers reproduced the material values at the evidence block. Contract methods, source permalinks, final-vs-observed fields, preserved REP identities, and the superseded supply-derived value are documented in `docs/moon-fork-final-record.md`.

## Compatibility

- schema remains version 2
- no existing top-level or legacy `forkActive` keys are removed or added
- `migratedRep` remains numeric
- `migratedRepWei` is additive only under normalized `fork.outcomes[]`
- existing consumers and legacy-only lifecycle behavior are covered

## Verification

- live `npm run build:fork-data` produced `migration-closed-resolved` with the verified winner/current REP
- `npm run test:fork-lifecycle` — 16 passed
- `npm run typecheck:scripts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- generated JSON key-shape compatibility comparison
- `git diff --check`

Closes #147
