### PR TITLE
feat: finalize the general Augur FAQ

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,7 +30,7 @@ Start here to find the right doc. Read deeper only when the task calls for it.
 | [Technical Architecture](technical-architecture.md) | React/TypeScript component hierarchy, state management (Context API), UI patterns, visual rendering |
 | [Post-Fork Landing Page Implementation Plan](post-fork-landing-page-implementation-plan.md) | Implementation status and rollout plan for the migration CTA/countdown, verified Fork Record, and lifecycle data contract |
 | [Public Data Endpoints](public-data-endpoints.md) | Structured JSON endpoints at /data/*.json for external consumers — schemas, conventions, adding new endpoints |
-| [FAQ Feature](faq-feature.md) | FAQ page design, route, collapsible Q&A, landing page/footer integration |
+| [FAQ Feature](faq-feature.md) | General `/faq` content, native disclosures, stable question anchors, and footer integration |
 | [Blog Feature](blog-feature.md) | Blog frontmatter schema, MDX integration, RSS feed, Learn section |
 | [Migration Guide Feature](migration-guide-feature.md) | Moon Fork migration guide, step-by-step REP migration, MigrationGuideLayout |
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,7 +30,7 @@ Start here to find the right doc. Read deeper only when the task calls for it.
 | [Technical Architecture](technical-architecture.md) | React/TypeScript component hierarchy, state management (Context API), UI patterns, visual rendering |
 | [Post-Fork Landing Page Implementation Plan](post-fork-landing-page-implementation-plan.md) | Implementation status and rollout plan for the migration CTA/countdown, verified Fork Record, and lifecycle data contract |
 | [Public Data Endpoints](public-data-endpoints.md) | Structured JSON endpoints at /data/*.json for external consumers — schemas, conventions, adding new endpoints |
-| [FAQ Feature](faq-feature.md) | General `/faq` content, native disclosures, stable question anchors, and footer integration |
+| [FAQ Feature](faq-feature.md) | Finalized `/faq` content, static post-fork behavior, stable question anchors, safety guidance, and site integration |
 | [Blog Feature](blog-feature.md) | Blog frontmatter schema, MDX integration, RSS feed, Learn section |
 | [Migration Guide Feature](migration-guide-feature.md) | Moon Fork migration guide, step-by-step REP migration, MigrationGuideLayout |
 

--- a/docs/faq-feature.md
+++ b/docs/faq-feature.md
@@ -7,78 +7,69 @@ tags: [faq, feature]
 
 ## Overview
 
-Static `/faq` page covering the Augur fork for REP holders. Surfaced as the first (urgent) hero menu item on the landing page. Ships as a hardcoded Astro page — no content collection.
+Static `/faq` page for concise answers about Augur as a whole. The Moon Fork appears in one focused historical subsection; the page is not a migration guide.
 
 ## Route & Files
 
 - **Page:** `src/pages/faq.astro`
-- **Styles:** `src/styles/global.css` (`.faq-item`, `.faq-answer`, `.faq-group`)
+- **FAQ item:** `src/features/faq/item.astro`
+- **Styles:** `src/styles/global.css` (shared FAQ styles)
+
+The `/faq` route is preserved. The page has no content collection and no client-side FAQ state.
 
 ## Page Layout
 
-Follows the same `grid grid-rows-[auto_1fr_auto] min-h-screen` shell used by `mission.astro` and `team.astro`:
+The page uses the same `grid grid-rows-[auto_1fr_auto] min-h-screen` shell as the other top-level content pages:
 
-- **Top:** `PageHeader` component with back link to home and social links.
-- **Middle:** Content area with max-width constraint, scrollable overflow.
+- **Top:** `PageHeader` with a back link to home and social links.
+- **Middle:** A general Augur FAQ with concise native disclosure items.
 - **Bottom:** Standard `Footer` component.
 
-## Title Treatment
-
-Same label // bold-label pattern as `BlogLayout`:
-
-- Muted label: `FAQ`
-- Separator: `//`
-- Bold loud label: `FORK & MIGRATION`
+The title treatment is `FAQ // AUGUR`. Metadata describes Augur markets, reporting, REP, forks, Lituus, and the completed Moon Fork.
 
 ## Content Structure
 
-Intro paragraph followed by 7 sections. Each section has a `SectionHeading` and a `faq-group` div containing native `<details>`/`<summary>` collapsible items:
+The Q&A is grouped by subject:
 
-1. **What is happening?** — Context on the fork itself
-2. **Timeline** — Fork phases and key dates
-3. **Required Action** — Migration mechanics and dos/don'ts
-4. **Tokens** — Token behavior and supply
-5. **REPv1 Holders** — Migration path from v1 to v2 to fork
-6. **Exchanges** — Guidance for holders on exchanges
-7. **Safety & Process** — Reversibility, deadlines, official tools
+1. **Augur Basics** — Augur, prediction markets, and REP.
+2. **Markets & Reporting** — market resolution, dispute bonds, and the fork threshold.
+3. **Forks & REP** — universes, one-way migration, and parent-universe behavior.
+4. **Moon Fork · Historical Record** — the completed event, verified token identity, and the archived procedure.
+5. **Lituus** — its role as a standalone oracle and relationship to Augur.
+6. **Safety & Participation** — token verification and links into the Fork Learn topic.
 
-No numbering. Section headings organize the Q&A semantically.
+Answers stay short and link to existing Learn routes for depth. The archived `/learn/fork/migration/` page is linked only as a historical record. The FAQ does not present migration as an available action or duplicate the Learn curriculum.
 
-## Q&A Styling (`global.css`)
+## Disclosure & Anchor Behavior
 
-Collapsible Q&A styled to match the terminal aesthetic via `.faq-item` and `.faq-answer`:
+`src/features/faq/item.astro` renders native `<details>` and `<summary>` elements. No JavaScript opens, closes, or otherwise manages FAQ state, preserving browser disclosure behavior and keyboard accessibility.
 
-- **Summary (closed):** `>_` prefix rendered via `::before`, `text-foreground` color, bottom border separator between items
-- **Summary (open):** `text-loud-foreground`, `>_` prefix glows with `drop-shadow` using `--color-primary`
-- **Answer content:** Indented, `font-prose` (IBM Plex Mono) font family, `text-foreground`, `text-transform: none` (no uppercase override)
-- **Browser markers:** WebKit and standard `::marker` hidden with `display: none`
+Each question has a stable `id` on its `<details>` element. Current anchors are:
+
+- `#what-is-augur`
+- `#what-is-a-prediction-market`
+- `#what-is-rep-used-for`
+- `#how-are-markets-resolved`
+- `#what-is-a-dispute-bond`
+- `#when-does-augur-fork`
+- `#what-is-a-fork`
+- `#is-rep-migration-reversible`
+- `#what-happens-to-unmigrated-rep`
+- `#what-was-the-moon-fork`
+- `#which-outcome-won-the-moon-fork`
+- `#where-is-the-moon-fork-record`
+- `#what-is-lituus`
+- `#how-does-lituus-relate-to-augur`
+- `#how-do-i-verify-a-token`
+- `#where-should-i-learn-more`
+
+A deep link scrolls to the relevant `<details>` element. It does not force the item open; visitors can use the native summary control to disclose the answer.
 
 ## Site Integration
 
-The FAQ is linked from two site-level entry points:
+The FAQ remains linked from:
 
-1. **`src/features/home/hero-banner.tsx`** — direct `/faq` link in the landing-page menu.
+1. `src/features/home/hero-banner.tsx` — the landing-page menu.
+2. `src/components/shell/footer.astro` — the `>_ KB` section, labeled **AUGUR FAQ**.
 
-2. **`src/components/shell/footer.astro`** — FAQ link in the `>_ KB` section.
-
-The FAQ page also renders `src/features/learn/migration-cta.tsx`, a red-bordered inline CTA linking to `/learn/fork/migration/`.
-
-## Footer Integration
-
-`src/components/shell/footer.astro` — FAQ link added to `>_ KB` section as the **first item**, above the Augur Whitepaper link:
-
-```
-FORK & MIGRATION FAQ → /faq
-AUGUR WHITEPAPER → (external link)
-```
-
-## Image Slot
-
-An `<!-- IMAGE SLOT: Task 5 will insert the hero image here -->` comment placeholder remains in the page. No image is currently rendered. Can be filled later with a portrait-oriented asset.
-
-## Constraints
-
-- **No JavaScript:** Native HTML `<details>`/`<summary>` only — zero client-side interactivity needed
-- **No content collection:** Content is hardcoded directly in the `.astro` file, not sourced from a collection
-- **No deep linking:** No per-question anchor IDs (can be added later if needed)
-- **Uppercase override:** Main page and headings use uppercase via Tailwind; Q&A content remains normal case for readability
+The FAQ no longer renders the migration CTA or derives its content from fork lifecycle state.

--- a/docs/faq-feature.md
+++ b/docs/faq-feature.md
@@ -7,61 +7,80 @@ tags: [faq, feature]
 
 ## Overview
 
-Static `/faq` page for concise answers about Augur as a whole. The Moon Fork appears in one focused historical subsection; the page is not a migration guide.
+Static `/faq` page for current Augur questions and the completed Moon Fork. It tells visitors what they can use today, summarizes the historical fork and token transition, answers exchange and wallet questions, and warns against post-deadline migration scams.
+
+The page does not present migration as an available action. ForkWatch and the historical blog posts provide supporting detail.
 
 ## Route & Files
 
 - **Page:** `src/pages/faq.astro`
 - **FAQ item:** `src/features/faq/item.astro`
 - **Styles:** `src/styles/global.css` (shared FAQ styles)
+- **Regression test:** `scripts/faq.test.ts`
 
-The `/faq` route is preserved. The page has no content collection and no client-side FAQ state.
+The `/faq` route has no content collection or client-side FAQ state.
 
 ## Page Layout
 
 The page uses the same `grid grid-rows-[auto_1fr_auto] min-h-screen` shell as the other top-level content pages:
 
 - **Top:** `PageHeader` with a back link to home and social links.
-- **Middle:** A general Augur FAQ with concise native disclosure items.
+- **Middle:** The general Augur FAQ, rendered as native disclosure items.
 - **Bottom:** Standard `Footer` component.
 
-The title treatment is `FAQ // AUGUR`. Metadata describes the Augur reboot, REP after the Moon Fork, the final fork record, and protocol mechanics.
+The title treatment is `FAQ // AUGUR`. Metadata describes using Augur today and the completed Moon Fork, including REP tokens, exchanges, and safety.
 
 ## Content Structure
 
-The Q&A is organized around questions current visitors are likely to bring to the site:
+The finalized FAQ contains seven sections:
 
-1. **Augur Today** — what is live, whether this site is a trading interface, and what the reboot is building toward.
-2. **REP After the Moon Fork** — the current token, multiple contracts, migration status, and contract verification.
-3. **The Moon Fork** — why it happened, whether it is complete, the winning universe, and the evidence record.
-4. **Protocol Questions** — concise definitions of the fork threshold, universes, and irreversible migration.
+1. **Augur Today** — whether visitors can use Augur now and what the reboot is building toward.
+2. **The Moon Fork** — what happened, why the fork occurred, and why the migration deadline cannot be reopened.
+3. **Timeline** — the completed escalation and migration dates.
+4. **How the Fork Played Out** — escalation, migration, and the losing outcome universe.
+5. **Tokens** — `REPv2_Yes_1`, the Kraken `AUGUR` ticker, the parent REP token, and wallet visibility.
+6. **Exchanges** — the historical handling of REP held on Kraken and other exchanges.
+7. **Scams & Safety** — post-deadline migration and recovery scams.
 
-Generic encyclopedia prompts such as “What is Augur?” and “What is a prediction market?” are intentionally excluded; the homepage and Learn path provide that orientation.
+Generic encyclopedia prompts such as “What is Augur?” and “What is a prediction market?” remain excluded. The homepage and Learn path provide that orientation.
 
-Answers stay short and link to existing Learn routes for depth. The archived `/learn/fork/migration/` page is linked only as a historical record. The FAQ does not present migration as an available action or duplicate the Learn curriculum.
+The fork answers preserve the protocol's lazy child-universe behavior: an outcome has a potential child universe, but that child and its REP token are created only when migration first targets the outcome.
+
+## Static Post-Fork Behavior
+
+The FAQ is a post-fork reference. It does not import fork-lifecycle helpers, render `MigrationCta`, or switch copy based on build-time migration state. Its migration answers state that the contract-enforced deadline has passed and cannot be reopened.
+
+Historical support links include:
+
+- ForkWatch at `https://v3.augur.net/`
+- The three Moon Fork blog posts
+- Kraken's migration notice
+- Etherscan for the current `REPv2_Yes_1` contract
 
 ## Disclosure & Anchor Behavior
 
 `src/features/faq/item.astro` renders native `<details>` and `<summary>` elements. No JavaScript opens, closes, or otherwise manages FAQ state, preserving browser disclosure behavior and keyboard accessibility.
 
-Each question has a stable `id` on its `<details>` element. Current anchors are:
+Each question has a stable `id` on its `<details>` element:
 
-- `#what-is-live-today`
-- `#is-this-a-trading-interface`
+- `#can-i-use-augur-today`
 - `#what-is-the-reboot-building`
-- `#which-rep-token-is-current`
-- `#why-are-there-multiple-rep-contracts`
-- `#is-another-rep-migration-required`
-- `#what-happened-to-other-rep`
-- `#how-do-i-verify-rep`
-- `#why-did-the-moon-fork-happen`
-- `#is-the-moon-fork-complete`
-- `#which-universe-won`
-- `#where-is-the-on-chain-evidence`
-- `#where-is-the-complete-record`
-- `#what-causes-an-augur-fork`
-- `#what-is-a-universe`
-- `#why-is-rep-migration-irreversible`
+- `#i-own-repv2-what-happened`
+- `#i-didnt-migrate-in-time-is-there-anything-i-can-do`
+- `#why-did-augur-fork`
+- `#what-is-a-fork-in-simple-terms`
+- `#when-did-the-fork-start-and-end`
+- `#what-happened-during-the-escalation-game-phase-1`
+- `#what-happened-during-the-migration-window-phase-2`
+- `#what-happened-if-someone-migrated-to-the-no-universe`
+- `#is-there-a-new-rep-token`
+- `#is-augur-on-kraken-the-same-as-repv2-yes-1`
+- `#does-the-old-rep-token-still-exist`
+- `#the-new-token-doesnt-appear-in-my-wallet-yet-is-something-wrong`
+- `#my-rep-was-on-kraken-did-i-need-to-do-anything`
+- `#what-about-rep-on-other-exchanges-gate-upbit`
+- `#what-happened-to-rep-left-on-an-exchange`
+- `#someone-offered-to-migrate-or-recover-my-rep-is-that-real`
 
 A deep link scrolls to the relevant `<details>` element. It does not force the item open; visitors can use the native summary control to disclose the answer.
 
@@ -71,5 +90,6 @@ The FAQ remains linked from:
 
 1. `src/features/home/hero-banner.tsx` — the landing-page menu.
 2. `src/components/shell/footer.astro` — the `>_ KB` section, labeled **AUGUR FAQ**.
+3. `src/features/fork-monitor/post-fork-record.tsx` — the verified Fork Record dialog.
 
-The FAQ no longer renders the migration CTA or derives its content from fork lifecycle state.
+The footer also preserves the post-fork Dark Florist and whitepaper-link corrections introduced with the closed-migration messaging.

--- a/docs/faq-feature.md
+++ b/docs/faq-feature.md
@@ -25,17 +25,18 @@ The page uses the same `grid grid-rows-[auto_1fr_auto] min-h-screen` shell as th
 - **Middle:** A general Augur FAQ with concise native disclosure items.
 - **Bottom:** Standard `Footer` component.
 
-The title treatment is `FAQ // AUGUR`. Metadata describes Augur markets, reporting, REP, forks, and the completed Moon Fork.
+The title treatment is `FAQ // AUGUR`. Metadata describes the Augur reboot, REP after the Moon Fork, the final fork record, and protocol mechanics.
 
 ## Content Structure
 
-The Q&A is grouped by subject:
+The Q&A is organized around questions current visitors are likely to bring to the site:
 
-1. **Augur Basics** — Augur, prediction markets, and REP.
-2. **Markets & Reporting** — market resolution, dispute bonds, and the fork threshold.
-3. **Forks & REP** — universes, one-way migration, and parent-universe behavior.
-4. **Moon Fork · Historical Record** — the completed event, verified token identity, and the archived procedure.
-5. **Safety & Participation** — token verification and links into the Fork Learn topic.
+1. **Augur Today** — what is live, whether this site is a trading interface, and what the reboot is building toward.
+2. **REP After the Moon Fork** — the current token, multiple contracts, migration status, and contract verification.
+3. **The Moon Fork** — why it happened, whether it is complete, the winning universe, and the evidence record.
+4. **Protocol Questions** — concise definitions of the fork threshold, universes, and irreversible migration.
+
+Generic encyclopedia prompts such as “What is Augur?” and “What is a prediction market?” are intentionally excluded; the homepage and Learn path provide that orientation.
 
 Answers stay short and link to existing Learn routes for depth. The archived `/learn/fork/migration/` page is linked only as a historical record. The FAQ does not present migration as an available action or duplicate the Learn curriculum.
 
@@ -45,20 +46,22 @@ Answers stay short and link to existing Learn routes for depth. The archived `/l
 
 Each question has a stable `id` on its `<details>` element. Current anchors are:
 
-- `#what-is-augur`
-- `#what-is-a-prediction-market`
-- `#what-is-rep-used-for`
-- `#how-are-markets-resolved`
-- `#what-is-a-dispute-bond`
-- `#when-does-augur-fork`
-- `#what-is-a-fork`
-- `#is-rep-migration-reversible`
-- `#what-happens-to-unmigrated-rep`
-- `#what-was-the-moon-fork`
-- `#which-outcome-won-the-moon-fork`
-- `#where-is-the-moon-fork-record`
-- `#how-do-i-verify-a-token`
-- `#where-should-i-learn-more`
+- `#what-is-live-today`
+- `#is-this-a-trading-interface`
+- `#what-is-the-reboot-building`
+- `#which-rep-token-is-current`
+- `#why-are-there-multiple-rep-contracts`
+- `#is-another-rep-migration-required`
+- `#what-happened-to-other-rep`
+- `#how-do-i-verify-rep`
+- `#why-did-the-moon-fork-happen`
+- `#is-the-moon-fork-complete`
+- `#which-universe-won`
+- `#where-is-the-on-chain-evidence`
+- `#where-is-the-complete-record`
+- `#what-causes-an-augur-fork`
+- `#what-is-a-universe`
+- `#why-is-rep-migration-irreversible`
 
 A deep link scrolls to the relevant `<details>` element. It does not force the item open; visitors can use the native summary control to disclose the answer.
 

--- a/docs/faq-feature.md
+++ b/docs/faq-feature.md
@@ -25,7 +25,7 @@ The page uses the same `grid grid-rows-[auto_1fr_auto] min-h-screen` shell as th
 - **Middle:** A general Augur FAQ with concise native disclosure items.
 - **Bottom:** Standard `Footer` component.
 
-The title treatment is `FAQ // AUGUR`. Metadata describes Augur markets, reporting, REP, forks, Lituus, and the completed Moon Fork.
+The title treatment is `FAQ // AUGUR`. Metadata describes Augur markets, reporting, REP, forks, and the completed Moon Fork.
 
 ## Content Structure
 
@@ -35,8 +35,7 @@ The Q&A is grouped by subject:
 2. **Markets & Reporting** — market resolution, dispute bonds, and the fork threshold.
 3. **Forks & REP** — universes, one-way migration, and parent-universe behavior.
 4. **Moon Fork · Historical Record** — the completed event, verified token identity, and the archived procedure.
-5. **Lituus** — its role as a standalone oracle and relationship to Augur.
-6. **Safety & Participation** — token verification and links into the Fork Learn topic.
+5. **Safety & Participation** — token verification and links into the Fork Learn topic.
 
 Answers stay short and link to existing Learn routes for depth. The archived `/learn/fork/migration/` page is linked only as a historical record. The FAQ does not present migration as an available action or duplicate the Learn curriculum.
 
@@ -58,8 +57,6 @@ Each question has a stable `id` on its `<details>` element. Current anchors are:
 - `#what-was-the-moon-fork`
 - `#which-outcome-won-the-moon-fork`
 - `#where-is-the-moon-fork-record`
-- `#what-is-lituus`
-- `#how-does-lituus-relate-to-augur`
 - `#how-do-i-verify-a-token`
 - `#where-should-i-learn-more`
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"test:learn-model": "node --experimental-strip-types --test scripts/learn-model.test.ts",
 		"test:evergreen-fork": "node --experimental-strip-types --test scripts/evergreen-fork.test.ts",
 		"test:migration-archive": "node --experimental-strip-types --test scripts/migration-archive.test.ts",
+		"test:faq": "node --experimental-strip-types --test scripts/faq.test.ts",
 		"typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
 		"preview": "astro build && wrangler dev",
 		"astro": "astro",

--- a/scripts/faq.test.ts
+++ b/scripts/faq.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+const read = (file: string) =>
+	readFileSync(path.join(repositoryRoot, file), "utf8");
+
+const faq = read("src/pages/faq.astro");
+const faqItem = read("src/features/faq/item.astro");
+const footer = read("src/components/shell/footer.astro");
+const featureDocumentation = read("docs/faq-feature.md");
+
+const faqAnchorIds = [
+	"what-is-augur",
+	"what-is-a-prediction-market",
+	"what-is-rep-used-for",
+	"how-are-markets-resolved",
+	"what-is-a-dispute-bond",
+	"when-does-augur-fork",
+	"what-is-a-fork",
+	"is-rep-migration-reversible",
+	"what-happens-to-unmigrated-rep",
+	"what-was-the-moon-fork",
+	"which-outcome-won-the-moon-fork",
+	"where-is-the-moon-fork-record",
+	"what-is-lituus",
+	"how-does-lituus-relate-to-augur",
+	"how-do-i-verify-a-token",
+	"where-should-i-learn-more",
+];
+
+test("keeps the FAQ general and the Moon Fork subsection historical", () => {
+	assert.match(faq, /title="Augur FAQ \| Augur"/u);
+	assert.match(faq, /<PageTitle prefix="FAQ" title="AUGUR"/u);
+	assert.match(faq, /Moon Fork · Historical Record/u);
+	assert.match(faq, /archived migration record/u);
+	assert.doesNotMatch(faq, /MigrationCta|isMigrationOpen|migrationOpen/u);
+	assert.doesNotMatch(
+		faq,
+		/migration-open|migration window is open|Open now|active migration|must migrate/iu,
+	);
+});
+
+test("uses native disclosure controls with unique, documented question anchors", () => {
+	assert.match(faqItem, /<details[^>]*id=\{id\}/u);
+	assert.match(faqItem, /<summary/u);
+	assert.doesNotMatch(faqItem, /client:|<script/u);
+
+	const ids = [...faq.matchAll(/<FaqItem id="([^"]+)"/gu)].map(
+		(match) => match[1],
+	);
+	assert.deepEqual(ids, faqAnchorIds);
+	assert.equal(new Set(ids).size, ids.length);
+	for (const id of faqAnchorIds) {
+		assert.match(featureDocumentation, new RegExp(`#${id}\\b`, "u"));
+	}
+});
+
+test("links FAQ readers only to existing Learn routes and updates the footer label", () => {
+	const learnLinks = [
+		...new Set(
+			[...faq.matchAll(/href="([^"]+)"/gu)]
+				.map((match) => match[1])
+				.filter((href) => href.startsWith("/learn/")),
+		),
+	];
+	assert.deepEqual(learnLinks.sort(), [
+		"/learn/fork/",
+		"/learn/fork/disputes-and-bonds/",
+		"/learn/fork/migration/",
+		"/learn/fork/what-to-do/",
+	].sort());
+	assert.ok(
+		existsSync(path.join(repositoryRoot, "src/content/learn/fork/migration.mdx")),
+	);
+	assert.match(footer, /AUGUR FAQ/u);
+	assert.doesNotMatch(footer, /FORK & MIGRATION FAQ/u);
+});

--- a/scripts/faq.test.ts
+++ b/scripts/faq.test.ts
@@ -12,44 +12,56 @@ const faqItem = read("src/features/faq/item.astro");
 const footer = read("src/components/shell/footer.astro");
 const featureDocumentation = read("docs/faq-feature.md");
 
-const faqAnchorIds = [
-	"what-is-live-today",
-	"is-this-a-trading-interface",
-	"what-is-the-reboot-building",
-	"which-rep-token-is-current",
-	"why-are-there-multiple-rep-contracts",
-	"is-another-rep-migration-required",
-	"what-happened-to-other-rep",
-	"how-do-i-verify-rep",
-	"why-did-the-moon-fork-happen",
-	"is-the-moon-fork-complete",
-	"which-universe-won",
-	"where-is-the-on-chain-evidence",
-	"where-is-the-complete-record",
-	"what-causes-an-augur-fork",
-	"what-is-a-universe",
-	"why-is-rep-migration-irreversible",
+const faqSections = [
+	"Augur Today",
+	"The Moon Fork",
+	"Timeline",
+	"How the Fork Played Out",
+	"Tokens",
+	"Exchanges",
+	"Scams & Safety",
 ];
 
-test("keeps the FAQ general and the Moon Fork subsection historical", () => {
+const faqAnchorIds = [
+	"can-i-use-augur-today",
+	"what-is-the-reboot-building",
+	"i-own-repv2-what-happened",
+	"i-didnt-migrate-in-time-is-there-anything-i-can-do",
+	"why-did-augur-fork",
+	"what-is-a-fork-in-simple-terms",
+	"when-did-the-fork-start-and-end",
+	"what-happened-during-the-escalation-game-phase-1",
+	"what-happened-during-the-migration-window-phase-2",
+	"what-happened-if-someone-migrated-to-the-no-universe",
+	"is-there-a-new-rep-token",
+	"is-augur-on-kraken-the-same-as-repv2-yes-1",
+	"does-the-old-rep-token-still-exist",
+	"the-new-token-doesnt-appear-in-my-wallet-yet-is-something-wrong",
+	"my-rep-was-on-kraken-did-i-need-to-do-anything",
+	"what-about-rep-on-other-exchanges-gate-upbit",
+	"what-happened-to-rep-left-on-an-exchange",
+	"someone-offered-to-migrate-or-recover-my-rep-is-that-real",
+];
+
+test("renders the finalized Augur FAQ without active-migration state", () => {
 	assert.match(faq, /title="Augur FAQ \| Augur"/u);
 	assert.match(faq, /<PageTitle prefix="FAQ" title="AUGUR"/u);
-	assert.match(faq, /<SectionHeading text="Augur Today"/u);
-	assert.match(faq, /<SectionHeading text="REP After the Moon Fork"/u);
-	assert.match(faq, /<SectionHeading text="The Moon Fork"/u);
-	assert.match(faq, /<SectionHeading text="Protocol Questions"/u);
-	assert.match(faq, /archived Moon Fork record/u);
-	assert.doesNotMatch(faq, /question="What is Augur\?"|What is a prediction market\?|Where should I learn more\?|Safety & Participation/u);
-	assert.doesNotMatch(faq, /MigrationCta|isMigrationOpen|migrationOpen/u);
-	assert.doesNotMatch(faq, /Lituus|lituus/u);
-	assert.doesNotMatch(featureDocumentation, /\*\*Lituus\*\*|what-is-lituus|how-does-lituus/u);
+
+	const sections = [...faq.matchAll(/<SectionHeading text="([^"]+)"/gu)].map(
+		(match) => match[1],
+	);
+	assert.deepEqual(sections, faqSections);
 	assert.doesNotMatch(
 		faq,
-		/migration-open|migration window is open|Open now|active migration|must migrate/iu,
+		/MigrationCta|getForkLifecycleAtBuild|isMigrationOpen|migrationOpen|migration-open|must migrate/iu,
+	);
+	assert.doesNotMatch(
+		faq,
+		/question="What is Augur\?"|question="What is a prediction market\?"/u,
 	);
 });
 
-test("uses native disclosure controls with unique, documented question anchors", () => {
+test("uses native disclosure controls with unique, documented anchors", () => {
 	assert.match(faqItem, /<details[^>]*id=\{id\}/u);
 	assert.match(faqItem, /<summary/u);
 	assert.doesNotMatch(faqItem, /client:|<script/u);
@@ -64,21 +76,38 @@ test("uses native disclosure controls with unique, documented question anchors",
 	}
 });
 
-test("links FAQ readers only to existing Learn routes and updates the footer label", () => {
-	const learnLinks = [
-		...new Set(
-			[...faq.matchAll(/href="([^"]+)"/gu)]
-				.map((match) => match[1])
-				.filter((href) => href.startsWith("/learn/")),
-		),
-	];
-	assert.deepEqual(learnLinks.sort(), [
-		"/learn/fork/",
-		"/learn/fork/migration/",
-	].sort());
-	assert.ok(
-		existsSync(path.join(repositoryRoot, "src/content/learn/fork/migration.mdx")),
+test("preserves lazy child-universe creation in reader-facing answers", () => {
+	assert.match(faq, /each child universe was created when REP first migrated to it/u);
+	assert.match(
+		faq,
+		/A child universe and its REP token were created when REP first migrated to that outcome/u,
 	);
+	assert.doesNotMatch(
+		faq,
+		/created a (?:child universe|new REP token) for every possible outcome|created a new REP token for each universe/iu,
+	);
+});
+
+test("keeps finalized FAQ destinations and the combined footer updates", () => {
+	for (const file of [
+		"src/content/learn/fork/index.mdx",
+		"src/pages/mission.astro",
+		"src/pages/team.astro",
+		"src/content/blog/the-augur-fork-is-here/index.mdx",
+		"src/content/blog/phase-1-the-escalation-game/index.mdx",
+		"src/content/blog/phase-2-the-fork-migration/index.mdx",
+	]) {
+		assert.ok(existsSync(path.join(repositoryRoot, file)), `${file} must exist`);
+	}
+
+	assert.match(faq, /https:\/\/v3\.augur\.net\//u);
+	assert.match(faq, /https:\/\/support\.kraken\.com\/articles\/augur-migration/u);
+	assert.match(faq, /REPv2_Yes_1/u);
+	assert.match(faq, /0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D/u);
+
 	assert.match(footer, /AUGUR FAQ/u);
 	assert.doesNotMatch(footer, /FORK & MIGRATION FAQ/u);
+	assert.match(footer, /https:\/\/github\.com\/darkflorist/u);
+	assert.match(footer, /AUGUR V2 WHITEPAPER/u);
+	assert.match(footer, /AUGUR LITUUS WHITEPAPER/u);
 });

--- a/scripts/faq.test.ts
+++ b/scripts/faq.test.ts
@@ -25,8 +25,6 @@ const faqAnchorIds = [
 	"what-was-the-moon-fork",
 	"which-outcome-won-the-moon-fork",
 	"where-is-the-moon-fork-record",
-	"what-is-lituus",
-	"how-does-lituus-relate-to-augur",
 	"how-do-i-verify-a-token",
 	"where-should-i-learn-more",
 ];
@@ -37,6 +35,8 @@ test("keeps the FAQ general and the Moon Fork subsection historical", () => {
 	assert.match(faq, /Moon Fork · Historical Record/u);
 	assert.match(faq, /archived migration record/u);
 	assert.doesNotMatch(faq, /MigrationCta|isMigrationOpen|migrationOpen/u);
+	assert.doesNotMatch(faq, /Lituus|lituus/u);
+	assert.doesNotMatch(featureDocumentation, /\*\*Lituus\*\*|what-is-lituus|how-does-lituus/u);
 	assert.doesNotMatch(
 		faq,
 		/migration-open|migration window is open|Open now|active migration|must migrate/iu,

--- a/scripts/faq.test.ts
+++ b/scripts/faq.test.ts
@@ -13,27 +13,33 @@ const footer = read("src/components/shell/footer.astro");
 const featureDocumentation = read("docs/faq-feature.md");
 
 const faqAnchorIds = [
-	"what-is-augur",
-	"what-is-a-prediction-market",
-	"what-is-rep-used-for",
-	"how-are-markets-resolved",
-	"what-is-a-dispute-bond",
-	"when-does-augur-fork",
-	"what-is-a-fork",
-	"is-rep-migration-reversible",
-	"what-happens-to-unmigrated-rep",
-	"what-was-the-moon-fork",
-	"which-outcome-won-the-moon-fork",
-	"where-is-the-moon-fork-record",
-	"how-do-i-verify-a-token",
-	"where-should-i-learn-more",
+	"what-is-live-today",
+	"is-this-a-trading-interface",
+	"what-is-the-reboot-building",
+	"which-rep-token-is-current",
+	"why-are-there-multiple-rep-contracts",
+	"is-another-rep-migration-required",
+	"what-happened-to-other-rep",
+	"how-do-i-verify-rep",
+	"why-did-the-moon-fork-happen",
+	"is-the-moon-fork-complete",
+	"which-universe-won",
+	"where-is-the-on-chain-evidence",
+	"where-is-the-complete-record",
+	"what-causes-an-augur-fork",
+	"what-is-a-universe",
+	"why-is-rep-migration-irreversible",
 ];
 
 test("keeps the FAQ general and the Moon Fork subsection historical", () => {
 	assert.match(faq, /title="Augur FAQ \| Augur"/u);
 	assert.match(faq, /<PageTitle prefix="FAQ" title="AUGUR"/u);
-	assert.match(faq, /Moon Fork · Historical Record/u);
-	assert.match(faq, /archived migration record/u);
+	assert.match(faq, /<SectionHeading text="Augur Today"/u);
+	assert.match(faq, /<SectionHeading text="REP After the Moon Fork"/u);
+	assert.match(faq, /<SectionHeading text="The Moon Fork"/u);
+	assert.match(faq, /<SectionHeading text="Protocol Questions"/u);
+	assert.match(faq, /archived Moon Fork record/u);
+	assert.doesNotMatch(faq, /question="What is Augur\?"|What is a prediction market\?|Where should I learn more\?|Safety & Participation/u);
 	assert.doesNotMatch(faq, /MigrationCta|isMigrationOpen|migrationOpen/u);
 	assert.doesNotMatch(faq, /Lituus|lituus/u);
 	assert.doesNotMatch(featureDocumentation, /\*\*Lituus\*\*|what-is-lituus|how-does-lituus/u);
@@ -68,9 +74,7 @@ test("links FAQ readers only to existing Learn routes and updates the footer lab
 	];
 	assert.deepEqual(learnLinks.sort(), [
 		"/learn/fork/",
-		"/learn/fork/disputes-and-bonds/",
 		"/learn/fork/migration/",
-		"/learn/fork/what-to-do/",
 	].sort());
 	assert.ok(
 		existsSync(path.join(repositoryRoot, "src/content/learn/fork/migration.mdx")),

--- a/src/components/shell/footer.astro
+++ b/src/components/shell/footer.astro
@@ -100,7 +100,7 @@ import Button from "../ui/button.tsx";
           <ul class="space-y-2">
             <li>
               <Button variant="link" href="/faq">
-                FORK & MIGRATION FAQ
+                AUGUR FAQ
               </Button>
             </li>
             <li>

--- a/src/features/faq/item.astro
+++ b/src/features/faq/item.astro
@@ -1,12 +1,13 @@
 ---
 export interface Props {
+	id?: string;
 	question: string;
 }
 
-const { question } = Astro.props;
+const { id, question } = Astro.props;
 ---
 
-<details class="mb-0.5 group border border-transparent focus-within:border-foreground/50">
+<details id={id} class="mb-0.5 group border border-transparent focus-within:border-foreground/50">
   <summary class="flex items-center gap-3 p-4 cursor-pointer list-none text-xl text-foreground tracking-wider font-display font-light uppercase select-none transition-colors duration-200 rounded outline-none bg-foreground/5">
     <span class="text-muted-foreground shrink-0 transition-colors duration-200 group-open:text-primary group-open:drop-shadow-[0_0_var(--glow-size-sm)_var(--color-primary)]">
       <span class="group-open:hidden">+</span>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,22 +1,23 @@
 ---
-import FaqItem from "../features/faq/item.astro";
 import SectionHeading from "../components/content/section-heading.astro";
+import Footer from "../components/shell/footer.astro";
 import PageHeader from "../components/shell/page-header.tsx";
 import PageTitle from "../components/shell/page-title.astro";
-import Footer from "../components/shell/footer.astro";
+import FaqItem from "../features/faq/item.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout
   title="Augur FAQ | Augur"
-  description="Current answers about the Augur reboot, REP after the Moon Fork, the final fork record, and protocol mechanics."
+  description="Current answers about using Augur today and the completed Moon Fork, including REP tokens, exchanges, and safety."
   keywords={[
     "Augur FAQ",
     "Augur reboot",
     "Augur REP",
     "REPv2_Yes_1",
     "Augur fork",
-    "Moon Fork"
+    "Moon Fork",
+    "REP migration"
   ]}
 >
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
@@ -27,75 +28,111 @@ import Layout from "../layouts/Layout.astro";
         <PageTitle prefix="FAQ" title="AUGUR" class="mb-8" />
 
         <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
-          Current answers about the Augur reboot, REP after the Moon Fork, and the protocol's fork mechanics.
+          Current answers about using Augur today and the completed Moon Fork.
         </p>
 
         <SectionHeading text="Augur Today" />
         <div class="faq-group mb-12">
-          <FaqItem id="what-is-live-today" question="What is live today?">
-            <p>The Augur reboot is active, but a new Augur-native prediction-market application has not yet been relaunched. This site publishes project updates, protocol education, and the verified record of the completed Moon Fork.</p>
-          </FaqItem>
-          <FaqItem id="is-this-a-trading-interface" question="Is this a trading interface?">
-            <p>No. Augur.net is the project's information and monitoring site. It does not create markets, hold funds, or execute trades.</p>
+          <FaqItem id="can-i-use-augur-today" question="Can I use Augur today?">
+            <p>Not as a new Augur-native prediction-market application: one has not yet relaunched. You can use this site to read project updates, inspect the <a href="https://v3.augur.net/" target="_blank" rel="noopener noreferrer">ForkWatch record</a>, and study the <a href="/learn/fork/">Learn material</a>, but Augur.net is not a trading interface and no migration action is available here.</p>
           </FaqItem>
           <FaqItem id="what-is-the-reboot-building" question="What is the reboot building toward?">
             <p>Current work centers on a new oracle architecture, broader REP access, and an eventual Augur-native market protocol after the oracle's security and fee mechanisms are finalized. The <a href="/mission/">mission timeline</a> and <a href="/team/">team page</a> describe that work.</p>
           </FaqItem>
         </div>
 
-        <SectionHeading text="REP After the Moon Fork" />
-        <div class="faq-group mb-12">
-          <FaqItem id="which-rep-token-is-current" question="Which REP token is current?">
-            <p>The winning universe's REP token is <strong>REPv2_Yes_1</strong> at <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank" rel="noopener noreferrer">0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D</a>. The final record identifies it from the winning universe's on-chain contracts.</p>
-          </FaqItem>
-          <FaqItem id="why-are-there-multiple-rep-contracts" question="Why are there multiple REP contracts?">
-            <p>The Moon Fork created a child universe—and a distinct REP token—for every possible outcome. Token names and tickers alone are therefore not enough to identify the winning REP contract.</p>
-          </FaqItem>
-          <FaqItem id="is-another-rep-migration-required" question="Is another REP migration required?">
-            <p>No further migration has been announced. The Moon Fork migration window closed on August 3, 2026. The archived migration page is retained only as a historical record.</p>
-          </FaqItem>
-          <FaqItem id="what-happened-to-other-rep" question="What happened to REP in the other universes?">
-            <p>REP migration was one-way. REP left in the parent universe was locked from new markets and staking, while REP in losing child universes remained separate from the winning universe's current REP token.</p>
-          </FaqItem>
-          <FaqItem id="how-do-i-verify-rep" question="How do I verify the correct REP contract?">
-            <p>Compare the full contract address—not only the token symbol—with the <a href="/learn/fork/migration/">final Moon Fork record</a>, then inspect that address on a block explorer such as Etherscan.</p>
-          </FaqItem>
-        </div>
-
         <SectionHeading text="The Moon Fork" />
         <div class="faq-group mb-12">
-          <FaqItem id="why-did-the-moon-fork-happen" question="Why did the Moon Fork happen?">
-            <p>A dispute over the Artemis II liftoff market reached Augur's fork threshold. That activated the protocol's last-resort process for resolving the market through REP migration.</p>
+          <FaqItem id="i-own-repv2-what-happened" question="I own REPv2. What happened?">
+            <p>Micah Zoltu, an Augur community member, raised funds to trigger a fork over whether the Artemis II mission successfully lifted off (it did). The fork opened a path to an outcome-specific universe for each possible outcome; each child universe was created when REP first migrated to it. REP holders had until the migration deadline to move their tokens into the universe they believed was correct. That window has closed.</p>
+            <p><strong>Learn more:</strong></p>
+            <ul>
+              <li><a href="/blog/the-augur-fork-is-here/">The Augur Fork is Here</a></li>
+              <li><a href="/blog/phase-1-the-escalation-game/">Phase 1: The Escalation Game</a></li>
+              <li><a href="/blog/phase-2-the-fork-migration/">Phase 2: The Fork Migration</a></li>
+            </ul>
           </FaqItem>
-          <FaqItem id="is-the-moon-fork-complete" question="Is the Moon Fork complete?">
-            <p>Yes. The migration deadline passed on August 3, 2026, the forking market finalized, and the winning universe is recorded on Ethereum.</p>
+          <FaqItem id="i-didnt-migrate-in-time-is-there-anything-i-can-do" question="I didn't migrate in time. Is there anything I can do?">
+            <p>No. The deadline was enforced by the fork contract rather than by policy, so it cannot be reopened or extended, and no one can migrate on your behalf. REP left in the parent universe is expected to be worthless, since Augur development continues on the forked token, REPv2_Yes_1, instead.</p>
+            <p>Anyone offering to migrate, recover, or unlock that REP now is running a scam.</p>
           </FaqItem>
-          <FaqItem id="which-universe-won" question="Which universe won?">
-            <p>The <strong>Yes</strong> universe won. The finalized record identifies outcome index 1 and its on-chain REP symbol, <strong>REPv2_Yes_1</strong>.</p>
+          <FaqItem id="why-did-augur-fork" question="Why did Augur fork?">
+            <p>Forks are part of Augur's design. They happen when there is a major dispute — in this case, over the outcome of the Artemis II market.</p>
           </FaqItem>
-          <FaqItem id="where-is-the-on-chain-evidence" question="Where is the on-chain evidence?">
-            <p>The <a href="/data/fork-risk.json">published fork record</a> contains the observed block, winning universe, deadline, and migration totals. The result was reproduced through independent Ethereum RPC providers at the same pinned block.</p>
-          </FaqItem>
-          <FaqItem id="where-is-the-complete-record" question="Where is the complete historical record?">
-            <p>The <a href="/learn/fork/migration/">archived Moon Fork record</a> preserves the procedure, screenshots, and token distinctions. It is historical evidence, not current migration guidance.</p>
+          <FaqItem id="what-is-a-fork-in-simple-terms" question={`What is a "fork" in simple terms?`}>
+            <p>The system can split into multiple versions, called universes. Holders choose the correct one by moving their REP into it.</p>
           </FaqItem>
         </div>
 
-        <SectionHeading text="Protocol Questions" />
+        <SectionHeading text="Timeline" />
         <div class="faq-group mb-12">
-          <FaqItem id="what-causes-an-augur-fork" question="What causes an Augur fork?">
-            <p>A fork begins when a dispute bond reaches 2.5% of all theoretical REP. In Augur's genesis universe, that threshold was 275,000 REP.</p>
-          </FaqItem>
-          <FaqItem id="what-is-a-universe" question="What is a universe?">
-            <p>A universe is a version of Augur with its own markets and REP token. A fork creates one child universe for every possible outcome of the disputed market, including Invalid.</p>
-          </FaqItem>
-          <FaqItem id="why-is-rep-migration-irreversible" question="Why is REP migration irreversible?">
-            <p>Migration is how REP holders commit to one outcome universe. Allowing REP to move back or between sibling universes would let the same stake support conflicting outcomes.</p>
+          <FaqItem id="when-did-the-fork-start-and-end" question="When did the fork start and end?">
+            <p><strong>Start:</strong> April 8, 2026</p>
+            <p><strong>Escalation Game (Phase 1):</strong> April–early June 2026. Complete.</p>
+            <p><strong>Migration Window (Phase 2):</strong> early June–August 3, 2026. Complete.</p>
           </FaqItem>
         </div>
 
-        <div class="border-t border-foreground/20 pt-8">
-          <p>For the full explanation, follow the <a href="/learn/fork/">Fork learning path</a>.</p>
+        <SectionHeading text="How the Fork Played Out" />
+        <div class="faq-group mb-12">
+          <FaqItem id="what-happened-during-the-escalation-game-phase-1" question="What happened during the escalation game (Phase 1)?">
+            <p>People could dispute outcomes by staking REP in an escalation game, where each round required a larger stake on opposing sides. If they backed the correct outcome, they could earn a return from those on the losing side (up to ~40% in this test). Participation was optional.</p>
+            <p>Phase 1 is complete: enough REP was staked to reach the fork threshold.</p>
+          </FaqItem>
+          <FaqItem id="what-happened-during-the-migration-window-phase-2" question="What happened during the migration window (Phase 2)?">
+            <p>REP holders could migrate their tokens 1:1 into the outcome-specific universe they believed was correct. A child universe and its REP token were created when REP first migrated to that outcome. Migrated REP went overwhelmingly to the universe for the truthful outcome, whose token is REPv2_Yes_1.</p>
+          </FaqItem>
+          <FaqItem id="what-happened-if-someone-migrated-to-the-no-universe" question={`What happened if someone migrated to the "No" universe?`}>
+            <p>That REP is expected to be worthless. Augur's next iteration will not be built in that universe, so there will be no activity there.</p>
+          </FaqItem>
+        </div>
+
+        <SectionHeading text="Tokens" />
+        <div class="faq-group mb-12">
+          <FaqItem id="is-there-a-new-rep-token" question="Is there a new REP token?">
+            <p>Yes. The fork made a distinct REP token possible for each outcome; a token was created with its child universe when REP first migrated to that outcome. Holders received the token of the universe they migrated to, 1:1.</p>
+            <p>Augur development continues on <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank" rel="noopener noreferrer">REPv2_Yes_1</a>, the token for the truthful outcome. The Lituus Foundation has migrated its own holdings and added liquidity. It trades as <a href="https://pro.kraken.com/app/trade/AUGUR-USD" target="_blank" rel="noopener noreferrer">AUGUR on Kraken</a> and on <a href="https://app.uniswap.org/explore/tokens/ethereum/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank" rel="noopener noreferrer">Uniswap</a>.</p>
+          </FaqItem>
+          <FaqItem id="is-augur-on-kraken-the-same-as-repv2-yes-1" question={`Is "AUGUR" on Kraken the same as REPv2_Yes_1?`}>
+            <p>Yes. REPv2_Yes_1 is the token's on-chain name, used on Uniswap and <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank" rel="noopener noreferrer">Etherscan</a>; Kraken lists that same token under the ticker AUGUR.</p>
+          </FaqItem>
+          <FaqItem id="does-the-old-rep-token-still-exist" question="Does the old REP token still exist?">
+            <p>Yes, but it is not expected to have value or use going forward.</p>
+          </FaqItem>
+          <FaqItem id="the-new-token-doesnt-appear-in-my-wallet-yet-is-something-wrong" question="The new token doesn't appear in my wallet yet. Is something wrong?">
+            <p>Usually nothing is wrong. The forked token is new, so many wallets don't detect it automatically yet. We are in contact with platforms and wallets to add support. Most wallets also let you add a token manually via an “import token” or “add custom token” feature — use the REPv2_Yes_1 contract address 0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D.</p>
+            <p>To confirm your balance independently, look up your address on <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank" rel="noopener noreferrer">Etherscan</a>.</p>
+          </FaqItem>
+        </div>
+
+        <SectionHeading text="Exchanges" />
+        <div class="faq-group mb-12">
+          <FaqItem id="my-rep-was-on-kraken-did-i-need-to-do-anything" question="My REP was on Kraken. Did I need to do anything?">
+            <p>No. Kraken supported the fork and migrated REP on behalf of its users, converting balances 1:1 into the new token, which it lists as <a href="https://pro.kraken.com/app/trade/AUGUR-USD" target="_blank" rel="noopener noreferrer">AUGUR</a>.</p>
+            <p><strong><a href="https://support.kraken.com/articles/augur-migration" target="_blank" rel="noopener noreferrer">→ Read Kraken's full migration notice</a></strong></p>
+          </FaqItem>
+          <FaqItem id="what-about-rep-on-other-exchanges-gate-upbit" question="What about REP on other exchanges (Gate, Upbit)?">
+            <p>Exchange support varied, and not every exchange migrated on behalf of its users. The safest route was to withdraw REP to a self-custodied wallet and migrate directly. If you held REP on an exchange through the fork and have not seen the new token credited, contact that exchange.</p>
+            <p><strong><a href="https://v3.augur.net/#exchange-support" target="_blank" rel="noopener noreferrer">→ Check which exchanges supported the migration</a></strong></p>
+          </FaqItem>
+          <FaqItem id="what-happened-to-rep-left-on-an-exchange" question="What happened to REP left on an exchange?">
+            <p>If the exchange did not support the migration, its holders may be left with a worthless version of REP.</p>
+            <p><strong><a href="https://v3.augur.net/#exchange-support" target="_blank" rel="noopener noreferrer">→ See whether your exchange supported the migration</a></strong></p>
+          </FaqItem>
+        </div>
+
+        <SectionHeading text="Scams & Safety" />
+        <div class="faq-group mb-12">
+          <FaqItem id="someone-offered-to-migrate-or-recover-my-rep-is-that-real" question="Someone offered to migrate or recover my REP. Is that real?">
+            <p>No. Migration closed in early August 2026 and cannot be reopened, so any site, DM, or “support agent” offering to migrate, recover, or unlock REP is a scam.</p>
+            <p>Nobody from Augur or the Lituus Foundation will DM you first, and no legitimate process will ever ask for your seed phrase or private keys, or ask you to sign a transaction to “verify” your holdings.</p>
+          </FaqItem>
+        </div>
+
+        <div class="mt-8 border-foreground/10 text-foreground">
+          <p class="mb-3">Still have questions? Come find us in the community:</p>
+          <p class="mb-1">→ <a class="text-loud-foreground" href="https://discord.gg/Y3tCZsSmz3" target="_blank" rel="noopener noreferrer">Join the Discord</a></p>
+          <p>→ Follow <a class="text-loud-foreground" href="https://x.com/AugurProject" target="_blank" rel="noopener noreferrer">@AugurProject</a> on X</p>
         </div>
       </div>
     </main>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,22 +1,21 @@
 ---
+import FaqItem from "../features/faq/item.astro";
 import SectionHeading from "../components/content/section-heading.astro";
-import Footer from "../components/shell/footer.astro";
 import PageHeader from "../components/shell/page-header.tsx";
 import PageTitle from "../components/shell/page-title.astro";
-import FaqItem from "../features/faq/item.astro";
+import Footer from "../components/shell/footer.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout
   title="Augur FAQ | Augur"
-  description="Concise answers about Augur prediction markets, reporting, REP, forks, and the completed Moon Fork."
+  description="Current answers about the Augur reboot, REP after the Moon Fork, the final fork record, and protocol mechanics."
   keywords={[
     "Augur FAQ",
-    "prediction markets",
+    "Augur reboot",
     "Augur REP",
-    "Augur reporting",
-    "Augur disputes",
-    "Augur forks",
+    "REPv2_Yes_1",
+    "Augur fork",
     "Moon Fork"
   ]}
 >
@@ -28,79 +27,75 @@ import Layout from "../layouts/Layout.astro";
         <PageTitle prefix="FAQ" title="AUGUR" class="mb-8" />
 
         <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
-          Short answers about Augur markets, reporting, REP, forks, and the completed Moon Fork.
-          Use <a href="/learn/fork/">Learn</a> for deeper explanations and the archived
-          <a href="/learn/fork/migration/">Moon Fork migration record</a> for historical procedure.
+          Current answers about the Augur reboot, REP after the Moon Fork, and the protocol's fork mechanics.
         </p>
 
-        <SectionHeading text="Augur Basics" />
+        <SectionHeading text="Augur Today" />
         <div class="faq-group mb-12">
-          <FaqItem id="what-is-augur" question="What is Augur?">
-            <p>Augur is a decentralized prediction-market platform and oracle on Ethereum. People create markets about real-world events, trade outcome shares, and report which outcomes occurred.</p>
+          <FaqItem id="what-is-live-today" question="What is live today?">
+            <p>The Augur reboot is active, but a new Augur-native prediction-market application has not yet been relaunched. This site publishes project updates, protocol education, and the verified record of the completed Moon Fork.</p>
           </FaqItem>
-          <FaqItem id="what-is-a-prediction-market" question="What is a prediction market?">
-            <p>A market lists possible outcomes for an event. Participants trade shares tied to those outcomes; after reporting and disputes, a finalized market settles according to its final outcome.</p>
+          <FaqItem id="is-this-a-trading-interface" question="Is this a trading interface?">
+            <p>No. Augur.net is the project's information and monitoring site. It does not create markets, hold funds, or execute trades.</p>
           </FaqItem>
-          <FaqItem id="what-is-rep-used-for" question="What is REP used for?">
-            <p>REP is Augur's reputation token. In Augur v2 it is used for reporting, disputing, and staking—not for trading. Traders use DAI for market positions.</p>
+          <FaqItem id="what-is-the-reboot-building" question="What is the reboot building toward?">
+            <p>Current work centers on a new oracle architecture, broader REP access, and an eventual Augur-native market protocol after the oracle's security and fee mechanisms are finalized. The <a href="/mission/">mission timeline</a> and <a href="/team/">team page</a> describe that work.</p>
           </FaqItem>
         </div>
 
-        <SectionHeading text="Markets & Reporting" />
+        <SectionHeading text="REP After the Moon Fork" />
         <div class="faq-group mb-12">
-          <FaqItem id="how-are-markets-resolved" question="How are Augur markets resolved?">
-            <p>After an event, a designated reporter can submit an initial report. If that does not happen, reporting opens to other REP holders. Dispute rounds can challenge the tentative outcome before the market finalizes.</p>
-            <p><strong><a href="/learn/fork/disputes-and-bonds/">Learn how reporting disputes and bonds work</a>.</strong></p>
+          <FaqItem id="which-rep-token-is-current" question="Which REP token is current?">
+            <p>The winning universe's REP token is <strong>REPv2_Yes_1</strong> at <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank" rel="noopener noreferrer">0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D</a>. The final record identifies it from the winning universe's on-chain contracts.</p>
           </FaqItem>
-          <FaqItem id="what-is-a-dispute-bond" question="What is a dispute bond?">
-            <p>A dispute bond is REP committed to challenge a tentative outcome. Bonds can be funded by multiple participants and escalate as disagreement continues; a successful dispute replaces the tentative outcome.</p>
+          <FaqItem id="why-are-there-multiple-rep-contracts" question="Why are there multiple REP contracts?">
+            <p>The Moon Fork created a child universe—and a distinct REP token—for every possible outcome. Token names and tickers alone are therefore not enough to identify the winning REP contract.</p>
           </FaqItem>
-          <FaqItem id="when-does-augur-fork" question="When does Augur fork?">
-            <p>A fork begins when a dispute bond reaches at least 2.5% of all theoretical REP. In the genesis universe, that threshold is 275,000 REP. A fork is Augur's resolution method of last resort.</p>
-            <p><strong><a href="/learn/fork/">Read the fork overview in Learn</a>.</strong></p>
+          <FaqItem id="is-another-rep-migration-required" question="Is another REP migration required?">
+            <p>No further migration has been announced. The Moon Fork migration window closed on August 3, 2026. The archived migration page is retained only as a historical record.</p>
+          </FaqItem>
+          <FaqItem id="what-happened-to-other-rep" question="What happened to REP in the other universes?">
+            <p>REP migration was one-way. REP left in the parent universe was locked from new markets and staking, while REP in losing child universes remained separate from the winning universe's current REP token.</p>
+          </FaqItem>
+          <FaqItem id="how-do-i-verify-rep" question="How do I verify the correct REP contract?">
+            <p>Compare the full contract address—not only the token symbol—with the <a href="/learn/fork/migration/">final Moon Fork record</a>, then inspect that address on a block explorer such as Etherscan.</p>
           </FaqItem>
         </div>
 
-        <SectionHeading text="Forks & REP" />
+        <SectionHeading text="The Moon Fork" />
         <div class="faq-group mb-12">
-          <FaqItem id="what-is-a-fork" question="What is an Augur fork?">
-            <p>A fork creates a child universe for each possible outcome, including Invalid. REP holders choose a universe by migrating REP; the child with the most migrated REP wins, and the parent universe is locked for new markets and staking.</p>
+          <FaqItem id="why-did-the-moon-fork-happen" question="Why did the Moon Fork happen?">
+            <p>A dispute over the Artemis II liftoff market reached Augur's fork threshold. That activated the protocol's last-resort process for resolving the market through REP migration.</p>
           </FaqItem>
-          <FaqItem id="is-rep-migration-reversible" question="Is REP migration reversible?">
-            <p>No. Migration is one-way, and tokens in sibling universes are separate. The general fork mechanics are explained in <a href="/learn/fork/">Learn</a>.</p>
+          <FaqItem id="is-the-moon-fork-complete" question="Is the Moon Fork complete?">
+            <p>Yes. The migration deadline passed on August 3, 2026, the forking market finalized, and the winning universe is recorded on Ethereum.</p>
           </FaqItem>
-          <FaqItem id="what-happens-to-unmigrated-rep" question="What happens to REP left in the parent universe?">
-            <p>After Augur v2's fork period, REP left in the parent universe is permanently locked and expected to lose value. This is protocol history, not a current action notice.</p>
+          <FaqItem id="which-universe-won" question="Which universe won?">
+            <p>The <strong>Yes</strong> universe won. The finalized record identifies outcome index 1 and its on-chain REP symbol, <strong>REPv2_Yes_1</strong>.</p>
+          </FaqItem>
+          <FaqItem id="where-is-the-on-chain-evidence" question="Where is the on-chain evidence?">
+            <p>The <a href="/data/fork-risk.json">published fork record</a> contains the observed block, winning universe, deadline, and migration totals. The result was reproduced through independent Ethereum RPC providers at the same pinned block.</p>
+          </FaqItem>
+          <FaqItem id="where-is-the-complete-record" question="Where is the complete historical record?">
+            <p>The <a href="/learn/fork/migration/">archived Moon Fork record</a> preserves the procedure, screenshots, and token distinctions. It is historical evidence, not current migration guidance.</p>
           </FaqItem>
         </div>
 
-        <SectionHeading text="Moon Fork · Historical Record" />
+        <SectionHeading text="Protocol Questions" />
         <div class="faq-group mb-12">
-          <FaqItem id="what-was-the-moon-fork" question="What was the Moon Fork?">
-            <p>The Moon Fork was Augur v2's completed fork over the Artemis II liftoff market. It is preserved as a historical case, separate from general fork education and the archived migration procedure.</p>
+          <FaqItem id="what-causes-an-augur-fork" question="What causes an Augur fork?">
+            <p>A fork begins when a dispute bond reaches 2.5% of all theoretical REP. In Augur's genesis universe, that threshold was 275,000 REP.</p>
           </FaqItem>
-          <FaqItem id="which-outcome-won-the-moon-fork" question="Which outcome won, and what is the recorded REP token?">
-            <p>The finalized Ethereum mainnet record identifies outcome index 1, <strong>Yes</strong>, as the winner. It identifies <strong>REPv2_Yes_1</strong> at <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank" rel="noopener noreferrer">0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D</a> as the winning universe's REP token.</p>
+          <FaqItem id="what-is-a-universe" question="What is a universe?">
+            <p>A universe is a version of Augur with its own markets and REP token. A fork creates one child universe for every possible outcome of the disputed market, including Invalid.</p>
           </FaqItem>
-          <FaqItem id="where-is-the-moon-fork-record" question="Where can I read the Moon Fork record?">
-            <p>The <a href="/learn/fork/migration/">archived migration record</a> preserves the historical procedure, screenshots, and token distinctions. It is available for reference and is not current migration guidance.</p>
+          <FaqItem id="why-is-rep-migration-irreversible" question="Why is REP migration irreversible?">
+            <p>Migration is how REP holders commit to one outcome universe. Allowing REP to move back or between sibling universes would let the same stake support conflicting outcomes.</p>
           </FaqItem>
         </div>
 
-        <SectionHeading text="Safety & Participation" />
-        <div class="faq-group mb-12">
-          <FaqItem id="how-do-i-verify-a-token" question="How do I verify a REP token?">
-            <p>Check the chain and contract address, not just a ticker symbol. For Moon Fork identities, compare the address with the finalized record and verify it on a block explorer such as <a href="https://etherscan.io/" target="_blank" rel="noopener noreferrer">Etherscan</a>.</p>
-          </FaqItem>
-          <FaqItem id="where-should-i-learn-more" question="Where should I learn more?">
-            <p>Start with the <a href="/learn/fork/">Fork topic</a>, then read <a href="/learn/fork/disputes-and-bonds/">disputes and bonds</a> or the <a href="/learn/fork/what-to-do/">evergreen fork-risk guide</a>. The <a href="/learn/fork/migration/">Moon Fork migration page</a> is a historical record.</p>
-          </FaqItem>
-        </div>
-
-        <div class="mt-8 border-foreground/10 text-foreground">
-          <p class="mb-3">Still have questions? Come find us in the community:</p>
-          <p class="mb-1">→ <a class="text-loud-foreground" href="https://discord.gg/Y3tCZsSmz3" target="_blank" rel="noopener noreferrer">Join the Discord</a></p>
-          <p>→ Follow <a class="text-loud-foreground" href="https://x.com/AugurProject" target="_blank" rel="noopener noreferrer">@AugurProject</a> on X</p>
+        <div class="border-t border-foreground/20 pt-8">
+          <p>For the full explanation, follow the <a href="/learn/fork/">Fork learning path</a>.</p>
         </div>
       </div>
     </main>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -9,7 +9,7 @@ import Layout from "../layouts/Layout.astro";
 
 <Layout
   title="Augur FAQ | Augur"
-  description="Concise answers about Augur prediction markets, reporting, REP, forks, Lituus, and the completed Moon Fork."
+  description="Concise answers about Augur prediction markets, reporting, REP, forks, and the completed Moon Fork."
   keywords={[
     "Augur FAQ",
     "prediction markets",
@@ -17,8 +17,7 @@ import Layout from "../layouts/Layout.astro";
     "Augur reporting",
     "Augur disputes",
     "Augur forks",
-    "Moon Fork",
-    "Lituus oracle"
+    "Moon Fork"
   ]}
 >
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
@@ -29,7 +28,7 @@ import Layout from "../layouts/Layout.astro";
         <PageTitle prefix="FAQ" title="AUGUR" class="mb-8" />
 
         <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
-          Short answers about Augur markets, reporting, REP, forks, Lituus, and the completed Moon Fork.
+          Short answers about Augur markets, reporting, REP, forks, and the completed Moon Fork.
           Use <a href="/learn/fork/">Learn</a> for deeper explanations and the archived
           <a href="/learn/fork/migration/">Moon Fork migration record</a> for historical procedure.
         </p>
@@ -85,16 +84,6 @@ import Layout from "../layouts/Layout.astro";
           </FaqItem>
           <FaqItem id="where-is-the-moon-fork-record" question="Where can I read the Moon Fork record?">
             <p>The <a href="/learn/fork/migration/">archived migration record</a> preserves the historical procedure, screenshots, and token distinctions. It is available for reference and is not current migration guidance.</p>
-          </FaqItem>
-        </div>
-
-        <SectionHeading text="Lituus" />
-        <div class="faq-group mb-12">
-          <FaqItem id="what-is-lituus" question="What is Lituus?">
-            <p>Lituus is a standalone decentralized oracle, not a prediction-market platform. It publishes outcomes for other protocols that need decentralized resolution.</p>
-          </FaqItem>
-          <FaqItem id="how-does-lituus-relate-to-augur" question="How does Lituus relate to Augur?">
-            <p>Lituus generalizes the oracle in Augur v2 into standalone infrastructure and redesigns parts of its reporting, fee, and fork mechanisms. They are distinct protocol designs.</p>
           </FaqItem>
         </div>
 

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -4,182 +4,118 @@ import Footer from "../components/shell/footer.astro";
 import PageHeader from "../components/shell/page-header.tsx";
 import PageTitle from "../components/shell/page-title.astro";
 import FaqItem from "../features/faq/item.astro";
-import MigrationCta from "../features/learn/migration-cta.tsx";
 import Layout from "../layouts/Layout.astro";
-import { getForkLifecycleAtBuild, isMigrationOpen } from "../lib/fork-data";
-
-const forkLifecycle = getForkLifecycleAtBuild();
-const migrationOpen = isMigrationOpen(forkLifecycle.state);
-const faqIntro = (() => {
-	switch (forkLifecycle.state) {
-		case "migration-closed-resolved":
-		case "migration-closed-unverified":
-			return "Augur's first algorithmic fork is now complete. This page explains what happened, what it means for REP holders, and where the token stands now.";
-		case "data-unavailable":
-			return "Current fork status is temporarily unavailable. This page remains available as an educational reference.";
-		case "monitoring":
-			return "There is no active migration window at this time. This page explains Augur's fork and migration process.";
-		default:
-			return "This page explains Augur's fork and migration process.";
-	}
-})();
 ---
 
 <Layout
-  title="FAQ — Fork & Migration | Augur"
-  description="What happened in Augur's first algorithmic fork, what it means for REP holders, and where the token stands now."
+  title="Augur FAQ | Augur"
+  description="Concise answers about Augur prediction markets, reporting, REP, forks, Lituus, and the completed Moon Fork."
   keywords={[
-    "augur fork",
-    "REP migration",
-    "augur FAQ",
-    "REP token fork",
-    "augur universe",
-    "REP holder",
-    "fork migration",
-    "augur reboot"
+    "Augur FAQ",
+    "prediction markets",
+    "Augur REP",
+    "Augur reporting",
+    "Augur disputes",
+    "Augur forks",
+    "Moon Fork",
+    "Lituus oracle"
   ]}
 >
   <div class="grid grid-rows-[auto_1fr_auto] min-h-screen">
-    <!-- Top Section: Navigation -->
     <PageHeader client:load backHref="/" />
 
-    <!-- Middle Section: Content -->
     <main class="overflow-y-auto px-4 md:px-8 pt-8 mb-12">
       <div class="max-w-3xl mx-auto">
+        <PageTitle prefix="FAQ" title="AUGUR" class="mb-8" />
 
-        <!-- Title -->
-        <PageTitle prefix="FAQ" title="FORK & MIGRATION" class="mb-8" />
+        <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
+          Short answers about Augur markets, reporting, REP, forks, Lituus, and the completed Moon Fork.
+          Use <a href="/learn/fork/">Learn</a> for deeper explanations and the archived
+          <a href="/learn/fork/migration/">Moon Fork migration record</a> for historical procedure.
+        </p>
 
-        <!-- IMAGE SLOT: Task 5 will insert the hero image here -->
-
-        <!-- Intro -->
-        {migrationOpen ? (
-          <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
-            Augur is going through its first algorithmic fork. If you own REP, you must act —
-            <span class="text-loud-foreground"> failing to migrate your tokens within the window
-            will likely render them worthless.</span>
-            This page answers the most important questions.
-          </p>
-        ) : (
-          <p class="text-center normal-case leading-tight text-foreground mb-12 mx-auto max-w-xl">
-            {faqIntro}
-          </p>
-        )}
-
-        {migrationOpen && (
-          <MigrationCta
-            className="mb-12"
-            eyebrow="CRITICAL · MIGRATION IMMINENT"
-            title="Your REP is worthless if you don't migrate"
-            description="The full procedure — wallet, token contracts, signing order — before the migration deadline."
-          />
-        )}
-
-        <!-- WHAT HAPPENED -->
-        <SectionHeading text="What happened?" />
+        <SectionHeading text="Augur Basics" />
         <div class="faq-group mb-12">
-          <FaqItem question="I OWN REPV2. WHAT HAPPENED?">
-              <p>Micah Zoltu, an Augur community member, raised funds to trigger a fork over whether the Artemis II mission successfully lifted off (it did). The fork split Augur into universes, one for each outcome. REP holders had until the migration deadline to move their tokens into the universe they believed was correct. That window has closed.</p>
-              <p><strong>Learn more:</strong></p>
-              <ul>
-                <li><a href="/blog/the-augur-fork-is-here/" target="_blank">The Augur Fork is Here</a></li>
-                <li><a href="/blog/phase-1-the-escalation-game/" target="_blank">Phase 1: The Escalation Game</a></li>
-                <li><a href="/blog/phase-2-the-fork-migration/" target="_blank">Phase 2: The Fork Migration</a></li>
-              </ul>
-            </FaqItem>
-          <FaqItem question="I DIDN'T MIGRATE IN TIME. IS THERE ANYTHING I CAN DO?">
-              <p>No. The deadline was enforced by the fork contract rather than by policy, so it cannot be reopened or extended, and no one can migrate on your behalf. REP left in the parent universe is expected to be worthless, since Augur development continues on the forked token, REPv2_Yes_1, instead.</p>
-              <p>Anyone offering to migrate, recover, or unlock that REP now is running a scam.</p>
-            </FaqItem>
-          <FaqItem question="WHY DID AUGUR FORK?">
-              <p>Forks are part of Augur's design. They happen when there is a major dispute — in this case, over the outcome of the Artemis II market.</p>
-            </FaqItem>
-          <FaqItem question={`WHAT IS A "FORK" IN SIMPLE TERMS?`}>
-              <p>The system splits into multiple versions (called universes). Holders choose the correct one by moving their REP into it.</p>
-            </FaqItem>
+          <FaqItem id="what-is-augur" question="What is Augur?">
+            <p>Augur is a decentralized prediction-market platform and oracle on Ethereum. People create markets about real-world events, trade outcome shares, and report which outcomes occurred.</p>
+          </FaqItem>
+          <FaqItem id="what-is-a-prediction-market" question="What is a prediction market?">
+            <p>A market lists possible outcomes for an event. Participants trade shares tied to those outcomes; after reporting and disputes, a finalized market settles according to its final outcome.</p>
+          </FaqItem>
+          <FaqItem id="what-is-rep-used-for" question="What is REP used for?">
+            <p>REP is Augur's reputation token. In Augur v2 it is used for reporting, disputing, and staking—not for trading. Traders use DAI for market positions.</p>
+          </FaqItem>
         </div>
 
-        <!-- TIMELINE -->
-        <SectionHeading text="Timeline" />
+        <SectionHeading text="Markets & Reporting" />
         <div class="faq-group mb-12">
-          <FaqItem question="WHEN DID THE FORK START AND END?">
-              <p><strong>Start:</strong> April 8, 2026</p>
-              <p><strong>Escalation Game (Phase 1):</strong> April - early June. Complete.</p>
-              <p><strong>Migration Window (Phase 2):</strong> early June - early August 2026. Complete.</p>
-            </FaqItem>
+          <FaqItem id="how-are-markets-resolved" question="How are Augur markets resolved?">
+            <p>After an event, a designated reporter can submit an initial report. If that does not happen, reporting opens to other REP holders. Dispute rounds can challenge the tentative outcome before the market finalizes.</p>
+            <p><strong><a href="/learn/fork/disputes-and-bonds/">Learn how reporting disputes and bonds work</a>.</strong></p>
+          </FaqItem>
+          <FaqItem id="what-is-a-dispute-bond" question="What is a dispute bond?">
+            <p>A dispute bond is REP committed to challenge a tentative outcome. Bonds can be funded by multiple participants and escalate as disagreement continues; a successful dispute replaces the tentative outcome.</p>
+          </FaqItem>
+          <FaqItem id="when-does-augur-fork" question="When does Augur fork?">
+            <p>A fork begins when a dispute bond reaches at least 2.5% of all theoretical REP. In the genesis universe, that threshold is 275,000 REP. A fork is Augur's resolution method of last resort.</p>
+            <p><strong><a href="/learn/fork/">Read the fork overview in Learn</a>.</strong></p>
+          </FaqItem>
         </div>
 
-        <!-- HOW IT PLAYED OUT -->
-        <SectionHeading text="How the fork played out" />
+        <SectionHeading text="Forks & REP" />
         <div class="faq-group mb-12">
-          <FaqItem question="WHAT HAPPENED DURING THE ESCALATION GAME (PHASE 1)?">
-              <p>People could dispute outcomes by staking REP in an escalation game, where each round requires a larger stake on opposing sides. If they backed the correct outcome, they could earn a return from those on the losing side (up to ~40% in this test). Participation was optional.</p>
-              <p>Phase 1 is complete: enough REP was staked to reach the fork threshold.</p>
-            </FaqItem>
-          <FaqItem question="WHAT HAPPENED DURING THE MIGRATION WINDOW (PHASE 2)?">
-              <p>The fork split Augur into multiple universes, one for each outcome. REP holders could migrate their tokens 1:1 to the universe they believed was correct, receiving the new token for that universe. Migrated REP went overwhelmingly to the universe for the truthful outcome, whose token is REPv2_Yes_1.</p>
-            </FaqItem>
-          <FaqItem question={`WHAT HAPPENED IF SOMEONE MIGRATED TO THE "NO" UNIVERSE?`}>
-              <p>That REP is expected to be worthless. Augur's next iteration will not be built in that universe, so there will be no activity there.</p>
-            </FaqItem>
+          <FaqItem id="what-is-a-fork" question="What is an Augur fork?">
+            <p>A fork creates a child universe for each possible outcome, including Invalid. REP holders choose a universe by migrating REP; the child with the most migrated REP wins, and the parent universe is locked for new markets and staking.</p>
+          </FaqItem>
+          <FaqItem id="is-rep-migration-reversible" question="Is REP migration reversible?">
+            <p>No. Migration is one-way, and tokens in sibling universes are separate. The general fork mechanics are explained in <a href="/learn/fork/">Learn</a>.</p>
+          </FaqItem>
+          <FaqItem id="what-happens-to-unmigrated-rep" question="What happens to REP left in the parent universe?">
+            <p>After Augur v2's fork period, REP left in the parent universe is permanently locked and expected to lose value. This is protocol history, not a current action notice.</p>
+          </FaqItem>
         </div>
 
-        <!-- TOKENS -->
-        <SectionHeading text="Tokens" />
+        <SectionHeading text="Moon Fork · Historical Record" />
         <div class="faq-group mb-12">
-          <FaqItem question="IS THERE A NEW REP TOKEN?">
-              <p>Yes. The fork created a new REP token for each universe; holders received the token of the universe they migrated to, 1:1.</p>
-              <p>Augur development continues on <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank">REPv2_Yes_1</a>, the token for the truthful outcome. The Lituus Foundation has migrated its own holdings and added liquidity. It trades as <a href="https://pro.kraken.com/app/trade/AUGUR-USD" target="_blank">AUGUR on Kraken</a> and on <a href="https://app.uniswap.org/explore/tokens/ethereum/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank">Uniswap</a>.</p>
-            </FaqItem>
-          <FaqItem question={`IS "AUGUR" ON KRAKEN THE SAME AS REPV2_YES_1?`}>
-              <p>Yes. REPv2_Yes_1 is the token's on-chain name, used on Uniswap and <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank">Etherscan</a>; Kraken lists that same token under the ticker AUGUR.</p>
-            </FaqItem>
-          <FaqItem question="DOES THE OLD REP TOKEN STILL EXIST?">
-              <p>Yes, but it is not expected to have value or use going forward.</p>
-            </FaqItem>
-          <FaqItem question="THE NEW TOKEN DOESN'T APPEAR IN MY WALLET YET. IS SOMETHING WRONG?">
-              <p>Usually nothing is wrong. The forked token is new, so many wallets don't detect it automatically yet. We are in contact with platforms and wallets to add support. Most wallets also let you add a token manually via an "import token" or "add custom token" feature — use the REPv2_Yes_1 contract address 0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D.</p>
-              <p>To confirm your balance independently, look up your address on <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank">Etherscan</a>.</p>
-            </FaqItem>
+          <FaqItem id="what-was-the-moon-fork" question="What was the Moon Fork?">
+            <p>The Moon Fork was Augur v2's completed fork over the Artemis II liftoff market. It is preserved as a historical case, separate from general fork education and the archived migration procedure.</p>
+          </FaqItem>
+          <FaqItem id="which-outcome-won-the-moon-fork" question="Which outcome won, and what is the recorded REP token?">
+            <p>The finalized Ethereum mainnet record identifies outcome index 1, <strong>Yes</strong>, as the winner. It identifies <strong>REPv2_Yes_1</strong> at <a href="https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D" target="_blank" rel="noopener noreferrer">0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D</a> as the winning universe's REP token.</p>
+          </FaqItem>
+          <FaqItem id="where-is-the-moon-fork-record" question="Where can I read the Moon Fork record?">
+            <p>The <a href="/learn/fork/migration/">archived migration record</a> preserves the historical procedure, screenshots, and token distinctions. It is available for reference and is not current migration guidance.</p>
+          </FaqItem>
         </div>
 
-        <!-- EXCHANGES -->
-        <SectionHeading text="Exchanges" />
+        <SectionHeading text="Lituus" />
         <div class="faq-group mb-12">
-          <FaqItem question="MY REP WAS ON KRAKEN. DID I NEED TO DO ANYTHING?">
-              <p>No. Kraken supported the fork and migrated REP on behalf of its users, converting balances 1:1 into the new token, which it lists as <a href="https://pro.kraken.com/app/trade/AUGUR-USD" target="_blank">AUGUR</a>.</p>
-              <p><strong><a href="https://support.kraken.com/articles/augur-migration" target="_blank">→ Read Kraken's full migration notice</a></strong></p>
-            </FaqItem>
-          <FaqItem question="WHAT ABOUT REP ON OTHER EXCHANGES (GATE, UPBIT)?">
-              <p>Exchange support varied, and not every exchange migrated on behalf of its users. The safest route was to withdraw REP to a self-custodied wallet and migrate directly. If you held REP on an exchange through the fork and have not seen the new token credited, contact that exchange.</p>
-              <p><strong><a href="https://v3.augur.net/#exchange-support" target="_blank">→ Check which exchanges supported the migration</a></strong></p>
-            </FaqItem>
-          <FaqItem question="WHAT HAPPENED TO REP LEFT ON AN EXCHANGE?">
-              <p>If the exchange did not support the migration, its holders may be left with a worthless version of REP.</p>
-              <p><strong><a href="https://v3.augur.net/#exchange-support" target="_blank">→ See whether your exchange supported the migration</a></strong></p>
-            </FaqItem>
+          <FaqItem id="what-is-lituus" question="What is Lituus?">
+            <p>Lituus is a standalone decentralized oracle, not a prediction-market platform. It publishes outcomes for other protocols that need decentralized resolution.</p>
+          </FaqItem>
+          <FaqItem id="how-does-lituus-relate-to-augur" question="How does Lituus relate to Augur?">
+            <p>Lituus generalizes the oracle in Augur v2 into standalone infrastructure and redesigns parts of its reporting, fee, and fork mechanisms. They are distinct protocol designs.</p>
+          </FaqItem>
         </div>
 
-        <!-- SCAMS & SAFETY -->
-        <SectionHeading text="Scams & Safety" />
+        <SectionHeading text="Safety & Participation" />
         <div class="faq-group mb-12">
-          <FaqItem question="SOMEONE OFFERED TO MIGRATE OR RECOVER MY REP. IS THAT REAL?">
-              <p>No. Migration closed in early August 2026 and cannot be reopened, so any site, DM, or "support agent" offering to migrate, recover, or unlock REP is a scam.</p>
-              <p>Nobody from Augur or the Lituus Foundation will DM you first, and no legitimate process will ever ask for your seed phrase or private keys, or ask you to sign a transaction to "verify" your holdings.</p>
-            </FaqItem>
+          <FaqItem id="how-do-i-verify-a-token" question="How do I verify a REP token?">
+            <p>Check the chain and contract address, not just a ticker symbol. For Moon Fork identities, compare the address with the finalized record and verify it on a block explorer such as <a href="https://etherscan.io/" target="_blank" rel="noopener noreferrer">Etherscan</a>.</p>
+          </FaqItem>
+          <FaqItem id="where-should-i-learn-more" question="Where should I learn more?">
+            <p>Start with the <a href="/learn/fork/">Fork topic</a>, then read <a href="/learn/fork/disputes-and-bonds/">disputes and bonds</a> or the <a href="/learn/fork/what-to-do/">evergreen fork-risk guide</a>. The <a href="/learn/fork/migration/">Moon Fork migration page</a> is a historical record.</p>
+          </FaqItem>
         </div>
 
-        <!-- Closing -->
         <div class="mt-8 border-foreground/10 text-foreground">
           <p class="mb-3">Still have questions? Come find us in the community:</p>
-          <p class="mb-1">→ <a class="text-loud-foreground" href="https://discord.gg/Y3tCZsSmz3" target="_blank">Join the Discord</a></p>
-          <p>→ Follow <a class="text-loud-foreground" href="https://x.com/AugurProject" target="_blank">@AugurProject</a> on X</p>
+          <p class="mb-1">→ <a class="text-loud-foreground" href="https://discord.gg/Y3tCZsSmz3" target="_blank" rel="noopener noreferrer">Join the Discord</a></p>
+          <p>→ Follow <a class="text-loud-foreground" href="https://x.com/AugurProject" target="_blank" rel="noopener noreferrer">@AugurProject</a> on X</p>
         </div>
-
       </div>
     </main>
 
-    <!-- Bottom Section: Footer -->
     <Footer />
   </div>
 </Layout>


### PR DESCRIPTION
## Summary

- Publishes the finalized 18-question `/faq` across seven sections: Augur Today, The Moon Fork, Timeline, How the Fork Played Out, Tokens, Exchanges, and Scams & Safety.
- Answers current visitor questions while preserving the completed Moon Fork as historical context rather than an active migration event.
- Clarifies `REPv2_Yes_1`, Kraken's `AUGUR` ticker, wallet visibility, exchange handling, and post-deadline scam risks.
- Preserves native `<details>/<summary>` disclosures and adds 18 documented, stable question anchors.
- Removes lifecycle-dependent FAQ copy and the active migration CTA while retaining the combined post-fork footer updates from #164.
- Describes child universes and their REP tokens as lazily created when migration first targets an outcome.

Closes #153

## Acceptance evidence

- [x] `/faq` is recognizably a general Augur FAQ, beginning with what visitors can use today and what the reboot is building toward.
- [x] Answers are concise and point to existing Learn, blog, ForkWatch, exchange, and block-explorer references for deeper material.
- [x] Completed Moon Fork material is grouped into clearly historical sections covering the event, timeline, outcome, tokens, and exchanges.
- [x] No answer suggests migration remains open, and no active migration CTA or lifecycle-dependent copy remains.
- [x] All 18 question anchors are unique and documented in `docs/faq-feature.md`; deep links scroll to native disclosure items without forcing them open.
- [x] Reader-facing fork answers preserve lazy child-universe creation.
- [x] The footer label is `AUGUR FAQ`, and #164's Dark Florist and whitepaper-link corrections remain intact.
- [x] No Learn lesson or migration content was changed.

## Verification

- `npm run test:faq` — 4 tests passed
- `npm run typecheck`
- `npm run typecheck:scripts`
- `npm run lint`
- `npm run build`
- `npm run build:gh-pages`
- `git diff --check`

A fresh ordered integration check with the current heads of #163, #162, and #161 also passed the Learn model, evergreen Fork, migration archive, FAQ, fork-lifecycle, and blog-lint test suites; both typechecks; lint; and both build modes after retaining each PR's test script during the expected `package.json` conflict resolutions.
