### PR TITLE
feat: make the Fork learning path evergreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"test:blog-lint": "node --experimental-strip-types --test scripts/blog-lint/*.test.ts",
 		"test:fork-lifecycle": "node --experimental-strip-types --test scripts/fork-lifecycle.test.ts",
 		"test:learn-model": "node --experimental-strip-types --test scripts/learn-model.test.ts",
+		"test:evergreen-fork": "node --experimental-strip-types --test scripts/evergreen-fork.test.ts",
 		"typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
 		"preview": "astro build && wrangler dev",
 		"astro": "astro",

--- a/scripts/evergreen-fork.test.ts
+++ b/scripts/evergreen-fork.test.ts
@@ -203,6 +203,14 @@ test("connects evergreen lessons without importing live-event or Moon Fork facts
 	assert.doesNotMatch(evergreen, /MigrationCta|isMigrationOpen|MIGRATION IMMINENT|Migrate your REP before/iu);
 	assert.doesNotMatch(evergreen, /REPv2_Yes_1|0x[0-9a-f]{40}|Artemis II|June 11/iu);
 	assert.match(mechanics, /Current-action boundary/u);
+	assert.match(
+		mechanics,
+		/A child universe is created only when REP is migrated to that outcome/u,
+	);
+	assert.doesNotMatch(
+		mechanics,
+		/When the fork starts, Augur creates one child universe for each possible outcome/u,
+	);
 	assert.match(preparedness, /not a live migration checklist/u);
 });
 

--- a/scripts/evergreen-fork.test.ts
+++ b/scripts/evergreen-fork.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import {
+	getLearnEntryPath,
+	getLearnNavigation,
+	type LearnEntryLike,
+	type LearnMetadata,
+} from "../src/lib/learn.ts";
+
+const forkContentDir = fileURLToPath(
+	new URL("../src/content/learn/fork/", import.meta.url),
+);
+
+const expectedEntries = [
+	{
+		file: "index.mdx",
+		slug: "fork/index",
+		order: 1,
+		contentType: "topic",
+		label: "WHAT IS A FORK?",
+		historical: false,
+		status: "available",
+	},
+	{
+		file: "disputes-and-bonds.mdx",
+		slug: "fork/disputes-and-bonds",
+		order: 2,
+		contentType: "lesson",
+		label: "HOW DISPUTES & BONDS WORK",
+		historical: false,
+		status: "available",
+	},
+	{
+		file: "migration-mechanics.mdx",
+		slug: "fork/migration-mechanics",
+		order: 3,
+		contentType: "lesson",
+		label: "HOW FORK MIGRATION WORKS",
+		historical: false,
+		status: "available",
+	},
+	{
+		file: "what-to-do.mdx",
+		slug: "fork/what-to-do",
+		order: 4,
+		contentType: "guide",
+		label: "WHAT TO DO AROUND FORK RISK",
+		historical: false,
+		status: "available",
+	},
+	{
+		file: "migration.mdx",
+		slug: "fork/migration",
+		order: 6,
+		contentType: "historical-record",
+		label: "MOON FORK MIGRATION RECORD",
+		historical: true,
+		status: "archived",
+	},
+] as const;
+
+function readFrontmatter(file: string): Record<string, string | boolean | number> {
+	const content = readFileSync(`${forkContentDir}/${file}`, "utf8");
+	const match = content.match(/^---\n([\s\S]*?)\n---/u);
+	assert.ok(match, `${file} must have frontmatter`);
+
+	return Object.fromEntries(
+		match[1].split("\n").map((line) => {
+			const separator = line.indexOf(":");
+			assert.notEqual(separator, -1, `Invalid frontmatter line in ${file}: ${line}`);
+			const key = line.slice(0, separator);
+			const rawValue = line.slice(separator + 1).trim();
+			const value = rawValue.replace(/^(['"])(.*)\1$/u, "$2");
+
+			if (value === "true" || value === "false") {
+				return [key, value === "true"];
+			}
+			if (/^\d+$/u.test(value)) {
+				return [key, Number(value)];
+			}
+			return [key, value];
+		}),
+	);
+}
+
+function readContent(file: string): string {
+	return readFileSync(`${forkContentDir}/${file}`, "utf8");
+}
+
+test("defines the ordered evergreen Fork sequence and preserves the archive URL", () => {
+	const entries: LearnEntryLike[] = expectedEntries.map((expected) => ({
+		slug: expected.slug,
+		data: readFrontmatter(expected.file) as unknown as LearnMetadata,
+	}));
+
+	assert.deepEqual(
+		entries.map(({ slug, data }) => ({
+			slug,
+			order: data.order,
+			contentType: data.contentType,
+			label: data.label,
+			historical: data.historical,
+			status: data.status,
+		})),
+		expectedEntries.map(({ slug, order, contentType, label, historical, status }) => ({
+			slug,
+			order,
+			contentType,
+			label,
+			historical,
+			status,
+		})),
+	);
+
+	assert.deepEqual(
+		getLearnNavigation(entries, "fork").map(({ label, path, order, contentType, historical, status }) => ({
+			label,
+			path,
+			order,
+			contentType,
+			historical,
+			status,
+		})),
+		[
+			{
+				label: "WHAT IS A FORK?",
+				path: "/learn/fork/",
+				order: 1,
+				contentType: "topic",
+				historical: false,
+				status: "available",
+			},
+			{
+				label: "HOW DISPUTES & BONDS WORK",
+				path: "/learn/fork/disputes-and-bonds/",
+				order: 2,
+				contentType: "lesson",
+				historical: false,
+				status: "available",
+			},
+			{
+				label: "HOW FORK MIGRATION WORKS",
+				path: "/learn/fork/migration-mechanics/",
+				order: 3,
+				contentType: "lesson",
+				historical: false,
+				status: "available",
+			},
+			{
+				label: "WHAT TO DO AROUND FORK RISK",
+				path: "/learn/fork/what-to-do/",
+				order: 4,
+				contentType: "guide",
+				historical: false,
+				status: "available",
+			},
+			{
+				label: "MOON FORK MIGRATION RECORD",
+				path: "/learn/fork/migration/",
+				order: 6,
+				contentType: "historical-record",
+				historical: true,
+				status: "archived",
+			},
+		],
+	);
+
+	for (const entry of expectedEntries) {
+		assert.ok(existsSync(`${forkContentDir}/${entry.file}`), `${entry.file} must remain present`);
+		assert.equal(getLearnEntryPath(entry.slug), `/learn/${entry.slug.replace(/\/index$/u, "")}/`);
+	}
+});
+
+test("uses declarative presentation metadata for evergreen and archived entries", () => {
+	for (const expected of expectedEntries) {
+		const metadata = readFrontmatter(expected.file);
+
+		assert.equal(metadata.topic, "fork");
+		assert.equal(
+			metadata.presentation,
+			expected.historical ? "historical-record" : "standard",
+		);
+	}
+});
+
+test("connects evergreen lessons without importing live-event or Moon Fork facts", () => {
+	const index = readContent("index.mdx");
+	const disputes = readContent("disputes-and-bonds.mdx");
+	const mechanics = readContent("migration-mechanics.mdx");
+	const preparedness = readContent("what-to-do.mdx");
+	const evergreen = [index, disputes, mechanics, preparedness].join("\n");
+
+	assert.match(index, /disputes-and-bonds/u);
+	assert.match(index, /migration-mechanics/u);
+	assert.match(index, /what-to-do/u);
+	assert.match(disputes, /migration-mechanics/u);
+	assert.match(mechanics, /what-to-do/u);
+	assert.match(preparedness, /migration-mechanics/u);
+	assert.match(preparedness, /historical migration record/u);
+
+	assert.doesNotMatch(evergreen, /MigrationCta|isMigrationOpen|MIGRATION IMMINENT|Migrate your REP before/iu);
+	assert.doesNotMatch(evergreen, /REPv2_Yes_1|0x[0-9a-f]{40}|Artemis II|June 11/iu);
+	assert.match(mechanics, /Current-action boundary/u);
+	assert.match(preparedness, /not a live migration checklist/u);
+});
+
+test("anchors protocol education to maintained and pinned evidence", () => {
+	const content = readContent("migration-mechanics.mdx");
+
+	assert.match(content, /augur-v2-whitepaper-summary|augur-v2-protocol-glossary/u);
+	assert.match(content, /Universe\.sol/u);
+	assert.match(content, /ReputationToken\.sol/u);
+	assert.match(content, /bd13a797016b373834e9414096c6086f35aa628f/u);
+});

--- a/src/content/learn/fork/disputes-and-bonds.mdx
+++ b/src/content/learn/fork/disputes-and-bonds.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How Disputes & Bonds Work"
-description: "Understand dispute escalation, bond mechanics, and how fork risk is calculated."
+description: "Learn how Augur v2 dispute rounds escalate and how the fork monitor measures progress."
 topic: fork
 order: 2
 contentType: lesson
@@ -14,153 +14,64 @@ import ProseCard from '../../../components/content/prose-card.astro'
 
 # How Disputes & Bonds Work
 
-Disputes are the core mechanism that makes Augur work. When people disagree about an outcome, they challenge each other using bonds—financial commitments that keep everyone honest.
+A fork is the end of an escalation path, not the first response to disagreement. Augur first gives reporters and REP holders a sequence of reporting and dispute rounds in which a tentative outcome can be challenged.
 
-## A Real-World Example
+## From report to dispute
 
-Imagine a market asks: **"Will BTC reach $100,000 in 2025?"**
+After a market's event ends, a designated reporter has an initial reporting window. If the market receives a report, that outcome becomes tentative. A REP holder can challenge it by staking REP on a different outcome during a dispute round.
 
-1. **Reporter A** says YES and locks up REP as their report bond
-2. **Reporter B** disagrees and says NO—they lock up 2x the initial bond amount to dispute
-3. **Reporter C** thinks B is wrong and says YES again—they lock up 2x B's bond (4x initial)
-4. This continues escalating until everyone agrees... or the bond reaches 275,000 REP and a fork is triggered
+The first dispute round can last up to 24 hours. Subsequent dispute rounds can last up to seven days. The exact market state and timing come from the protocol; a dispute is not by itself evidence that a fork is imminent.
 
-## What is a Dispute Bond?
+## The bond formula
 
-A dispute bond is REP (Augur's governance token) that you must lock up to challenge an outcome. It serves three purposes:
+For dispute round *n*, the bond required to dispute in favor of outcome *ω* is:
 
-1. **Skin in the game:** Disputers must risk their own capital to challenge outcomes
-2. **Spam prevention:** High bond amounts deter frivolous disputes
-3. **Fair resolution:** If your dispute is correct, you get your bond back plus a fee
+> **B(ω, n) = 2A<sub>n</sub> − 3S(ω, n)**
 
-## The Dispute Process Step-by-Step
+Where *A<sub>n</sub>* is the total stake across all outcomes at the beginning of the round and *S(ω, n)* is the stake on the proposed outcome at that point. The formula means the target is not a simple fixed multiple of the previous bond. Bond sizes depend on the market's stake distribution.
 
-```
-┌─────────────────────────────┐         ┌─────────────────────────────┐
-│  STEP 1: Initial Report     │         │  STEP 2: First Dispute      │
-│                             │         │                             │
-│  Reporter submits outcome   │────────▶│  Someone disagrees          │
-│  Example: "YES"             │         │  Posts 2x initial bond      │
-│  Locks up initial bond      │         │  Submits: "NO"              │
-└─────────────────────────────┘         │  If no further dispute →    │
-                                        │  Market settles             │
-                                        └────────────┬────────────────┘
-                                                     ↓
-┌─────────────────────────────┐         ┌─────────────────────────────┐
-│  STEP 4: Fork Trigger       │         │  STEP 3: Escalation         │
-│                             │         │                             │
-│  Bond reaches 275,000 REP   │◀────────│  Another disputes back      │
-│  Instead of continuing,     │         │  Posts 2x previous bond     │
-│  FORK IS TRIGGERED          │         │  Submits: "YES"             │
-│                             │         │  Process repeats...         │
-│  → 60-day fork period       │         │  Bonds keep doubling        │
-│  → REP holders govern       │         └─────────────────────────────┘
-└─────────────────────────────┘
-```
+Bonds are crowdsourced: several users can contribute to the same dispute. A dispute succeeds when an outcome other than the tentative outcome accumulates enough stake to fill its bond.
 
-## Bond Escalation Example
+## What happens after a successful dispute?
 
-Here's how bonds grow with each dispute round:
+The filled bond's size, measured against all theoretical REP, determines the next state:
 
 <ProseCard>
-| Round | Bond Size | Risk Level |
-|-------|-----------|-----------|
-| 1st Dispute | 1,000 REP | Low |
-| 2nd Dispute | 2,000 REP | Low |
-| 3rd Dispute | 4,000 REP | Medium |
-| 4th Dispute | 8,000 REP | High |
-| 5th+ Disputes | 16,000+ REP | Extreme |
-
-*Actual bond amounts vary based on protocol parameters, but the doubling pattern is consistent.*
+| Filled dispute bond | Protocol result |
+|---|---|
+| Less than 0.02% of theoretical REP | The new tentative outcome enters another dispute round immediately. |
+| At least 0.02% but less than 2.5% | The new tentative outcome enters a waiting-for-window phase before another dispute round. |
+| At least 2.5% | The market enters the fork state. |
 </ProseCard>
 
-## Why 275,000 REP?
+The 2.5% threshold is a proportion of theoretical REP, not a promise that every deployment uses the genesis-universe number. In the genesis universe, the maintained reference calculates 2.5% of 11,000,000 REP as 275,000 REP.
 
-The 275,000 REP threshold was chosen as a balance:
+## Outcomes for participants
 
-<ProseCard>
-- **ACCESSIBILITY:** Low enough that disputes can escalate naturally
-- **SAFETY:** High enough that only serious, well-funded disputes trigger forks
-- **GOVERNANCE:** Ensures protocol-level disagreements go to REP holders to choose
-</ProseCard>
+During a dispute round, stake is held in escrow. Unsuccessful dispute stake is returned when the round ends. When a market finalizes without a fork, stake on an incorrect outcome is forfeited: the protocol burns 20% and redistributes the remainder to REP staked on the final outcome. The bond design targets a 40% return for successful disputers.
 
-## Bond Economics: Winning and Losing
+These are protocol incentive rules, not financial advice or a forecast of any individual result.
 
-<ProseCard>
-| OUTCOME | WHAT HAPPENS TO YOUR BOND |
-|---------|--------------------------|
-| **Your Dispute Is Correct** | **You get your bond back + a fee**<br/>The fee is additional REP awarded for being right |
-| **Your Dispute Is Incorrect** | **You lose your bond**<br/>It gets redistributed to winning disputers or the protocol |
-</ProseCard>
+## How to read fork progress
 
-## How Fork Risk is Calculated
-
-The fork meter tracks the dispute's progress through the escalation path:
+The site's monitor uses the funded dispute round and the observed bond trajectory:
 
 <ProseCard class="text-center">
-(Current Round ÷ Estimated Total Rounds) × 100 = Fork Risk %
+**(Current funded dispute round ÷ Estimated total rounds) × 100 = Round progress**
 </ProseCard>
 
-### Understanding the Formula
+- **Current funded dispute round** is the highest non-zero dispute participant observed for the market.
+- **Estimated total rounds** is projected from recent bond growth until the configured fork threshold would be reached.
+- **Round progress** is a measurement of escalation, not a probability of a fork and not a claim about the correct outcome.
 
-**Current Round**: The highest dispute round that has been funded so far. Each round corresponds to a crowdsourcer — when someone fills the bond for round 3, the dispute is at round 3.
+If there are too few rounds or the trajectory cannot support a defensible projection, the monitor preserves an unknown value rather than inventing precision.
 
-**Estimated Total Rounds**: Projected from the bond growth trajectory. Since bonds grow exponentially each round, the script extrapolates how many more rounds it would take before the bond reaches the 275,000 REP fork threshold.
+## Why this leads to migration mechanics
 
-### Two Calculation Examples
+If a successfully filled bond reaches the fork threshold, Augur creates child universes and REP holders can make a one-way choice among them. That process is separate from ordinary dispute participation.
 
-<ProseCard>
-**EXAMPLE 1: LOW RISK**
+Continue with **[How Fork Migration Works →](/learn/fork/migration-mechanics/)**. For future-oriented preparation rather than live instructions, read **[What To Do Around Fork Risk →](/learn/fork/what-to-do/)**.
 
-Current dispute round: **3**
-Estimated total rounds: **~12**
+## Protocol basis
 
-(3 ÷ 12) × 100 = **25% risk**
-
-*Interpretation: Early rounds. Bonds are still small relative to the fork threshold. Many more escalations needed before a fork is possible.*
-</ProseCard>
-
-<ProseCard>
-**EXAMPLE 2: HIGH RISK**
-
-Current dispute round: **9**
-Estimated total rounds: **~12**
-
-(9 ÷ 12) × 100 = **75% risk**
-
-*Interpretation: Late-stage dispute. Only a few more rounds of escalation remain before the bond would reach the fork threshold.*
-</ProseCard>
-
-## What Happens When Fork Conditions Are Met?
-
-Once a dispute bond reaches or exceeds 275,000 REP:
-
-<ProseCard>
-- **FORK PERIOD:** A 60-day window begins for REP holders to migrate their REP
-- **MARKETS FREEZE:** No new trades on disputed markets
-- **REP MIGRATION:** You choose which fork version you support
-- **WINNING FORK:** The fork with the most REP support becomes canonical
-- **RESOLUTION:** Markets settle according to the winning fork's outcomes
-</ProseCard>
-
-## Strategic Considerations
-
-### For Dispute Participants
-- High-conviction disputes are only worth posting if you're confident you'll win
-- Later dispute rounds become prohibitively expensive for casual participants
-- High-stakes disputes push the system toward fork, affecting all markets
-
-### For Market Users
-- Monitor disputes if your outcome is challenged
-- Disputed markets settle slower than undisputed ones
-- High-risk markets might not settle until after a fork resolves
-
-## Key Takeaways
-
-- **Disputes escalate:** Each new dispute doubles the bond size (approximately)
-- **Forks are triggered mechanically:** When the dispute bond hits 275,000 REP
-- **Risk is measurable:** The meter tracks how far through the escalation path the dispute has progressed
-- **Escalation is expensive:** High-stakes disputes require serious financial commitment
-- **Fork is ultimate resolution:** When community disagreement is severe, REP holders decide
-
-[Next: What To Do at Different Risk Levels →](/learn/fork/what-to-do)
+The thresholds, bond formula, dispute windows, and incentive descriptions follow the [Augur v2 whitepaper preserved by this project](https://github.com/AugurProject/augur-reboot-website/blob/main/docs/raw/augur-whitepaper-v2.pdf) and its maintained protocol glossary. The fork-state and migration behavior are implemented in the pinned [`Universe.sol`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/Universe.sol) and [`ReputationToken.sol`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/ReputationToken.sol).

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "What is a Fork?"
-description: "Learn about Augur protocol forks, how they work, and why fork risk matters."
+title: "What Is a Fork?"
+description: "An evergreen introduction to Augur v2 fork mechanics, dispute escalation, and preparedness."
 topic: fork
 order: 1
 contentType: topic
@@ -11,83 +11,76 @@ presentation: standard
 ---
 
 import ProseCard from '../../../components/content/prose-card.astro'
-import MigrationCta from '../../../features/learn/migration-cta.tsx'
-import { getForkLifecycleAtBuild, isMigrationOpen } from '../../../lib/fork-data'
 
-export const migrationOpen = isMigrationOpen(getForkLifecycleAtBuild().state)
+# What Is a Fork?
 
-{migrationOpen && (
-  <MigrationCta
-    className="not-prose mb-8"
-    eyebrow="CRITICAL · MIGRATION IMMINENT"
-    title="Migrate your REP before the deadline"
-    description="Unmigrated REP will be left in a dead universe. Follow the step-by-step guide to move it safely."
-  />
-)}
+A fork is Augur's resolution method of last resort. It begins when a market disagreement survives the ordinary reporting and dispute process and a dispute bond reaches the protocol's fork threshold. The protocol then creates child universes so REP holders can commit to the outcome they believe is correct.
 
-> **New to Augur?** This guide assumes some familiarity with prediction markets. If you're completely new, start with Augur basics first.
+This page is evergreen protocol education. It does not announce a live fork, set a migration deadline, or tell anyone to move REP.
 
-# What is a Fork?
+> **New to this topic?** This path assumes a basic familiarity with prediction markets and Augur's reporting cycle. It starts with the fork trigger, then explains disputes, general migration mechanics, preparedness, and the boundary between protocol education and historical event material.
 
-**TL;DR** — A fork is Augur's emergency mechanism when the community can't agree on an outcome. It's rare, but important to monitor.
+## Learning outcomes
 
-A fork happens when a severe disagreement about an outcome escalates through the dispute system. When disputes get expensive and serious enough (bond reaches 275,000 REP), the protocol splits into two branches and REP holders choose which version is correct.
+By the end of this path, you should be able to:
 
-## Key Terms
+- distinguish an initial report, a dispute, and a fork;
+- explain why dispute bonds escalate and what the fork threshold means;
+- describe one-way REP migration without treating it as a current action;
+- read the site's fork monitor as a measurement of protocol state, not a probability forecast; and
+- separate reusable mechanics from facts about the completed Moon Fork.
+
+## The Fork learning path
+
+The lessons are ordered so each one supplies context for the next:
+
+1. **[What Is a Fork?](/learn/fork/)** — the trigger, lifecycle, and vocabulary.
+2. **[How Disputes & Bonds Work](/learn/fork/disputes-and-bonds/)** — the escalation mechanism that can lead to a fork.
+3. **[How Fork Migration Works](/learn/fork/migration-mechanics/)** — general child-universe and migration mechanics.
+4. **[What To Do Around Fork Risk](/learn/fork/what-to-do/)** — preparedness for a possible future fork, not an active-event checklist.
+5. A separate Moon Fork case study records what happened in that named event. Its dates, addresses, totals, and outcome are not protocol rules.
+6. **[Moon Fork Migration Record](/learn/fork/migration/)** — the existing historical procedure, retained for research and troubleshooting rather than current instructions.
+
+## Key terms
 
 <ProseCard>
-**REP** — Augur's governance token. Used to report outcomes and settle disputes.
+**REP** — Augur v2's reputation token. It is used in reporting and disputes; it is not the currency used to trade market shares.
 
-**Dispute** — A challenge to an outcome. When someone disagrees with the current outcome, they post a bond to dispute it.
+**Tentative outcome** — The outcome currently proposed by the reporting process. It can change when a dispute succeeds.
 
-**Bond** — REP locked up to challenge an outcome. Bonds grow larger with each dispute round.
+**Dispute bond** — The protocol-calculated amount of REP that must be filled to successfully dispute a tentative outcome. A bond can be crowdsourced by multiple participants.
 
-**Fork Threshold** — 275,000 REP. When the largest active dispute bond hits this amount, a fork is triggered.
+**Universe** — An Augur protocol context containing markets and a REP token. A fork creates a child universe for each possible outcome, including Invalid.
+
+**Theoretical REP** — The supply basis used by the protocol for percentage thresholds. The genesis-universe reference is 11,000,000 REP, so 2.5% is 275,000 REP; a live deployment's configured value is authoritative.
 </ProseCard>
 
-## Why Forks Matter
+## What the monitor means
 
-Forks are Augur's ultimate security mechanism. They ensure that:
-
-- **No single entity controls outcomes** — Disputes can always be escalated to the community
-- **REP holders govern** — When serious disagreements arise, the community chooses what's correct
-- **Bad actors face consequences** — Invalid outcomes get rejected by the network
-
-## How to Monitor Fork Risk
-
-The fork meter tracks **how far through the escalation path the largest dispute has progressed**:
+The fork monitor measures progress through an observed dispute escalation path:
 
 <ProseCard class="text-center">
-The Formula
-
-**(Current Dispute Round ÷ Estimated Total Rounds) × 100 = Risk %**
+**(Current funded dispute round ÷ Estimated total rounds) × 100 = Round progress**
 </ProseCard>
 
-The percentage tells you how far along the path to a fork the dispute has reached:
+The estimate is derived from the observed bond trajectory. It is a display signal for how far escalation has progressed; it is not a probability that a fork will happen, a judgment about which outcome is true, or evidence that migration is open.
 
-<ProseCard>
-| LEVEL | RANGE | WHAT IT MEANS |
-|-------|-------|--------------|
-| NO RISK | 0% | No disputes. Normal trading. |
-| LOW | &lt;25% | Early dispute rounds. Fork unlikely. |
-| MODERATE | 25-50% | Mid-escalation. Monitor closely. |
-| HIGH | 50-75% | Late-stage dispute. Fork possible. |
-| CRITICAL | ≥75% | Approaching fork threshold. |
-</ProseCard>
+## Fork lifecycle in brief
 
-## What Happens If a Fork Occurs
+1. **A dispute reaches the threshold.** A successfully filled dispute bond of at least 2.5% of theoretical REP puts the market into the fork state. The 275,000 REP figure is the genesis-universe reference, not a universal substitute for the deployed protocol value.
+2. **Child universes are created.** There is one child for each possible outcome of the forking market, including Invalid.
+3. **The parent universe is locked.** No new markets or REP staking begin there. Disputes in other non-finalized markets are put on hold, although trading can continue and those markets cannot finalize until the fork period ends.
+4. **REP can be migrated once.** Holders choose a child universe, and that choice cannot be reversed or moved to a sibling universe. The fork period lasts up to 60 days under the Augur v2 reference mechanics.
+5. **The fork resolves.** The child receiving the most migrated REP by the end of the forking period becomes the winning universe, and its corresponding outcome becomes the forking market's final outcome.
+6. **The result becomes historical protocol state.** Non-finalized markets can continue only in the winning universe. Event-specific addresses, totals, deadlines, and observations belong in a case study or historical record, not in this lesson.
 
-When a fork is triggered:
+## Continue
 
-1. **Fork period starts** — 60 days for REP holders to choose
-2. **Markets freeze** — No new trades on disputed markets
-3. **You choose a fork** — Migrate your REP to the branch you believe is correct
-4. **Community chooses** — Most REP wins; that fork becomes the new Augur
-5. **Markets settle** — According to the winning fork's outcomes
+- Continue to **[How Disputes & Bonds Work →](/learn/fork/disputes-and-bonds/)**.
+- Then read **[How Fork Migration Works →](/learn/fork/migration-mechanics/)** for the general mechanics.
+- Use **[What To Do Around Fork Risk →](/learn/fork/what-to-do/)** for future-oriented preparation.
+- The **[Moon Fork Migration Record](/learn/fork/migration/)** is preserved at its existing URL as historical material.
 
-## Learn More
+## Protocol basis
 
-Ready to dive deeper? Here's what you should know:
-
-- **[How Disputes & Bonds Work](/learn/fork/disputes-and-bonds)** — Understand dispute escalation and why bonds matter
-- **[What To Do at Different Risk Levels](/learn/fork/what-to-do)** — Practical actions for each risk level
+This explanation follows the maintained Augur v2 reference and the version-controlled implementation: the [Augur v2 whitepaper preserved by this project](https://github.com/AugurProject/augur-reboot-website/blob/main/docs/raw/augur-whitepaper-v2.pdf), [`Universe.sol`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/Universe.sol), and [`ReputationToken.sol`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/ReputationToken.sol).

--- a/src/content/learn/fork/migration-mechanics.mdx
+++ b/src/content/learn/fork/migration-mechanics.mdx
@@ -24,7 +24,7 @@ A live protocol value is authoritative for its own threshold and deadline. The o
 
 ## Child universes
 
-When the fork starts, Augur creates one child universe for each possible outcome of the forking market, including Invalid. The parent universe is permanently locked for new markets and REP staking. Disputes in other non-finalized markets are paused until the fork period ends; existing markets can continue trading, but they cannot finalize during that period.
+When the fork starts, each possible outcome of the forking market, including Invalid, becomes a potential child universe. A child universe is created only when REP is migrated to that outcome, so outcomes with no migration may never have a child universe. The parent universe is permanently locked for new markets and REP staking. Disputes in other non-finalized markets are paused until the fork period ends; existing markets can continue trading, but they cannot finalize during that period.
 
 Each child universe has its own version of REP. The choice of child is therefore also a choice of which outcome's REP universe to support.
 

--- a/src/content/learn/fork/migration-mechanics.mdx
+++ b/src/content/learn/fork/migration-mechanics.mdx
@@ -1,0 +1,58 @@
+---
+title: "How Fork Migration Works"
+description: "Understand Augur v2 child universes, one-way REP migration, and fork resolution in general."
+topic: fork
+order: 3
+contentType: lesson
+label: "HOW FORK MIGRATION WORKS"
+historical: false
+status: available
+presentation: standard
+---
+
+import ProseCard from '../../../components/content/prose-card.astro'
+
+# How Fork Migration Works
+
+Fork migration is a protocol mechanism for choosing among competing outcomes. It is not a routine software upgrade and it is not a vote that can be changed later. This lesson describes the general Augur v2 mechanics; it does not provide instructions for a current event.
+
+## What starts migration?
+
+Migration becomes relevant only after a market dispute reaches the fork threshold: a successfully filled dispute bond of at least 2.5% of theoretical REP. The forked market supplies the possible outcomes for the child universes.
+
+A live protocol value is authoritative for its own threshold and deadline. The often-cited 275,000 REP value is the 2.5% genesis-universe reference, not a universal current value.
+
+## Child universes
+
+When the fork starts, Augur creates one child universe for each possible outcome of the forking market, including Invalid. The parent universe is permanently locked for new markets and REP staking. Disputes in other non-finalized markets are paused until the fork period ends; existing markets can continue trading, but they cannot finalize during that period.
+
+Each child universe has its own version of REP. The choice of child is therefore also a choice of which outcome's REP universe to support.
+
+## The migration choice
+
+During the forking period, REP in the parent universe can be migrated to a chosen child universe:
+
+1. **Choose an outcome universe.** The child must correspond to one of the forking market's possible outcomes.
+2. **Commit once.** Migration is one-way. REP cannot be moved from one sibling universe to another after it has migrated.
+3. **Respect protocol-specific staking rules.** REP staked on the forking market is constrained to the corresponding child; other staking positions are handled by the protocol's fork logic.
+4. **Use the deployed deadline.** The reference mechanics allow a forking period of up to 60 days. The deployed universe's fork-end value, not an old article or screenshot, determines whether the contract will accept a migration.
+
+<ProseCard>
+**Current-action boundary** — These rules explain what migration means if a future fork is confirmed. They do not establish that a fork is active, that a migration window is open, or that anyone should move REP now. Confirm current state and maintained instructions separately before taking any consequential action.
+</ProseCard>
+
+## How a fork resolves
+
+The child universe receiving the most migrated REP by the end of the forking period becomes the winning universe. Its corresponding outcome becomes the final outcome of the forking market. The protocol's fork reputation goal is half of theoretical REP, which is the amount needed for a child to win early under the reference implementation; the final result still depends on the contract state and deadline.
+
+The fork outcome cannot be disputed through the ordinary dispute process. Non-finalized markets from the parent can continue only in the winning universe after the fork. A migration percentage by itself is not proof of a winner or of the correct real-world outcome.
+
+## General mechanics versus event history
+
+The completed Moon Fork is a case study, not an example to reuse as protocol configuration. Its dates, market address, universe addresses, token identities, migration totals, and observed blocks belong in event-specific historical material. The existing **[Moon Fork Migration Record](/learn/fork/migration/)** preserves the old procedure at its public URL, but it is an archive rather than a current checklist.
+
+For future-oriented preparation, continue to **[What To Do Around Fork Risk →](/learn/fork/what-to-do/)**. For the escalation that precedes migration, return to **[How Disputes & Bonds Work →](/learn/fork/disputes-and-bonds/)**.
+
+## Protocol basis
+
+This lesson follows the [Augur v2 whitepaper preserved by this project](https://github.com/AugurProject/augur-reboot-website/blob/main/docs/raw/augur-whitepaper-v2.pdf), the maintained [Augur v2 protocol glossary](https://github.com/AugurProject/augur-reboot-website/blob/main/docs/augur-v2-protocol-glossary.md), and the pinned implementation in [`Universe.sol`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/Universe.sol) and [`ReputationToken.sol`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/ReputationToken.sol).

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -2,9 +2,9 @@
 title: "Moon Fork Migration Guide"
 description: "Step-by-step historical reference for the Augur Moon Fork REP migration."
 topic: fork
-order: 4
+order: 6
 contentType: historical-record
-label: "MIGRATION GUIDE"
+label: "MOON FORK MIGRATION RECORD"
 historical: true
 status: archived
 presentation: historical-record

--- a/src/content/learn/fork/what-to-do.mdx
+++ b/src/content/learn/fork/what-to-do.mdx
@@ -1,10 +1,10 @@
 ---
-title: "What To Do"
-description: "Action items to take at different fork risk levels."
+title: "What To Do Around Fork Risk"
+description: "Prepare for possible Augur fork conditions without treating historical material as live instructions."
 topic: fork
-order: 3
+order: 4
 contentType: guide
-label: "WHAT TO DO"
+label: "WHAT TO DO AROUND FORK RISK"
 historical: false
 status: available
 presentation: standard
@@ -14,68 +14,51 @@ import ProseCard from '../../../components/content/prose-card.astro'
 
 # What To Do Around Fork Risk
 
-**TL;DR** — Fork risk is manageable at low levels. Monitor more closely as it rises. During an active migration window, participants follow the current state and deadline shown on the landing page.
+This is a preparedness guide, not a live migration checklist. No current fork or migration deadline is implied here. The goal is to help you understand what to verify if a future fork condition is reported, while keeping historical Moon Fork instructions in their archived context.
 
-## Risk Overview
+## Use the monitor as a signal
+
+The monitor describes observed dispute escalation. Its round-progress percentage is not a probability, a prediction, or a statement about which outcome is true.
 
 <ProseCard>
-| LEVEL | SITUATION | YOUR ACTION |
-|-------|-----------|-------------|
-| No Risk (0%) | No disputes active | Trade normally. Check meter occasionally. |
-| Low (&lt;25%) | Early disputes | Identify which markets are disputed. Understand the disagreement. |
-| Moderate (25-50%) | Disputes escalating | Calculate your exposure. Think about exit strategies if needed. |
-| High (50-75%) | Large bonds active | Monitor daily. Consider reducing exposure. Prepare for fork governance. |
-| Critical (≥75%) | Fork imminent or active | Check the landing page for the current fork state and deadline. |
+| Display | What it describes | Prepared response |
+|---|---|---|
+| None / 0% | No funded dispute progress is being reported for the tracked market. | Learn the market's resolution source and check the monitor periodically. |
+| Low | Early observed escalation. | Identify the disputed market and read the underlying outcome evidence. |
+| Moderate | Escalation has progressed, but a fork is not established by this label. | Review your exposure and the protocol mechanics; do not infer a deadline from the gauge. |
+| High | Late observed escalation. | Verify the market and bond data from maintained sources and understand the possible fork states. |
+| Critical | The observed projection is near its configured fork threshold. | Treat this as a reason to verify protocol state, not as an instruction to migrate or trade. |
+| Unknown | A defensible round projection is unavailable. | Avoid guessing; use the underlying data and maintained project guidance. |
 </ProseCard>
 
-## High Risk (50-75%) — Prepare
+## Always be prepared
 
-The dispute has passed the halfway point. Fork is increasingly likely with continued escalation.
+- Know the market's resolution source and what evidence would distinguish its possible outcomes.
+- Keep track of which network, wallet, exchange, and REP version a record refers to. Historical token addresses are not automatically current recommendations.
+- Treat external links, screenshots, and old announcements as dated evidence. Confirm consequential information against the deployed contracts and maintained project records.
+- Do not treat a monitoring label as financial advice or as a guarantee that a fork will occur.
+- Read the general **[dispute and bond mechanics](/learn/fork/disputes-and-bonds/)** before interpreting escalation.
 
-**What you should do:**
+## If a future fork is confirmed
 
-- **Reduce exposure if uncomfortable** — Consider exiting disputed positions
-- **Monitor daily** — Check the fork meter and dispute progress regularly
-- **Understand the disagreement** — Review community discussions about the disputed outcome
-- **Prepare for fork governance** — If a fork occurs, be ready to choose with your REP
-- **Avoid new large bets** — Don't enter high-risk markets during escalation
-- **Know your positions** — Understand exactly how a fork would affect you
+These are verification questions for a future event, not actions to take now:
 
-## Critical Risk (≥75%) — Fork Is Likely or Active
+1. **Is the fork state real?** Confirm the forking market, parent universe, and fork state from the deployed protocol rather than from a screenshot or social post.
+2. **What are the child universes?** Match each child to the forking market's possible outcome, including Invalid where present.
+3. **What is the contract deadline?** Use the deployed universe's fork-end value. Do not copy a date from an old guide.
+4. **What does migration commit?** Migration is one-way, and sibling universes cannot be used to reverse the choice. Understand the consequence before any transaction.
+5. **Which result is authoritative?** A child receiving the most migrated REP becomes the winning universe under the reference mechanics. Confirm the contract-reported result after the relevant deadline before treating it as final history.
 
-The dispute is in its final rounds. A fork is imminent or may have been triggered. This is the highest-stakes scenario.
+The **[general migration mechanics lesson](/learn/fork/migration-mechanics/)** explains these rules without attaching them to a named event.
 
-**If the migration window is open:**
+## After a fork becomes history
 
-- **Understand your position** — Know exactly what outcome you're betting on in disputed markets
-- **Plan your fork choice** — Which fork version do you believe represents the correct outcomes?
-- **Prepare to migrate REP** — You'll choose which fork version to support during the 60-day period
-- **Engage with the community** — Discuss the disputed outcomes with other REP holders
-- **Be ready to act** — The fork period requires active participation and decision-making
-- **Prepare for market freezes** — Disputed markets will be frozen until the fork resolves
+A completed event should be read as a case study: separate observed facts, protocol behavior, and interpretation. The existing **[Moon Fork Migration Record](/learn/fork/migration/)** remains available at its public URL because it preserves useful historical steps and evidence. Its old tools, dates, addresses, and instructions are not a current action path.
 
-## During a Fork Event
+A future Moon Fork case study belongs beside this guide, not inside it. It should carry its own dates and provenance rather than turning event facts into evergreen protocol claims.
 
-### The 60-Day Fork Period
+## Continue the path
 
-- **Markets freeze:** No new trades on disputed markets
-- **REP migration:** Choose which fork version to support before the migration window closes
-- **Voting occurs:** Your REP migration determines your choice on the disputed outcome
-- **Communicate:** Engage in governance discussions about the right outcome
-- **Wait for resolution:** The fork window is 60 days
-
-### After a Verified Fork Resolution
-
-- **Check your REP:** Verify which REP token corresponds to the recorded winning fork
-- **Markets settle:** Markets settle according to the winning fork's outcomes
-- **Resume trading:** Normal Augur operations resume
-- **Evaluate impact:** Assess how the fork affected your positions
-
-## General Best Practices
-
-- **Check the meter regularly:** Make fork risk checking part of your routine
-- **Understand disputed outcomes:** Know what you're betting on before a dispute arises
-- **Size positions appropriately:** Don't over-commit to markets that could fork
-- **Stay informed:** Follow Augur discussions and governance
-- **Plan ahead:** Think through fork scenarios before they happen
-- **Engage with the community:** Forks are community decisions
+- Return to **[What Is a Fork?](/learn/fork/)** for the full sequence.
+- Review **[How Fork Migration Works](/learn/fork/migration-mechanics/)** for general protocol mechanics.
+- Use the **[historical migration record](/learn/fork/migration/)** only as dated reference material.


### PR DESCRIPTION
Closes #150

## Summary

- Reworked the Fork topic into an evergreen sequence: fork basics, disputes and bonds, general migration mechanics, and future-oriented preparedness.
- Added `/learn/fork/migration-mechanics/` without changing existing public routes.
- Added transitions and declarative metadata for the evergreen lessons; retained `/learn/fork/migration/` as the archived Moon Fork migration record.
- Kept Moon Fork event facts out of evergreen protocol education. The named event remains a separate case-study concern for the downstream retrospective work.
- Added issue-specific metadata, ordering, URL-preservation, transition, evidence, and no-live-action coverage.

## Acceptance evidence

- **Core lessons remain useful when no fork is active:** evergreen pages no longer import lifecycle state or render a migration CTA; the preparedness guide explicitly says it is not a live migration checklist.
- **Coherent ordered sequence:** metadata orders the available path as 1 `topic`, 2 `lesson`, 3 `lesson`, and 4 `guide`; order 5 remains available for the separate Moon Fork case study, and the historical record is order 6.
- **Moon Fork facts are clearly identified as a case study:** evergreen pages contain no Moon Fork addresses, token identities, dates, totals, or outcome claims; they explicitly distinguish event history from protocol rules.
- **No evergreen lesson presents migration as currently actionable:** copy is future-oriented and tests reject the prior live CTA/lifecycle language.
- **Existing URLs are preserved:** the four existing Learn content files remain in place, including `/learn/fork/migration/`; the archive body was not rewritten. The new route is additive.

## Verification

- `npm run typecheck` — pass, 0 errors/warnings/hints.
- `npm run typecheck:scripts` — pass.
- `npm run lint` — pass.
- `npm run build` — pass; Astro generated the existing Fork routes plus `/learn/fork/migration-mechanics/`.
- `npm run test:evergreen-fork` — pass, 4 tests.
- `npm run test:learn-model` — pass, 4 tests.
- `npm run test:fork-lifecycle` — pass, 16 tests.
- `git diff --check` — pass.

Build emitted only existing environment/configuration warnings (Cloudflare externalized Node modules, missing sitemap `site`, and unset analytics ID); no build errors.

## Protocol evidence

Claims were checked against the maintained project reference (`docs/fork-mechanics.md`, `docs/augur-v2-protocol-glossary.md`, `docs/augur-v2-whitepaper-summary.md`, and `docs/raw/augur-whitepaper-v2.pdf`) and pinned Augur source at commit `bd13a797016b373834e9414096c6086f35aa628f` (`Universe.sol` and `ReputationToken.sol`). The content distinguishes the fork-state period from the contract migration deadline and does not treat the genesis 275,000 REP figure as universal.

## Scope boundaries

This PR intentionally does not implement the `/learn` landing page, Moon Fork retrospective, archived migration body rewrite, FAQ, dependency changes, tsconfig changes, or `bun.lock` changes.