### PR TITLE
docs: publish The Moon Fork case study

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,7 @@ Start here to find the right doc. Read deeper only when the task calls for it.
 | [Post-Fork Landing Page Implementation Plan](post-fork-landing-page-implementation-plan.md) | Implementation status and rollout plan for the migration CTA/countdown, verified Fork Record, and lifecycle data contract |
 | [Public Data Endpoints](public-data-endpoints.md) | Structured JSON endpoints at /data/*.json for external consumers — schemas, conventions, adding new endpoints |
 | [FAQ Feature](faq-feature.md) | Finalized `/faq` content, static post-fork behavior, stable question anchors, safety guidance, and site integration |
+| [Moon Fork Retrospective Feature](moon-fork-retrospective-feature.md) | Canonical case-study route, evidence hierarchy, interpretation boundaries, reciprocal Learn links, and verification |
 | [Blog Feature](blog-feature.md) | Blog frontmatter schema, MDX integration, RSS feed, Learn section |
 | [Migration Guide Feature](migration-guide-feature.md) | Moon Fork migration guide, step-by-step REP migration, MigrationGuideLayout |
 

--- a/docs/moon-fork-retrospective-feature.md
+++ b/docs/moon-fork-retrospective-feature.md
@@ -1,0 +1,99 @@
+---
+title: Moon Fork Retrospective Feature
+tags: [learn, moon-fork, case-study, provenance]
+---
+
+# Moon Fork Retrospective Feature
+
+## Purpose
+
+The canonical Moon Fork case study is published at `/learn/fork/moon-fork/`. It explains what happened during Augur's first completed algorithmic fork without replacing the evergreen Fork lessons, the archived migration procedure, or the dated blog announcements.
+
+The page is durable historical analysis. It does not expose migration controls or derive current-action language from build-time fork state.
+
+## Files
+
+- **Content:** `src/content/learn/fork/moon-fork.mdx`
+- **Route generation:** `src/pages/learn/[...slug].astro`
+- **Topic entry point:** `src/content/learn/fork/index.mdx`
+- **Related archive:** `src/content/learn/fork/migration.mdx`
+- **Regression test:** `scripts/moon-fork-retrospective.test.ts`
+
+The content entry uses this metadata:
+
+```yaml
+topic: fork
+order: 5
+contentType: case-study
+label: "THE MOON FORK"
+historical: true
+status: available
+presentation: case-study
+```
+
+The archived migration record remains order 6 and retains its canonical `/learn/fork/migration/` route.
+
+## Evidence hierarchy
+
+Reader-facing final values come from [[moon-fork-final-record]]. The hierarchy is:
+
+1. Ethereum mainnet contract and block state pinned to finalized block `25,677,103`.
+2. Version-controlled deployed Augur v2 source and deployment records.
+3. Version-controlled ForkWatch token identity records.
+4. Dated project announcements for communication and phase context.
+
+Contract values override announcement-era schedule prose or derived presentation metrics. The case study identifies the winner using `getWinningChildUniverse()` and migration totals using each child token's `getTotalMigrated()` counter, not ERC-20 `totalSupply()`.
+
+## Editorial boundaries
+
+The page separates three kinds of statements:
+
+- **Observed facts:** dated values reproduced from the final evidence record.
+- **Evidence boundaries:** what the observation does not establish, including holder counts and incentive optimality.
+- **Interpretation and lessons:** project conclusions about data sources, state labels, token identity, exchange communication, and historical tool preservation.
+
+Implications for future Augur and Lituus work are framed as operational requirements. The Moon Fork is not presented as validation of an unimplemented future oracle design.
+
+## Protocol constraints
+
+- Child universes and their REP tokens are lazy: a child is created only when migration first targets an outcome.
+- The missing Invalid child at the evidence block records zero migration; it does not remove Invalid as a possible market outcome.
+- `isForking() == true` after the deadline means “forking or has forked” in the deployed implementation. It does not mean migration remains open.
+- `REPv2_Yes_1` at `0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D` is current REP in the winning universe. Kraken's `AUGUR` is an exchange ticker for that same token.
+
+## Cross-links
+
+The retrospective links to:
+
+- the Fork topic and evergreen dispute and migration lessons;
+- the Moon Fork migration archive;
+- the three dated fork-phase announcements;
+- Ethereum block, market, universe, and token records;
+- deployed Augur v2 source; and
+- the maintained final-record evidence document in the public repository.
+
+The Fork topic and migration archive link back to the retrospective. Broader persistent-navigation and homepage integration belongs to issue #154.
+
+## Verification
+
+Run:
+
+```bash
+npm run test:moon-fork-retrospective
+npm run test:evergreen-fork
+npm run test:learn-model
+npm run typecheck
+npm run typecheck:scripts
+npm run lint
+npm run build
+npm run build:gh-pages
+```
+
+The retrospective regression test checks canonical metadata, reciprocal links, final record values, observed-versus-interpretation structure, lazy child creation, and closed-migration safety.
+
+## Related documentation
+
+- [[moon-fork-final-record]] — authoritative final facts and provenance
+- [[public-knowledge-architecture]] — canonical route and surface boundaries
+- [[migration-guide-feature]] — historical procedure presentation
+- [[fork-mechanics]] — evergreen protocol context

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"test:evergreen-fork": "node --experimental-strip-types --test scripts/evergreen-fork.test.ts",
 		"test:migration-archive": "node --experimental-strip-types --test scripts/migration-archive.test.ts",
 		"test:faq": "node --experimental-strip-types --test scripts/faq.test.ts",
+		"test:moon-fork-retrospective": "node --experimental-strip-types --test scripts/moon-fork-retrospective.test.ts",
 		"typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
 		"preview": "astro build && wrangler dev",
 		"astro": "astro",

--- a/scripts/evergreen-fork.test.ts
+++ b/scripts/evergreen-fork.test.ts
@@ -51,6 +51,15 @@ const expectedEntries = [
 		status: "available",
 	},
 	{
+		file: "moon-fork.mdx",
+		slug: "fork/moon-fork",
+		order: 5,
+		contentType: "case-study",
+		label: "THE MOON FORK",
+		historical: true,
+		status: "available",
+	},
+	{
 		file: "migration.mdx",
 		slug: "fork/migration",
 		order: 6,
@@ -157,6 +166,14 @@ test("defines the ordered evergreen Fork sequence and preserves the archive URL"
 				status: "available",
 			},
 			{
+				label: "THE MOON FORK",
+				path: "/learn/fork/moon-fork/",
+				order: 5,
+				contentType: "case-study",
+				historical: true,
+				status: "available",
+			},
+			{
 				label: "MOON FORK MIGRATION RECORD",
 				path: "/learn/fork/migration/",
 				order: 6,
@@ -178,10 +195,13 @@ test("uses declarative presentation metadata for evergreen and archived entries"
 		const metadata = readFrontmatter(expected.file);
 
 		assert.equal(metadata.topic, "fork");
-		assert.equal(
-			metadata.presentation,
-			expected.historical ? "historical-record" : "standard",
-		);
+		const expectedPresentation =
+			expected.contentType === "case-study"
+				? "case-study"
+				: expected.contentType === "historical-record"
+					? "historical-record"
+					: "standard";
+		assert.equal(metadata.presentation, expectedPresentation);
 	}
 });
 
@@ -195,6 +215,7 @@ test("connects evergreen lessons without importing live-event or Moon Fork facts
 	assert.match(index, /disputes-and-bonds/u);
 	assert.match(index, /migration-mechanics/u);
 	assert.match(index, /what-to-do/u);
+	assert.match(index, /\/learn\/fork\/moon-fork\//u);
 	assert.match(disputes, /migration-mechanics/u);
 	assert.match(mechanics, /what-to-do/u);
 	assert.match(preparedness, /migration-mechanics/u);
@@ -207,9 +228,13 @@ test("connects evergreen lessons without importing live-event or Moon Fork facts
 		mechanics,
 		/A child universe is created only when REP is migrated to that outcome/u,
 	);
+	assert.match(
+		index,
+		/each child is created only when migration first targets that outcome/u,
+	);
 	assert.doesNotMatch(
-		mechanics,
-		/When the fork starts, Augur creates one child universe for each possible outcome/u,
+		[index, mechanics].join("\n"),
+		/When the fork starts, Augur creates one child universe for each possible outcome|A fork creates a child universe for each possible outcome/u,
 	);
 	assert.match(preparedness, /not a live migration checklist/u);
 });

--- a/scripts/migration-archive.test.ts
+++ b/scripts/migration-archive.test.ts
@@ -26,8 +26,9 @@ test("keeps the migration route as an archived historical record", () => {
 	assert.match(migration, /MIGRATION CLOSED/u);
 	assert.match(migration, /2026-08-03T01:00:59Z/u);
 	assert.match(migration, /this page contains no active migration call to action/iu);
-	assert.match(migration, /generalized migration-mechanics lesson.*Moon Fork retrospective/isu);
-	assert.match(migration, /not available on this branch/iu);
+	assert.match(migration, /\/learn\/fork\/migration-mechanics\//u);
+	assert.match(migration, /\/learn\/fork\/moon-fork\//u);
+	assert.doesNotMatch(migration, /not available on this branch/iu);
 });
 
 test("preserves final evidence and unambiguous REP identities", () => {
@@ -67,7 +68,7 @@ test("keeps every historical screenshot and archived tool reference", () => {
 	assert.match(migration, /archived migration page/u);
 });
 
-test("uses an archive-only presentation and avoids unpublished site links", () => {
+test("uses an archive-only presentation and links only to published routes", () => {
 	assert.match(layout, /ARCHIVE · MIGRATION CLOSED/u);
 	assert.match(layout, /Historical procedure and evidence only/u);
 	assert.doesNotMatch(layout, /isMigrationOpen|isMigrationClosed|MIGRATION IMMINENT/u);
@@ -76,19 +77,35 @@ test("uses an archive-only presentation and avoids unpublished site links", () =
 	assert.doesNotMatch(migration, /migration instructions will be available/u);
 
 	const internalLinks = new Set(
-	[...migration.matchAll(/\]\((\/[^)]+)\)/gu)].map(([, path]) => path),
-);
-assert.deepEqual(internalLinks, new Set([
-	"/blog/the-augur-fork-is-here/",
-	"/learn/fork/",
-	"/learn/fork/disputes-and-bonds/",
-]));
+		[...migration.matchAll(/\]\((\/[^)]+)\)/gu)].map(([, path]) => path),
+	);
+	assert.deepEqual(
+		internalLinks,
+		new Set([
+			"/blog/the-augur-fork-is-here/",
+			"/learn/fork/",
+			"/learn/fork/disputes-and-bonds/",
+			"/learn/fork/migration-mechanics/",
+			"/learn/fork/moon-fork/",
+		]),
+	);
 
-for (const [route, source] of [
-	["/blog/the-augur-fork-is-here/", "src/content/blog/the-augur-fork-is-here/index.mdx"],
-	["/learn/fork/", "src/content/learn/fork/index.mdx"],
-	["/learn/fork/disputes-and-bonds/", "src/content/learn/fork/disputes-and-bonds.mdx"],
-] as const) {
-	assert.ok(existsSync(resolve(root, source)), `missing source for ${route}`);
-}
+	for (const [route, source] of [
+		[
+			"/blog/the-augur-fork-is-here/",
+			"src/content/blog/the-augur-fork-is-here/index.mdx",
+		],
+		["/learn/fork/", "src/content/learn/fork/index.mdx"],
+		[
+			"/learn/fork/disputes-and-bonds/",
+			"src/content/learn/fork/disputes-and-bonds.mdx",
+		],
+		[
+			"/learn/fork/migration-mechanics/",
+			"src/content/learn/fork/migration-mechanics.mdx",
+		],
+		["/learn/fork/moon-fork/", "src/content/learn/fork/moon-fork.mdx"],
+	] as const) {
+		assert.ok(existsSync(resolve(root, source)), `missing source for ${route}`);
+	}
 });

--- a/scripts/moon-fork-retrospective.test.ts
+++ b/scripts/moon-fork-retrospective.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+const read = (file: string) =>
+	readFileSync(path.join(repositoryRoot, file), "utf8");
+
+const retrospective = read("src/content/learn/fork/moon-fork.mdx");
+const topic = read("src/content/learn/fork/index.mdx");
+const migrationArchive = read("src/content/learn/fork/migration.mdx");
+const finalRecord = read("docs/moon-fork-final-record.md");
+
+const requiredFinalValues = [
+	"25,677,103",
+	"0x963EED85778CC23E2D4636Cd4f29eECDF9827E9e",
+	"0x281171519Fb41540528398d8ED3EA257f0F32A9f",
+	"REPv2_Yes_1",
+	"0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D",
+	"6398081413681494610869400",
+	"1786227400866527400056",
+	"2026-08-03T01:00:59Z",
+];
+
+test("publishes the canonical Moon Fork case study in the Learn sequence", () => {
+	assert.match(retrospective, /^title: "The Moon Fork"$/mu);
+	assert.match(retrospective, /^topic: fork$/mu);
+	assert.match(retrospective, /^order: 5$/mu);
+	assert.match(retrospective, /^contentType: case-study$/mu);
+	assert.match(retrospective, /^historical: true$/mu);
+	assert.match(retrospective, /^status: available$/mu);
+	assert.match(retrospective, /^presentation: case-study$/mu);
+
+	assert.match(topic, /\/learn\/fork\/moon-fork\//u);
+	assert.match(migrationArchive, /\/learn\/fork\/moon-fork\//u);
+	assert.match(retrospective, /\/learn\/fork\/migration\//u);
+	assert.match(retrospective, /\/learn\/fork\/migration-mechanics\//u);
+});
+
+test("matches the verified final record and identifies current REP unambiguously", () => {
+	for (const value of requiredFinalValues) {
+		assert.match(retrospective, new RegExp(value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+		assert.match(finalRecord, new RegExp(value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+	}
+
+	assert.match(retrospective, /Winning outcome:\*\* index 1, \*\*Yes\*\*/u);
+	assert.match(retrospective, /current REP/iu);
+	assert.match(retrospective, /not ERC-20 `totalSupply\(\)` values/u);
+});
+
+test("separates observations, evidence boundaries, and interpretation", () => {
+	assert.match(retrospective, /^## What the final record showed$/mu);
+	assert.match(retrospective, /^## Expected behavior compared with observation$/mu);
+	assert.match(retrospective, /^## Interpretation and lessons$/mu);
+	assert.match(retrospective, /^## Implications for future Augur and Lituus work$/mu);
+	assert.match(retrospective, /^## Sources and provenance$/mu);
+	assert.match(retrospective, /These are interpretations, not additional protocol facts/u);
+	assert.match(retrospective, /does not, by itself, prove the security or economics/u);
+});
+
+test("preserves lazy child creation and closed-migration safety", () => {
+	assert.match(
+		retrospective,
+		/A child universe and its REP token are created only when migration first targets that outcome/u,
+	);
+	assert.match(retrospective, /Invalid \| No child existed at the evidence block/u);
+	assert.match(retrospective, /migration deadline was `2026-08-03T01:00:59Z`/u);
+	assert.match(retrospective, /it cannot be reopened/u);
+	assert.doesNotMatch(retrospective, /MigrationCta|isMigrationOpen|MIGRATION IMMINENT/iu);
+	assert.doesNotMatch(retrospective, /augurfork\.eth\.limo/iu);
+	assert.doesNotMatch(
+		retrospective,
+		/creates? (?:one )?child universe for each possible outcome|created a new REP token for each universe/iu,
+	);
+});

--- a/src/content/learn/fork/index.mdx
+++ b/src/content/learn/fork/index.mdx
@@ -14,7 +14,7 @@ import ProseCard from '../../../components/content/prose-card.astro'
 
 # What Is a Fork?
 
-A fork is Augur's resolution method of last resort. It begins when a market disagreement survives the ordinary reporting and dispute process and a dispute bond reaches the protocol's fork threshold. The protocol then creates child universes so REP holders can commit to the outcome they believe is correct.
+A fork is Augur's resolution method of last resort. It begins when a market disagreement survives the ordinary reporting and dispute process and a dispute bond reaches the protocol's fork threshold. The protocol then makes outcome-specific child universes available so REP holders can commit to the outcome they believe is correct; each child is created only when migration first targets that outcome.
 
 This page is evergreen protocol education. It does not announce a live fork, set a migration deadline, or tell anyone to move REP.
 
@@ -38,7 +38,7 @@ The lessons are ordered so each one supplies context for the next:
 2. **[How Disputes & Bonds Work](/learn/fork/disputes-and-bonds/)** — the escalation mechanism that can lead to a fork.
 3. **[How Fork Migration Works](/learn/fork/migration-mechanics/)** — general child-universe and migration mechanics.
 4. **[What To Do Around Fork Risk](/learn/fork/what-to-do/)** — preparedness for a possible future fork, not an active-event checklist.
-5. A separate Moon Fork case study records what happened in that named event. Its dates, addresses, totals, and outcome are not protocol rules.
+5. **[The Moon Fork](/learn/fork/moon-fork/)** — the completed event as a dated, evidence-based case study.
 6. **[Moon Fork Migration Record](/learn/fork/migration/)** — the existing historical procedure, retained for research and troubleshooting rather than current instructions.
 
 ## Key terms
@@ -50,7 +50,7 @@ The lessons are ordered so each one supplies context for the next:
 
 **Dispute bond** — The protocol-calculated amount of REP that must be filled to successfully dispute a tentative outcome. A bond can be crowdsourced by multiple participants.
 
-**Universe** — An Augur protocol context containing markets and a REP token. A fork creates a child universe for each possible outcome, including Invalid.
+**Universe** — An Augur protocol context containing markets and a REP token. A fork makes a child universe available for each possible outcome, including Invalid; the child is created when migration first targets that outcome.
 
 **Theoretical REP** — The supply basis used by the protocol for percentage thresholds. The genesis-universe reference is 11,000,000 REP, so 2.5% is 275,000 REP; a live deployment's configured value is authoritative.
 </ProseCard>
@@ -68,7 +68,7 @@ The estimate is derived from the observed bond trajectory. It is a display signa
 ## Fork lifecycle in brief
 
 1. **A dispute reaches the threshold.** A successfully filled dispute bond of at least 2.5% of theoretical REP puts the market into the fork state. The 275,000 REP figure is the genesis-universe reference, not a universal substitute for the deployed protocol value.
-2. **Child universes are created.** There is one child for each possible outcome of the forking market, including Invalid.
+2. **Child universes become available.** There is a possible child for each outcome of the forking market, including Invalid. A child universe and its REP token are created only when migration first targets that outcome.
 3. **The parent universe is locked.** No new markets or REP staking begin there. Disputes in other non-finalized markets are put on hold, although trading can continue and those markets cannot finalize until the fork period ends.
 4. **REP can be migrated once.** Holders choose a child universe, and that choice cannot be reversed or moved to a sibling universe. The fork period lasts up to 60 days under the Augur v2 reference mechanics.
 5. **The fork resolves.** The child receiving the most migrated REP by the end of the forking period becomes the winning universe, and its corresponding outcome becomes the forking market's final outcome.
@@ -79,6 +79,7 @@ The estimate is derived from the observed bond trajectory. It is a display signa
 - Continue to **[How Disputes & Bonds Work →](/learn/fork/disputes-and-bonds/)**.
 - Then read **[How Fork Migration Works →](/learn/fork/migration-mechanics/)** for the general mechanics.
 - Use **[What To Do Around Fork Risk →](/learn/fork/what-to-do/)** for future-oriented preparation.
+- Read **[The Moon Fork →](/learn/fork/moon-fork/)** for the completed event and its evidence.
 - The **[Moon Fork Migration Record](/learn/fork/migration/)** is preserved at its existing URL as historical material.
 
 ## Protocol basis

--- a/src/content/learn/fork/migration.mdx
+++ b/src/content/learn/fork/migration.mdx
@@ -69,9 +69,10 @@ The final record used contract reads and block state pinned to `25,677,103`. The
 
 ## Related material
 
-The [Fork topic](/learn/fork/) and [How Disputes & Bonds Work](/learn/fork/disputes-and-bonds/) pages are available on this branch for general protocol context. [The Augur Fork Is Here](/blog/the-augur-fork-is-here/) remains available as a dated historical account.
-
-The generalized migration-mechanics lesson and the Moon Fork retrospective are coordinated follow-up routes in [#150](https://github.com/AugurProject/augur-reboot-website/issues/150) and [#151](https://github.com/AugurProject/augur-reboot-website/issues/151). They are not available on this branch, so this archive does not link to unpublished site paths.
+- [The Moon Fork](/learn/fork/moon-fork/) is the canonical account of the trigger, timeline, final result, observed behavior, and lessons.
+- [How Fork Migration Works](/learn/fork/migration-mechanics/) explains the reusable protocol mechanics without event-specific instructions.
+- The [Fork topic](/learn/fork/) and [How Disputes & Bonds Work](/learn/fork/disputes-and-bonds/) provide the broader learning path.
+- [The Augur Fork Is Here](/blog/the-augur-fork-is-here/) remains a dated historical announcement rather than the canonical record.
 
 ## Why?
 

--- a/src/content/learn/fork/moon-fork.mdx
+++ b/src/content/learn/fork/moon-fork.mdx
@@ -1,0 +1,134 @@
+---
+title: "The Moon Fork"
+description: "A dated, evidence-based case study of Augur's first algorithmic fork, from dispute escalation through the final on-chain result."
+topic: fork
+order: 5
+contentType: case-study
+label: "THE MOON FORK"
+historical: true
+status: available
+presentation: case-study
+---
+
+import ProseCard from '../../../components/content/prose-card.astro'
+
+# The Moon Fork
+
+The Moon Fork was Augur's first completed algorithmic fork. Augur community member Micah Zoltu raised funds to drive a dispute over the market **“Will the Artemis II Mission successfully liftoff in the first week of April?”** through the protocol's escalation path. The event ended with outcome index 1, **Yes**, as the contract-reported winner.
+
+This page is a historical case study, not a migration guide. The migration deadline was `2026-08-03T01:00:59Z`; it cannot be reopened, and no action is available here.
+
+<ProseCard>
+**EXECUTIVE RECORD · OBSERVED 2026-08-03**
+
+- **Evidence block:** Ethereum mainnet block [`25,677,103`](https://etherscan.io/block/25677103), observed at `2026-08-03T21:36:23Z`
+- **Forking market:** [`0x963EED85778CC23E2D4636Cd4f29eECDF9827E9e`](https://etherscan.io/address/0x963EED85778CC23E2D4636Cd4f29eECDF9827E9e)
+- **Winning/canonical universe:** [`0x281171519Fb41540528398d8ED3EA257f0F32A9f`](https://etherscan.io/address/0x281171519Fb41540528398d8ED3EA257f0F32A9f)
+- **Winning outcome:** index 1, **Yes**
+- **Current REP:** **REPv2_Yes_1** at [`0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D`](https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D)
+</ProseCard>
+
+## Event timeline
+
+The dates below separate the public event timeline from the final contract observation.
+
+| Date | Recorded event |
+| --- | --- |
+| April 8, 2026 | The public Moon Fork process began. The disputed Artemis II market entered the escalation path described in the project's contemporary fork announcements. |
+| April–early June 2026 | Participants filled increasingly large dispute bonds. The escalation game ended after enough REP was staked to reach the fork threshold. |
+| Early June 2026 | The completed escalation opened the outcome-specific migration phase. REP could be moved one way from the parent universe into a selected child universe. |
+| August 3, 2026 at `01:00:59Z` | The contract-enforced migration deadline passed. Migration could no longer be extended or reopened. |
+| August 3, 2026 at `21:36:23Z` | The final evidence record was read at block `25,677,103`, 20 hours, 35 minutes, and 24 seconds after the deadline. Two independent Ethereum RPC providers returned the same material result. |
+
+The dated announcements remain useful artifacts: [The Augur Fork Is Here](/blog/the-augur-fork-is-here/), [Phase 1: The Escalation Game](/blog/phase-1-the-escalation-game/), and [Phase 2: The Fork Migration](/blog/phase-2-the-fork-migration/). They record what the project communicated at the time; this case study is the canonical durable account.
+
+## What the protocol was expected to do
+
+Augur v2 uses a fork only after ordinary reporting and escalating dispute bonds fail to settle a market. Once the fork threshold is reached:
+
+1. The disputed market becomes the forking market for its parent universe.
+2. REP holders can make a one-way migration toward a possible market outcome.
+3. A child universe and its REP token are created only when migration first targets that outcome; unused outcomes do not require an eagerly created child.
+4. The parent universe's fork end time bounds migration at the contract level.
+5. The child selected by `getWinningChildUniverse()` becomes the winning universe, and its outcome finalizes the forking market.
+
+The evergreen lessons explain these rules in more depth: [What Is a Fork?](/learn/fork/), [How Disputes & Bonds Work](/learn/fork/disputes-and-bonds/), and [How Fork Migration Works](/learn/fork/migration-mechanics/).
+
+## What the final record showed
+
+All values in this section were read from Ethereum mainnet at block `25,677,103`. The block hash was `0xab19846fa87d598ab7cf801092d94533b1fd4f3a0ebe2dc442c49f188f3af5b7`.
+
+| Protocol fact | Final recorded value |
+| --- | --- |
+| Parent/forking universe | [`0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA`](https://etherscan.io/address/0x49244BD018Ca9fd1f06ecC07B9E9De773246e5AA) |
+| Fork reputation goal | `5,497,186.882986651334933313 REP` |
+| Winning universe | [`0x281171519Fb41540528398d8ED3EA257f0F32A9f`](https://etherscan.io/address/0x281171519Fb41540528398d8ED3EA257f0F32A9f) |
+| Winning outcome | index 1, **Yes** |
+| Current REP | **REPv2_Yes_1** — [`0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D`](https://etherscan.io/token/0xCf6A0A7826fa124B7705d6f3c675eAD76f1e540D) |
+
+### Outcome-specific migration
+
+The totals below use each child REP token's `getTotalMigrated()` counter. They are not ERC-20 `totalSupply()` values.
+
+| Outcome | Child universe and token | Final migrated REP |
+| --- | --- | --- |
+| Invalid | No child existed at the evidence block; no token was created | `0` wei — `0 REP` |
+| Yes | `0x281171519Fb41540528398d8ED3EA257f0F32A9f`; `REPv2_Yes_1` | `6398081413681494610869400` wei — `6,398,081.4136814946108694 REP` |
+| No | `0xbaaD633FAa0E4847A4b66043E3E92102e5800546`; `REPv2_No_1` | `1786227400866527400056` wei — `1,786.227400866527400056 REP` |
+
+The existence of Yes and No children, while Invalid had no child, is direct evidence of lazy child-universe creation during migration. The Yes child held the largest recorded migrated amount and is the exact child returned by `getWinningChildUniverse()`.
+
+## Expected behavior compared with observation
+
+| Expected protocol behavior | Moon Fork observation | Evidence boundary |
+| --- | --- | --- |
+| Escalating disputes can reach the fork threshold and start a fork. | The escalation game completed and the parent universe recorded the Artemis II market as its forking market. | This confirms the deployed path executed; it does not measure whether every incentive was optimal. |
+| Migration creates outcome-specific children on demand. | Yes and No children existed; Invalid had no child at the evidence block. | A missing Invalid child means no migration created it, not that Invalid was removed as a possible outcome. |
+| REP migration is counted by the child token's dedicated counter. | `getTotalMigrated()` recorded about 6.398 million REP for Yes and 1,786.227 REP for No. | `totalSupply()` includes other protocol mint and burn effects and is not a migration tally. |
+| The contract determines the winner from fork state. | `getWinningChildUniverse()` returned the Yes universe, whose REP token is `REPv2_Yes_1`. | “Canonical universe” is this site's name for that contract-returned child, not a conclusion inferred from a chart. |
+| The fork end time closes migration. | The evidence block was more than 20 hours after the deadline, and `migrateIn()` rejects migration at or after that time. | The parent still returning `isForking() == true` means “forking or has forked” in the deployed code; it does not mean migration remained open. |
+
+## Participation and interface record
+
+The on-chain totals show how much REP migrated to each created child. They do **not** establish how many distinct people participated, how much activity was self-custodied, or how much was handled by exchanges. Those questions require holder-level and custodial evidence that is outside this record.
+
+Several practical boundaries were visible during and after the event:
+
+- **Wallet discovery:** new child REP tokens were not always detected automatically. Users sometimes needed the exact Ethereum mainnet contract address to add the token to a wallet.
+- **Exchange handling:** support varied by exchange. Kraken migrated supported balances and lists the current token under the ticker **AUGUR**, while its on-chain symbol remains **REPv2_Yes_1**.
+- **Tool lifecycle:** ForkWatch, reporting, and migration interfaces were useful during the event but needed explicit historical labeling after the deadline. The [Moon Fork Migration Record](/learn/fork/migration/) preserves those interfaces and screenshots without presenting them as current tools.
+- **Token naming:** REPv1, pre-fork REPv2, `REPv2_Yes_1`, and Kraken's `AUGUR` ticker refer to different lifecycle roles or labels. Documentation must always pair a token name with its chain, contract address, and current or legacy status.
+
+## Interpretation and lessons
+
+The observations above support several project lessons. These are interpretations, not additional protocol facts.
+
+1. **Contract state should outrank schedule prose.** Human-readable dates help participants, but the on-chain fork end time is the authoritative deadline.
+2. **Domain counters should outrank convenient proxies.** The first post-close snapshot treated child-token `totalSupply()` as migrated REP. Comparing it with `getTotalMigrated()` exposed a difference of `147,679.019985211005520574 REP`; the public generator was corrected to use the dedicated migration counter.
+3. **Lifecycle labels need contract-aware semantics.** A persistent `isForking()` value after closure could be misread as an open event. Public interfaces should derive “migration open” from the deadline and verified result rather than from that flag alone.
+4. **Outcome interfaces should account for lazy creation.** A possible outcome can remain valid even when no child contract exists because no REP migrated to it.
+5. **Token identity needs one durable source of truth.** Wallet names and exchange tickers can differ. The winning universe's `getReputationToken()` result, token symbol, chain, and contract address together identify current REP.
+6. **Custodial support must be communicated explicitly.** Exchange migration can reduce action for custodial users, but support cannot be assumed across venues.
+7. **Historical tools should remain inspectable without remaining actionable.** Preserving the procedure and screenshots helps research and troubleshooting; closed-state warnings prevent that evidence from becoming unsafe guidance.
+
+## Implications for future Augur and Lituus work
+
+The Moon Fork demonstrates that Augur v2's deployed fork path reached a contract-selected result under real transaction and interface conditions. It does not, by itself, prove the security or economics of a future oracle architecture, and it should not be used as evidence that Lituus mechanisms have already been validated.
+
+It does provide concrete requirements for future work: publish machine-readable evidence alongside reader-facing explanations, expose authoritative deadlines and domain counters, plan wallet and exchange naming before a token transition, test closed-state presentation, and preserve event artifacts after their operational period ends. Those requirements can inform Augur and Lituus implementation and communication without predetermining their protocol design.
+
+## Sources and provenance
+
+| Claim family | Primary source | Supporting source |
+| --- | --- | --- |
+| Block, deadline, market, universe, winner, token, and migrated totals | Ethereum mainnet contract reads pinned to block `25,677,103` | [Final Moon Fork Record](https://github.com/AugurProject/augur-reboot-website/blob/main/docs/moon-fork-final-record.md) |
+| Winner selection and post-deadline state semantics | [`Universe.sol` at deployed source commit `bd13a797`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/Universe.sol) | [How Fork Migration Works](/learn/fork/migration-mechanics/) |
+| Deadline enforcement and migration counter | [`ReputationToken.sol` at deployed source commit `bd13a797`](https://github.com/AugurProject/augur/blob/bd13a797016b373834e9414096c6086f35aa628f/packages/augur-core/src/contracts/reporting/ReputationToken.sol) | [Moon Fork Migration Record](/learn/fork/migration/) |
+| Event communication and phase descriptions | Dated project announcements linked in the timeline | The final contract record where announcement-era dates or terminology differ |
+| Current REP registry identity | Winning universe `getReputationToken()` plus the token's on-chain symbol | [ForkWatch REP registry at commit `19a05e5c`](https://github.com/AugurProject/augur-forkwatch-website/blob/19a05e5c276e0b9088ae57d8db54241797a95a22/src/domain/tokens/rep-tokens.ts#L20-L48) |
+
+## Continue
+
+- Review the reusable mechanics in **[How Fork Migration Works →](/learn/fork/migration-mechanics/)**.
+- Inspect the preserved procedure and screenshots in the **[Moon Fork Migration Record →](/learn/fork/migration/)**.
+- Return to the **[Fork learning path →](/learn/fork/)** or the full **[Learn catalog →](/learn/)**.


### PR DESCRIPTION
## Summary

- Adds `/learn/fork/moon-fork/` as the permanent record of what happened during the Moon Fork.
- Records the triggering market, timeline, winning universe, current REP token, and final migrated amounts using the verified block-pinned evidence.
- Compares the protocol's expected behavior with what was observed without treating migration as open.
- Covers practical lessons from wallet support, exchange handling, token naming, lifecycle labels, and archived tools.
- Links the Fork learning path, case study, and preserved migration procedure in both directions.
- Corrects the remaining Fork introduction language to describe child universes as created only when migration first targets an outcome.

Closes #151

## Verification

- `npm run test:moon-fork-retrospective` — 4 passed
- `npm run test:evergreen-fork` — 4 passed
- `npm run test:migration-archive` — 4 passed
- `npm run test:learn-model` — 9 passed
- `npm run typecheck`
- `npm run typecheck:scripts`
- `npm run lint`
- `npm run build`
- `npm run build:gh-pages`
- `git diff --check`

Both builds generated `/learn/fork/moon-fork/index.html`. The new targeted test is available as `npm run test:moon-fork-retrospective` and is intentionally not added to CI in this PR.
