### PR TITLE
Fix whitepaper presentation and footer links

### DIFF
--- a/scripts/faq.test.ts
+++ b/scripts/faq.test.ts
@@ -108,6 +108,20 @@ test("keeps finalized FAQ destinations and the combined footer updates", () => {
 	assert.match(footer, /AUGUR FAQ/u);
 	assert.doesNotMatch(footer, /FORK & MIGRATION FAQ/u);
 	assert.match(footer, /https:\/\/github\.com\/darkflorist/u);
-	assert.match(footer, /AUGUR V2 WHITEPAPER/u);
-	assert.match(footer, /AUGUR LITUUS WHITEPAPER/u);
+
+	const knowledgeBase = footer.match(
+		/<h4[^>]*>&gt;_ KB<\/h4>\s*<ul[^>]*>([\s\S]*?)<\/ul>/u,
+	)?.[1];
+	assert.ok(knowledgeBase, "footer KB group must exist");
+
+	const knowledgeBaseLinks = [...knowledgeBase.matchAll(
+		/<Button[^>]*href="([^"]+)"[^>]*>\s*([^<]+?)\s*<\/Button>/gu,
+	)]
+		.map(([, href, label]) => `${label.trim()}|${href}`)
+		.sort();
+
+	assert.deepEqual(knowledgeBaseLinks, [
+		"AUGUR FAQ|/faq",
+		"WHITEPAPERS|/whitepapers/",
+	]);
 });

--- a/src/content/whitepaper-v2/abstract-and-introduction.md
+++ b/src/content/whitepaper-v2/abstract-and-introduction.md
@@ -4,7 +4,7 @@ Jack Peterson, Joseph Krug, Micah Zoltu, Austin K. Williams, and Stephanie Alexa
 
 _Forecast Foundation_
 
-_(Dated: March 21, 2025)_
+_(Dated: January 27, 2026)_
 
 Augur is a trustless, decentralized oracle and platform for prediction markets. The outcomes of Augur’s prediction markets are chosen by users that hold Augur’s native Reputation token, who stake their tokens on the actual observed outcome and, in return, receive settlement fees from the markets. Augur’s incentive structure is designed to ensure that honest, accurate reporting of outcomes is always the most profitable option for Reputation token holders. Token holders can post progressively-larger Reputation bonds to dispute proposed market outcomes. If the size of these bonds reaches a certain threshold, Reputation splits into multiple versions, one for each possible outcome of the disputed market; token holders must then exchange their Reputation tokens for one of these versions. Versions of Reputation which do not correspond to the real-world outcome will become worthless, as no one will participate in prediction markets unless they are confident that the markets will resolve correctly. Therefore, token holders will select the only version of Reputation which they know will continue to have value: the version that corresponds to reality.
 

--- a/src/content/whitepaper-v2/how-augur-works.md
+++ b/src/content/whitepaper-v2/how-augur-works.md
@@ -24,11 +24,7 @@ Augur’s reporting system runs on a cycle of consecutive 7-day long dispute win
 
 ### 2. Participation Tokens
 
-During any dispute window, REP holders may purchase any number of participation tokens[^8] for one attorep[^9] each (participation tokens are ERC777 tokens on the Ethereum network). At the end of the dispute window, they may redeem their participation tokens for one attorep each, in addition to a proportional share of the dispute window’s reporting fee pool. If there were no actions (e.g., submitting a report or disputing a report submitted by another user) needed of a reporter, the reporter may purchase participation tokens to indicate that they showed up for the dispute window. Just like staked REP, participation tokens may be redeemed by their owners for a pro rata portion of fees in this dispute window. Participation tokens are primarily the means by which Augur pays fees to REP holders, but they may also serve as an additional incentive for REP holders to monitor the platform at least once per week. Even REP holders who do not want to participate in the reporting process may be incentivized to check-in with Augur once per 7-day dispute window in order to buy participation tokens and collect fees. This regular, active checking-in will ensure that they are familiar with how to use Augur, will be aware of forks when they occur, and thus should be more ready to participate in forks when they happen.
-
-![Figure 2. Reporting flowchart.](figures/figure-2-reporting-flowchart.jpeg)
-
-*Figure 2. Reporting flowchart.*
+During any dispute window, REP holders may purchase any number of participation tokens[^8] for one attorep[^9] each. At the end of the dispute window, they may redeem their participation tokens for one attorep each, in addition to a proportional share of the dispute window’s reporting fee pool. If there were no actions (e.g., submitting a report or disputing a report submitted by another user) needed of a reporter, the reporter may purchase participation tokens to indicate that they showed up for the dispute window. Just like staked REP, participation tokens may be redeemed by their owners for a pro rata portion of fees in this dispute window. Participation tokens are primarily the means by which Augur pays fees to REP holders, but they may also serve as an additional incentive for REP holders to monitor the platform at least once per week. Even REP holders who do not want to participate in the reporting process may be incentivized to check-in with Augur once per 7-day dispute window in order to buy participation tokens and collect fees. This regular, active checking-in will ensure that they are familiar with how to use Augur, will be aware of forks when they occur, and thus should be more ready to participate in forks when they happen.
 
 ### 3. Market State Progression
 
@@ -42,6 +38,10 @@ Augur markets can be in seven different states after creation. The potential sta
 - Fork
 - Finalized
 The relationship between these states can be seen in Fig. 2.
+
+![Figure 2. Reporting flowchart.](figures/figure-2-reporting-flowchart.jpeg)
+
+*Figure 2. Reporting flowchart.*
 
 ### 4. Pre-reporting
 

--- a/src/layouts/WhitepaperLayout.astro
+++ b/src/layouts/WhitepaperLayout.astro
@@ -77,7 +77,7 @@ const claudeHref = `https://claude.ai/new?${assistantQuery}`;
 							Release {edition.release} (<code class="normal-case tracking-normal">{edition.sourceRevision}</code>)
 						</span>
 					</div>
-					<div class="flex shrink-0 flex-wrap gap-2 font-display text-xs uppercase tracking-[0.15em]">
+					<div class="flex w-full flex-wrap gap-2 font-display text-xs uppercase tracking-[0.15em] md:w-auto md:shrink-0">
 						<WhitepaperActions
 							client:load
 							markdownHref={rawHref}


### PR DESCRIPTION
## Summary

- Update the v2 whitepaper date to January 27, 2026.
- Remove duplicated participation-token ERC777 wording and place Figure 2 after the market-state list.
- Make the whitepaper action row responsive on narrow screens.
- Strengthen the footer regression check to assert the exact KB link set.
- Defer broader shell/footer test organization to #183.

## Validation

- `npm run test:faq`
- `npm run check`
- `git diff --check`

Closes #176.
